### PR TITLE
Filtering for log stream

### DIFF
--- a/cmd/amp/cli/logs.go
+++ b/cmd/amp/cli/logs.go
@@ -37,7 +37,7 @@ func Logs(amp *client.AMP, cmd *cobra.Command) error {
 	if request.From, err = strconv.ParseInt(cmd.Flag("from").Value.String(), 10, 64); err != nil {
 		log.Fatalf("Unable to convert from parameter: %v\n", cmd.Flag("from").Value.String())
 	}
-	if request.Size, err = strconv.ParseInt(cmd.Flag("n").Value.String(), 10, 64); err != nil {
+	if request.Size, err = strconv.ParseInt(cmd.Flag("number").Value.String(), 10, 64); err != nil {
 		log.Fatalf("Unable to convert n parameter: %v\n", cmd.Flag("n").Value.String())
 	}
 	var short bool
@@ -45,7 +45,7 @@ func Logs(amp *client.AMP, cmd *cobra.Command) error {
 		log.Fatalf("Unable to convert short parameter: %v\n", cmd.Flag("short").Value.String())
 	}
 	var follow bool
-	if follow, err = strconv.ParseBool(cmd.Flag("f").Value.String()); err != nil {
+	if follow, err = strconv.ParseBool(cmd.Flag("follow").Value.String()); err != nil {
 		log.Fatalf("Unable to convert f parameter: %v\n", cmd.Flag("f").Value.String())
 	}
 

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -126,9 +126,9 @@ func main() {
 	logsCmd.Flags().String("container_id", "", "filter by the given container id")
 	logsCmd.Flags().String("node_id", "", "filter by the given node id")
 	logsCmd.Flags().String("from", "-1", "Fetches from the given index")
-	logsCmd.Flags().String("n", "100", "Number of results")
-	logsCmd.Flags().Bool("short", false, "Displays only the message field")
-	logsCmd.Flags().Bool("f", false, "Follow log output")
+	logsCmd.Flags().StringP("number", "n", "100", "Number of results")
+	logsCmd.Flags().BoolP("short", "s", false, "Displays only the message field")
+	logsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 
 	// This represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
#11

In order to test this PR:

```
./swarm stop
./swarm pull
./swarm start --min
```

In order to circumvent an issue (#69) in accessing kafka from amplifier, you need add kafka container hostname to your machine /etc/host.

Getting kafka hostname:

```
docker ps
docker inspect kafka_container_id | grep hostname
sudo cat /var/lib/docker/containers/a4424bcafbab110b67922994243aca15fc57ab3422fdec21f7460fe16b024456/hostname
```

Update /etc/hosts in order to assign 127.0.0.1 to kafka hostname:

```
127.0.0.1   localhost a4424bcafbab
```

Then test as follows:

```
make
amplifier
amp logs --f
amp logs --f --short
```
