### PR TITLE
Export connect/disconnect

### DIFF
--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -31,15 +31,17 @@ type AMP struct {
 	Conn          *grpc.ClientConn
 }
 
-func (a *AMP) connect() {
-	conn, err := grpc.Dial(serverAddress, grpc.WithInsecure())
+// Connect to amplifier
+func (a *AMP) Connect() {
+	conn, err := grpc.Dial(ServerAddress, grpc.WithInsecure())
 	if err != nil {
 		log.Fatal(err)
 	}
 	a.Conn = conn
 }
 
-func (a *AMP) disconnect() {
+// Disconnect from amplifier
+func (a *AMP) Disconnect() {
 	err := a.Conn.Close()
 	if err != nil {
 		log.Fatal(err)

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -7,8 +7,8 @@ import (
 
 // GithubOauth does an rpc call to login via github
 func (a *AMP) GithubOauth(username, password, otp string) (lastEight, name string, err error) {
-	a.connect()
-	defer a.disconnect()
+	a.Connect()
+	defer a.Disconnect()
 	c := oauth.NewGithubClient(a.Conn)
 	authReply, err := c.Create(context.Background(), &oauth.AuthRequest{
 		Username: username,


### PR DESCRIPTION
Need to export connect and disconnect from `api/client` so that they are accessible to CLI commands.

Verification

```
$ make
# start amplifier with --clientid and --clientsecret
$ amp login
```
