### PR TITLE
Add grafana to min services group

### DIFF
--- a/swarm
+++ b/swarm
@@ -35,6 +35,7 @@ MINIMAGES=(
   appcelerator/amp-agent:latest
   appcelerator/amp-log-worker:latest
   appcelerator/elasticsearch-amp:latest
+  appcelerator/grafana:latest
   appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
   appcelerator/kafka:latest
   appcelerator/kibana:latest
@@ -70,6 +71,7 @@ MINSERVICES=(
   amplogworker
   etcd
   elasticsearch
+  grafana
   kafka
   kafkamanager
   influxdb


### PR DESCRIPTION
Add grafana to complement the CLI stats.
## Verification

```
$ ./swarm pull
$ sudo ./swarm start --min
$ ./swarm monitor
```

When grafana service is started, open `http://localhost:6001` in a browser and navigate to the current and historic stats views (you may have to wait a short while for stats to start appearing).
