### PR TITLE
gitignore should not ignore amp and amp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-amp
-amplifier
+./amp
+./amplifier
 .glide/


### PR DESCRIPTION
This PR fixes `.gitignore` so only the platform-specific binaries generated by `make build` for `amp` and `amplifier` are ignored, but not the `amp` and `amplifier` subdirectories under `cmd`.
