### PR TITLE
add ETCDCTL_API env var to enable etcdctl on etcd container

### DIFF
--- a/swarm
+++ b/swarm
@@ -269,6 +269,7 @@ etcd() { # Owner: subfuzion
     --label amp.swarm="infrastructure" \
     -p 2379:2379 \
     -p 2380:2380 \
+    -e ETCDCTL_API=3 \
     quay.io/coreos/etcd:v3.0.4 etcd \
       --name etcd \
       --listen-client-urls http://0.0.0.0:2379 \


### PR DESCRIPTION
little update on swarm file for etcd service 
added ETCDCTL_API=3 env. var
then it allows to use etcdctl using:
docker exec -it [containerId] /etcdctl [command...]
to manually add, get, browse etcd data
