### PR TITLE
swarm start option support

### DIFF
--- a/swarm
+++ b/swarm
@@ -138,10 +138,14 @@ startservices() {
 
   echo "> Starting services..."
   # default is to run all the services
+  # check if --min was specified
+  # otherwise only run the services specified on the command line
   start=${SERVICES[@]}
-
-  # check if --min was specified, otherwise only run the services if specified by args
-  [[ $@ =~ "--min" ]] && start=${MINSERVICES[@]} || ([[ $# -ne 0 ]] && start=$@)
+  if [[ $@ =~ "--min" ]]; then
+    start=${MINSERVICES[@]}
+  elif [[ $# -ne 0 ]]; then
+    start=$@
+  fi
 
   for i in $start; do $i; done
 }


### PR DESCRIPTION
Can run all, --min, or specific set of services:

```
# run all the services
$ ./swarm start

# run the minimum required services for dev
$ ./swarm start --min

$ run specific set of services (services must be defined in the `swarm` script
$ ./swarm start etcd influxdb ...
```
