### PR TITLE
Add a monitor command to the swarm script

### DIFF
--- a/swarm
+++ b/swarm
@@ -82,7 +82,7 @@ ROLE=infrastructure
 usage() {
   cat << USAGE >&2
 Usage:
-  $(basename $0) [pull|start|stop|restart|ls]
+  $(basename $0) [pull|start|stop|restart|ls|monitor]
   $(basename $0) [ -h | --help ]
 
 Basic AMP swarm operations.
@@ -98,6 +98,7 @@ Commands:
   restart      Restart services (options: --min); same as stop, pull, start
   stop         Remove services
   ls           List running services
+  monitor      Continually update running services list with current status
 
 USAGE
   exit 1
@@ -134,6 +135,9 @@ main() {
       ;;
       ls)
         ls
+      ;;
+      monitor)
+        monitor "${@:2}"
       ;;
       -h)
         usage
@@ -195,6 +199,11 @@ startservices() {
 
 ls() {
   docker service ls --filter "label=amp.swarm=$ROLE"
+}
+
+monitor() {
+  interval=${1:-5}
+  clear; while true; do tput cup 0 0; docker service ls; sleep $interval; done
 }
 
 ampagent() {


### PR DESCRIPTION
This PR adds a `monitor` command to the `swarm` script to provide a continuously updating display of the swarm's replica status. Use from another terminal to the see the state of your services. By default, it updates the display every 5 seconds; you can change the refresh interval by providing an argument in seconds.

```
$ ./swarm monitor
$ ./swarm monitor 2  # refresh every 2 seconds, 5 is the default
```
