### PR TITLE
Add glide cache to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *.pb.go
 vendor
+.glide


### PR DESCRIPTION
This PR adds `.glide` to `.dockerignore` so that it isn't copied to the docker context when building a CI image.
## Verification

Confirm that the Dockerfile builds successfully and the client matches as expected:

```
$ docker build -t amptest .
$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock amptest docker version
Client:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.7
 Git commit:   v1.12.1
 Built:
 OS/Arch:      linux/amd64

$ docker rmi amptest
```
