### PR TITLE
Adds storage update support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean install install-server install-cli fmt simplify check version build run
+.PHONY: all clean install install-server install-cli fmt simplify check version build run test test-storage
 
 SHELL := /bin/bash
 BASEDIR := $(shell echo $${PWD})
@@ -43,14 +43,6 @@ clean:
 	@rm -rf $(GENERATED)
 	@rm -f $$(which amp)
 
-test:
-	@go test -v $(REPO)/data/storage/etcd
-	@go test -v $(REPO)/data/influx
-	@go test -v $(REPO)/api/rpc/logs
-	@go test -v $(REPO)/api/rpc/project
-	@go test -v $(REPO)/api/rpc/service
-	@go test -v $(REPO)/api/rpc/stat
-
 install: install-cli install-server
 
 install-cli: proto
@@ -91,3 +83,14 @@ install-deps:
 
 update-deps:
 	@glide update --strip-vcs --strip-vendor --update-vendored
+
+test: test-storage
+	@go test -v $(REPO)/data/influx
+	@go test -v $(REPO)/api/rpc/logs
+	@go test -v $(REPO)/api/rpc/project
+	@go test -v $(REPO)/api/rpc/service
+	@go test -v $(REPO)/api/rpc/stat
+
+test-storage:
+	@go test -v $(REPO)/data/storage/etcd
+	

--- a/data/storage/interface.go
+++ b/data/storage/interface.go
@@ -27,16 +27,17 @@ type Interface interface {
 	// If not found and ignoreNotFound is set, then out will be a zero object, otherwise
 	// error will be set to not found. A non-existing node or an empty response are both
 	// treated as not found.
-	// TODO: out will be proto3 message
 	Get(ctx context.Context, key string, out proto.Message, ignoreNotFound bool) error
 
 	// List(ctx context.Context, key string, resourceVersion string, filter FilterFunc, list interface{}) error
 
 	// TODO: will need to add preconditions support
-	// TODO: out needs to be proto3 message
 	Delete(ctx context.Context, key string, out proto.Message) error
 
+	// Update performs a guaranteed update, which means it will continue to retry until an update succeeds or the request is canceled.
 	// Update(ctx context.Context, key string, type interface, ignoreNotFound bool, precondtions *Preconditions, tryUpdate UpdateFunc) error
+	// TODO: the following is a temporary interface
+	Update(ctx context.Context, key string, val proto.Message, ttl int64) error
 
 	// Watch(ctx context.Context, key string, resourceVersion string, filter FilterFunc) (watch.Interface, error)
 


### PR DESCRIPTION
#10

Adds initial update support for the k/v store. This does not close the issue and does not yet implement guaranteed updates with a retry function for resolving conflicts. This is just meant to be a small PR to continue fleshing out more of the storage interfaces.
## Verification

```
$ ./swarm start etcd
$ make test-storage
```
