### PR TITLE
disable the net input for the telegraf telemetry worker (kafka consumer)

### DIFF
--- a/swarm
+++ b/swarm
@@ -384,6 +384,7 @@ telemetryworker() { # Owner: ndegory
     -e INPUT_SWAP_ENABLED=false \
     -e INPUT_SYSTEM_ENABLED=false \
     -e INPUT_NETSTAT_ENABLED=false \
+    -e INPUT_NET_ENABLED=false \
     -e INPUT_KAFKA_BROKER_URL=kafka:9092 \
     -e INPUT_KAFKA_TOPIC=telegraf \
     -e INFLUXDB_TIMEOUT=20 \


### PR DESCRIPTION
#83
- the appcelerator/telegraf image now has a new env variable to enable/disable the net plugin, disables the net plugin of telegraf for the kafka consumer in swarm
