### PR TITLE
CI adjustments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 *.pb.go
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # appclerator/protoc is based on alpine and includes latest go and protoc
 FROM appcelerator/protoc
 RUN apk --no-cache add make bash git docker curl
+RUN curl https://glide.sh/get | sh
 WORKDIR /go/src/github.com/appcelerator/amp
 COPY glide.lock /go/src/github.com/appcelerator/amp/
 COPY glide.yaml /go/src/github.com/appcelerator/amp/
-RUN curl https://glide.sh/get | sh
 RUN glide install
 COPY . /go/src/github.com/appcelerator/amp
 RUN make install-host

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ clean:
 	@rm -f $$(which amp)
 
 test:
-	@go test $(REPO)/api/server
-	@go test $(REPO)/data/etcd
+	@go test -v $(REPO)/api/server
+	@go test -v $(REPO)/data/etcd
 
 install: install-cli install-server
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@ services:
   sut:
     image: appcelerator/sut
     build: .
-    command: ["go", "test", "-v", "github.com/appcelerator/amp/data/etcd"]
+    command: ["make", "test"]
     environment:
       endpoints: http://etcd:2379
   etcd:


### PR DESCRIPTION
added vendor to `.dockerignore` to prevent any working around the glide files

changed go test output to verbose (better output on build server)

changed command back to `make test`

moved glide installation to bottom of the `Dockerfile` to prevent unneeded reinstalls
