### PR TITLE
keep only one input (kafka) on telemetry worker

### DIFF
--- a/swarm
+++ b/swarm
@@ -381,6 +381,7 @@ telemetryworker() { # Owner: ndegory
     -e INPUT_PROCESS_ENABLED=false \
     -e INPUT_SWAP_ENABLED=false \
     -e INPUT_SYSTEM_ENABLED=false \
+    -e INPUT_NETSTAT_ENABLED=false \
     -e INPUT_KAFKA_BROKER_URL=kafka:9092 \
     -e INPUT_KAFKA_TOPIC=telegraf \
     -e INFLUXDB_TIMEOUT=20 \


### PR DESCRIPTION
fix #59 

Removes the netstat input plugin on the telegraf telemetry worker
