### PR TITLE
Dockerizing toolchain part 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+amp
+amplifier
 .glide/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # appclerator/protoc is based on alpine and includes latest go and protoc
 FROM appcelerator/protoc
-RUN apk --no-cache add make bash git docker curl
+# TODO apk installs the wrong version of docker (1.11.1-r0), need 1.12
+RUN apk --no-cache add make bash git curl docker
 RUN curl https://glide.sh/get | sh
 WORKDIR /go/src/github.com/appcelerator/amp
 COPY glide.lock /go/src/github.com/appcelerator/amp/

--- a/hack/build
+++ b/hack/build
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+APP=$1
+
+# build variables (injected into binaries by linker -ldflags below)
+VERSION="1.0.0"
+BUILD=$(git rev-parse HEAD | cut -c1-8)
+
+OWNER=appcelerator
+REPO=github.com/$OWNER/amp
+
+GOOS=$(uname | tr [:upper:] [:lower:])
+GOARCH=amd64
+
+DOCKER_RUN="docker run -t --rm"
+GOTOOLS=appcelerator/gotools2
+
+GO="$DOCKER_RUN --name go -v $HOME/.ssh:/root/.ssh -v $GOPATH/bin:/go/bin -v $PWD:/go/src/$REPO -w /go/src/$REPO -e GOOS=$GOOS -e GOARCH=$GOARCH $GOTOOLS go"
+
+CMDDIR=cmd
+
+$GO build -ldflags "-X main.Version=$VERSION -X main.Build=$BUILD" $REPO/$CMDDIR/$APP


### PR DESCRIPTION
#91

This PR is part 4 in dockerizing the amp toolchain.

This PR adds a `build` rule to use the containerized version of go (based on `appcelerator/gotools` image).

NOTE: unlike the `install` rule, the `build` rule creates binaries in the repo root directory.
## Verification

```
$ make clean
$ make build
# verify that binaries were generated and are runnable
$ ./amp
$ ./amplifier
```
