### PR TITLE
Dockerizing toolchain part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ TAG := latest
 IMAGE := $(OWNER)/amp:$(TAG)
 
 # tools
-GOTOOLS := appcelerator/gotools
+GOTOOLS := appcelerator/gotools2
+
 GLIDE := docker run --rm -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide
 GLIDE_INSTALL := $(GLIDE) install -v
 GLIDE_UPDATE := $(GLIDE) update -v
-
 
 all: version check install
 
@@ -85,7 +85,7 @@ fmt:
 
 check:
 	@test -z $(shell gofmt -l ${CHECKSRC} | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make fmt'"
-	@for d in $$(go list ./... | grep -v /vendor/); do golint $${d} | sed '/pb\.go/d'; done
+	@for d in $$(go list ./... | grep -v /vendor/); do $(GOLINT) $${d} | sed '/pb\.go/d'; done
 	@go tool vet ${CHECKSRC}
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ SERVER := amplifier
 TAG := latest
 IMAGE := $(OWNER)/amp:$(TAG)
 
+# tools
+GOTOOLS := appcelerator/gotools
+GLIDE := docker run --rm -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide
+GLIDE_INSTALL := $(GLIDE) install -v
+GLIDE_UPDATE := $(GLIDE) update -v
+
+
 all: version check install
 
 version:
@@ -47,6 +54,12 @@ clean:
 	@rm -f $$(which amplifier)
 
 install: install-cli install-server
+
+install-deps:
+	@$(GLIDE_INSTALL)
+
+update-deps:
+	@$(GLIDE_UPDATE)
 
 install-cli: proto
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(CLI)
@@ -80,12 +93,6 @@ build:
 
 run: build
 	@CID=$(shell docker run --net=host -d --name $(SERVER) $(IMAGE)) && echo $${CID}
-
-install-deps:
-	@glide install --strip-vcs --strip-vendor --update-vendored
-
-update-deps:
-	@glide update --strip-vcs --strip-vendor --update-vendored
 
 test: test-storage test-influx test-stat test-logs test-project test-build test-service
 


### PR DESCRIPTION
#91

This PR is part 2 of 4 planned steps to close the issue for fully dockerizing the amp toolchain.

This PR updates `install-deps` and `update-deps` to use the containerized version of glide (based on `appcelerator/gotools` image).

IMPORTANT: This PR should not be merged before #103 
## Verification

```
# reinstall dependencies
$ rm -rf vendor
$ make install-deps
# should be no errors

# verify what was installed matches this PR
$ git status
# nothing should be modified
```
