### PR TITLE
Fix file owner for files generated by containerized tools on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,14 @@ GOARCH := amd64
 GO := $(DOCKER_RUN) --name go -v $${HOME}/.ssh:/root/.ssh -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) -e GOOS=$(GOOS) -e GOARCH=$(GOARCH) $(GOTOOLS) go
 GOTEST := $(DOCKER_RUN) --name go -v $${HOME}/.ssh:/root/.ssh -v $${GOPATH}/bin:/go/bin -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) go test -v
 
+GLIDE_DIRS := $${HOME}/.glide $${PWD}/.glide vendor
 GLIDE := $(DOCKER_RUN) -v $${HOME}/.ssh:/root/.ssh -v $${HOME}/.glide:/root/.glide -v $${PWD}:/go/src/$(REPO) -w /go/src/$(REPO) $(GOTOOLS) glide $${GLIDE_OPTS}
 GLIDE_INSTALL := $(GLIDE) install
 GLIDE_UPDATE := $(GLIDE) update
+
+# need UID:GID because files created by containerized tools when mounting
+# cwd are set to root:root
+UG := $(shell echo "$$(id -u $${USER}):$$(id -g $${USER})")
 
 all: version check build
 
@@ -67,9 +72,11 @@ clean:
 
 install-deps:
 	@$(GLIDE_INSTALL)
+	@chown -R $(UG) $(GLIDE_DIRS)
 
 update-deps:
 	@$(GLIDE_UPDATE)
+	@chown -R $(UG) $(GLIDE_DIRS)
 
 install: install-cli install-server
 
@@ -83,12 +90,15 @@ build: build-cli build-server
 
 build-cli: proto
 	@hack/build $(CLI)
+	@chown -R $(UG) $(CLI)
 
 build-server: proto
 	@hack/build $(SERVER)
+	@chown -R $(UG) $(SERVER)
 
 proto: $(PROTOFILES)
 	@for DIR in $(DIRS); do cd $(BASEDIR)/$${DIR}; ls *.proto > /dev/null 2>&1 && docker run --rm --name protoc -t -v $${PWD}:/go/src -v /var/run/docker.sock:/var/run/docker.sock appcelerator/protoc *.proto --go_out=plugins=grpc:. || true; done
+	@find . -type f -name '*.pb.go' $(EXCLUDE_FILES_FILTER) | xargs chown $(UG)
 
 # used to install when you're already inside a container
 install-host: proto-host


### PR DESCRIPTION
Closes #133 #132 #134
- This PR fixes an issue reported by @chrisccoy (#133) that occurs on Linux (but not Docker for Mac), in which files created in by tools running in containers when the current repo is mounted in a volume have the wrong owner (`root:root`). This causes a variety of issues since the user can no longer remove the files without running sudo, such as when switching to a branch that doesn't have them, or updating vendor dependencies, etc. Files affected include all the generated protobuf `*.pb.go` files, the mounted glide cache directories (`$HOME/.glide`, `./.glide`), and `amp` and `amplifier`.
  
  The approach taken by this PR is to run `chown` on the affected files or directories after the containerized tool runs.
- This PR fixes the broken Dockerfile build (#134).
## Verification

Confirm that `amp`, `amplifier`, and all the generated protobuf files have the correct owner:

```
$ make clean
$ make build

$ ls -la amp amplifier
$ find . -type f -name '*.pb.go' -not -path './.glide/*' -not -path './vendor/*' | xargs ls -la
```

Confirm that `~/.glide`, `.glide`, and `vendor` have the correct owner after installing dependencies:

```
$ rm -rf ~/.glide .glide vendor
$ make install-deps

$ ls -lad ~/.glide .glide vendor
```

Confirm that the Dockerfile now builds successfully:

```
$ docker build -t amptest .
$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock amptest docker version
Client:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.7
 Git commit:   v1.12.1
 Built:
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.0
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   8eab29e
 Built:        Thu Jul 28 21:15:28 2016
 OS/Arch:      linux/amd64

$ docker rmi amptest
```
