### PR TITLE
make install-deps fix for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ GOTEST := $(DOCKER_RUN) --name go -v $${HOME}/.ssh:/root/.ssh -v $${GOPATH}/bin:
 UG := $(shell echo "$$(id -u $${USER}):$$(id -g $${USER})")
 
 GLIDE := $(DOCKER_RUN) -u $(UG) -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide
-GLIDE_INSTALL := $(GLIDE) install -v
-GLIDE_UPDATE := $(GLIDE) update -v
+GLIDE_INSTALL := $(GLIDE) install
+GLIDE_UPDATE := $(GLIDE) update
 
 all: version check build
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ GOARCH := amd64
 GO := $(DOCKER_RUN) --name go -v $${HOME}/.ssh:/root/.ssh -v $${GOPATH}/bin:/go/bin -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) -e GOOS=$(GOOS) -e GOARCH=$(GOARCH) $(GOTOOLS) go
 GOTEST := $(DOCKER_RUN) --name go -v $${HOME}/.ssh:/root/.ssh -v $${GOPATH}/bin:/go/bin -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) go test -v
 
-GLIDE := $(DOCKER_RUN) -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide
+UG := $(shell echo "$$(id -u $${USER}):$$(id -g $${USER})")
+
+GLIDE := $(DOCKER_RUN) -u $(UG) -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide
 GLIDE_INSTALL := $(GLIDE) install -v
 GLIDE_UPDATE := $(GLIDE) update -v
 


### PR DESCRIPTION
When glide is run in a container with `make install-deps`, the current directory is mounted. On Docker for Windows, the packages that are installed have the correct user id and group, but on Linux, they are created with root as the owner, which causes issues when attempting to checkout different branches.

This PR fixes the issue by supplying the current user and group to the `docker run` command. Files that are created should correctly indicate the current user as the owner.
## Verification

```
$ sudo rm -rf ~/.glide .glide vendor   # `glide cc` should be enough, but not always
$ make install-deps
```

Confirm that `vendor` and files below it are owned by the correct owner, not root.
