### PR TITLE
authenticating logs cmd

### DIFF
--- a/api/rpc/logs/logs.go
+++ b/api/rpc/logs/logs.go
@@ -2,7 +2,9 @@ package logs
 
 import (
 	"encoding/json"
+	"github.com/appcelerator/amp/api/rpc/oauth"
 	"github.com/appcelerator/amp/data/elasticsearch"
+	"github.com/appcelerator/amp/data/storage"
 	"golang.org/x/net/context"
 	"gopkg.in/olivere/elastic.v3"
 )
@@ -13,11 +15,16 @@ const (
 
 // Logs is used to implement log.LogServer
 type Logs struct {
-	ES elasticsearch.Elasticsearch
+	ES    elasticsearch.Elasticsearch
+	Store storage.Interface
 }
 
 // Get implements log.LogServer
 func (s *Logs) Get(ctx context.Context, in *GetRequest) (*GetReply, error) {
+	_, err := oauth.CheckAuthorization(ctx, s.Store)
+	if err != nil {
+		return nil, err
+	}
 	// Prepare request to elasticsearch
 	request := s.ES.GetClient().Search().Index(esIndex)
 	if in.From >= 0 {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -35,7 +35,10 @@ func Start(config Config) {
 	log.Printf("amplifier is listening on port %s\n", config.Port[1:])
 	s := grpc.NewServer()
 	// project.RegisterProjectServer(s, &project.Service{})
-	logs.RegisterLogsServer(s, &logs.Logs{ES: ES})
+	logs.RegisterLogsServer(s, &logs.Logs{
+		ES:    ES,
+		Store: Store,
+	})
 	oauth.RegisterGithubServer(s, &oauth.Oauth{
 		Store:        Store,
 		ClientID:     config.ClientID,

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -112,7 +112,10 @@ func main() {
 		Long:  `Search through all the logs of the system and fetch entries matching provided criteria.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			a := client.NewAMP(&config)
-			a.Logs(cmd)
+			err := a.Logs(cmd)
+			if err != nil {
+				fmt.Println(err)
+			}
 		},
 	}
 


### PR DESCRIPTION
closes https://github.com/appcelerator/amp/issues/36

```
henry@henry-MacBookPro:~$ amp logs
amp (cli version: 1.0.0, build: b38c7eba)
Requires login
henry@henry-MacBookPro:~$ amp login
amp (cli version: 1.0.0, build: b38c7eba)
Login using github
github username or email: generalhenry
github password: 

Two Factor Authentication required
authentication code: 

Welcome Henry Allen-Tilford
you are logged in
henry@henry-MacBookPro:~$ amp logs
amp (cli version: 1.0.0, build: b38c7eba)
timestamp:"2016-08-17T16:02:27.289230629Z" time_id:"2016-08-17T16:02:27.289230629Z" service_id:"af2i2a7fbbvhd8zg8h827oz5n" service_name:"influxdb" message:"[httpd] 2016/08/17 16:02:27 ::1 - - [17/Aug/2016:16:02:27 +0000] GET /ping HTTP/1.1 204 0 - InfluxDBShell/0.13.0 fe6cc7ad-6493-11e6-8002-000000000000 76.58\302\265s" container_id:"0310fcc6f5eacb2553f9ecb1dc92171d3ad2f3015f4bd4552f24631172ef2458" node_id:"9m76ho7c8fgnj9hyeg9v0jare" 
timestamp:"2016-08-17T16:02:27.424613939Z" time_id:"2016-08-17T16:02:27.424613939Z" service_id:"af2i2a7fbbvhd8zg8h827oz5n" service_name:"influxdb" message:"[httpd] 2016/08/17 16:02:27 ::1 - root [17/Aug/2016:16:02:27 +0000] GET /ping HTTP/1.1 204 0 - influxDB importer/0.13.0 fe8171e2-6493-11e6-8005-000000000000 48.975\302\265s" container_id:"0310fcc6f5eacb2553f9ecb1dc92171d3ad2f3015f4bd4552f24631172ef2458" node_id:"9m76ho7c8fgnj9hyeg9v0jare" 

```
