### PR TITLE
Haproxy reverse proxy amplifier service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . /go/src/github.com/appcelerator/amp
 RUN make install-host
 EXPOSE 50101
 ENTRYPOINT []
-CMD [ "amplifier" ]
+CMD [ "/go/bin/amplifier", "--service"]

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ build-cli: proto
 build-server: proto
 	@hack/build $(SERVER)
 
+build-server-image:
+	@docker build -t appcelerator/$(SERVER):$(TAG) .
+
 proto: $(PROTOFILES)
 	@for DIR in $(DIRS); do cd $(BASEDIR)/$${DIR}; ls *.proto > /dev/null 2>&1 && docker run -u $(UG) --rm --name protoc -t -v $${PWD}:/go/src -v /var/run/docker.sock:/var/run/docker.sock appcelerator/protoc *.proto --go_out=plugins=grpc:. || true; done
 

--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	//DefaultServerAddress amplifier address + port default
 	DefaultServerAddress = "localhost:50101"
 )
 

--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultPort   = ":50101"
+	defaultPort   = ":81"
 	serverAddress = "localhost" + defaultPort
 )
 

--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	defaultPort   = ":81"
-	serverAddress = "localhost" + defaultPort
+	//DefaultServerAddress amplifier or HAProxy address
+	DefaultServerAddress = "localhost:50101"
 )
 
 // Configuration is for all configurable client settings
@@ -19,6 +19,8 @@ type Configuration struct {
 	Github  string
 	Target  string
 	Images  []string
+	Port   string
+	ServerAddress string
 }
 
 // AMP holds the state for the current environment
@@ -30,7 +32,7 @@ type AMP struct {
 
 // Connect to amplifier
 func (a *AMP) Connect() *grpc.ClientConn {
-	conn, err := grpc.Dial(serverAddress, grpc.WithInsecure())
+	conn, err := grpc.Dial(a.Configuration.ServerAddress, grpc.WithInsecure())
 	if err != nil {
 		log.Panic(err)
 	}

--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	//DefaultServerAddress amplifier or HAProxy address
 	DefaultServerAddress = "localhost:50101"
 )
 

--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -152,14 +152,12 @@ func (s *Stats) statQueryMetric(req *StatsRequest, metric string) (*StatsReply, 
 	if len(res.Results[0].Series) == 0 {
 		return nil, errors.New("No result found")
 	}
-
-	cpuReply := StatsReply{}
 	if len(res.Results[0].Series) == 0 {
 		return nil, errors.New("No result found")
 	}
 	list := res.Results[0].Series[0].Values
-	cpuReply.Entries = make([]*StatsEntry, len(list))
-	for i, row := range list {
+	containerMap := make(map[string]*StatsEntry)
+	for _, row := range list {
 		entry := StatsEntry{
 			Time:           s.getTimeFieldValue(row[0]),
 			Datacenter:     s.getStringFieldValue(row[1]),
@@ -188,34 +186,53 @@ func (s *Stats) statQueryMetric(req *StatsRequest, metric string) (*StatsReply, 
 			entry.NetTxBytes = s.getNumberFieldValue(row[11])
 			entry.NetRxBytes = s.getNumberFieldValue(row[12])
 		}
-
-		cpuReply.Entries[i] = &entry
+		s.sumByContainer(containerMap, &entry)
 	}
-	return s.computeData(req, &cpuReply)
+	return s.computeData(req, containerMap)
 }
 
-func (s *Stats) computeData(req *StatsRequest, data *StatsReply) (*StatsReply, error) {
+func (s *Stats) sumByContainer(containerMap map[string]*StatsEntry, row *StatsEntry) {
+	key := row.ContainerId
+	aggr, ok := containerMap[key]
+	if !ok {
+		containerMap[key] = row
+		if row.Cpu != 0 || row.Mem != 0 || row.IoRead != 0 || row.IoWrite != 0 || row.NetTxBytes != 0 || row.NetRxBytes != 0 {
+			row.Number = 1
+		}
+	} else {
+		aggr.Cpu += row.Cpu
+		aggr.Mem += row.Mem
+		aggr.MemUsage += row.MemUsage
+		aggr.MemLimit += row.MemLimit
+		aggr.IoRead += row.IoRead
+		aggr.IoWrite += row.IoWrite
+		aggr.NetTxBytes += row.NetTxBytes
+		aggr.NetRxBytes += row.NetRxBytes
+		if row.Cpu != 0 || row.Mem != 0 || row.IoRead != 0 || row.IoWrite != 0 || row.NetTxBytes != 0 || row.NetRxBytes != 0 {
+			aggr.Number++
+		}
+	}
+}
+
+func (s *Stats) computeData(req *StatsRequest, containerMap map[string]*StatsEntry) (*StatsReply, error) {
 	// aggreggate rows in map per id concidering req (containner_id | service_id | task_id | nodeId)
 	resultMap := make(map[string]*StatsEntry)
-	for _, row := range data.Entries {
+	for _, row := range containerMap {
 		key := s.getKey(req, row)
 		aggr, ok := resultMap[key]
 		if !ok {
 			resultMap[key] = row
-			if row.Cpu != 0 || row.Mem != 0 || row.IoRead != 0 || row.IoWrite != 0 || row.NetTxBytes != 0 || row.NetRxBytes != 0 {
-				row.Number = 1
-			}
 		} else {
-			aggr.Cpu += row.Cpu
-			aggr.Mem += row.Mem
-			aggr.MemUsage += row.MemUsage
-			aggr.MemLimit += row.MemLimit
-			aggr.IoRead += row.IoRead
-			aggr.IoWrite += row.IoWrite
-			aggr.NetTxBytes += row.NetTxBytes
-			aggr.NetRxBytes += row.NetRxBytes
-			if row.Cpu != 0 || row.Mem != 0 {
-				aggr.Number++
+			number := row.Number
+			if number >0 {
+				aggr.Cpu += row.Cpu / number
+				aggr.Mem += row.Mem / number
+				aggr.MemUsage += row.MemUsage / number
+				aggr.MemLimit += row.MemLimit / number
+				aggr.IoRead += row.IoRead / number
+				aggr.IoWrite += row.IoWrite / number
+				aggr.NetTxBytes += row.NetTxBytes / number
+				aggr.NetRxBytes += row.NetRxBytes / number
 			}
 		}
 	}

--- a/cmd/amp/confighelper.go
+++ b/cmd/amp/confighelper.go
@@ -9,8 +9,9 @@ import (
 
 // InitConfig reads in a config file and ENV variables if set.
 // Configuration variable lookup occurs in a specific order.
-func InitConfig(configFile string, config *client.Configuration, verbose bool) {
+func InitConfig(configFile string, config *client.Configuration, verbose bool, serverAddr string) {
 	config.Verbose = verbose
+	config.ServerAddress = serverAddr
 
 	// Add matching envirionment variables - will be first in precedence.
 	viper.AutomaticEnv()

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -112,6 +112,7 @@ func main() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
 
+
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)
 	RootCmd.AddCommand(startCmd)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -110,7 +110,11 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "Config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().String("target", "local", `target environment ("local"|"virtualbox"|"aws")`)
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
+<<<<<<< 6d9143a34fdbe62882f12343609539a74e53e744
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
+=======
+	RootCmd.PersistentFlags().StringVarP(&serverAddr, "server", "s", client.DefaultServerAddress, "Server address")
+>>>>>>> add -s --server to choose the target
 
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -112,7 +112,6 @@ func main() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
 
-
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)
 	RootCmd.AddCommand(startCmd)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	cobra.OnInitialize(func() {
 		InitConfig(configFile, &Config, verbose, serverAddr)
+		fmt.Println("Server: "+Config.ServerAddress)
 		AMP = client.NewAMP(&Config)
 		AMP.Connect()
 		cli.AtExit(func() {
@@ -109,7 +110,7 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "Config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().String("target", "local", `target environment ("local"|"virtualbox"|"aws")`)
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
-	RootCmd.PersistentFlags().StringVarP(&serverAddr, "server", "s", client.DefaultServerAddress, "Server address")
+	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
 
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -22,6 +22,7 @@ var (
 	Config     client.Configuration
 	configFile string
 	verbose    bool
+	serverAddr string
 
 	// RootCmd is the base command for the CLI.
 	RootCmd = &cobra.Command{
@@ -36,7 +37,7 @@ func main() {
 	fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
 
 	cobra.OnInitialize(func() {
-		InitConfig(configFile, &Config, verbose)
+		InitConfig(configFile, &Config, verbose, serverAddr)
 		AMP = client.NewAMP(&Config)
 		AMP.Connect()
 		cli.AtExit(func() {
@@ -108,6 +109,7 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "Config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().String("target", "local", `target environment ("local"|"virtualbox"|"aws")`)
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
+	RootCmd.PersistentFlags().StringVarP(&serverAddr, "server", "s", client.DefaultServerAddress, "Server address")
 
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -110,11 +110,7 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "Config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().String("target", "local", `target environment ("local"|"virtualbox"|"aws")`)
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `verbose output`)
-<<<<<<< 6d9143a34fdbe62882f12343609539a74e53e744
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
-=======
-	RootCmd.PersistentFlags().StringVarP(&serverAddr, "server", "s", client.DefaultServerAddress, "Server address")
->>>>>>> add -s --server to choose the target
 
 	RootCmd.AddCommand(createCmd)
 	RootCmd.AddCommand(stopCmd)

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-
 	"github.com/appcelerator/amp/api/server"
 	flag "github.com/spf13/pflag"
 )

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -9,12 +9,15 @@ import (
 
 const (
 	defaultPort             = ":50101"
-	etcdDefaultEndpoints    = "http://etcd:2379"
-	elasticsearchDefaultURL = "http://elasticsearch:9200"
 	defaultClientID         = ""
 	defaultClientSecret     = ""
-	kafkaDefaultURL         = "kafka:9092"
-	influxDefaultURL        = "http://influxdb:8086"
+)
+
+var (
+	etcdDefaultEndpoints    = "http://localhost:2379"
+	elasticsearchDefaultURL = "http://localhost:9200"
+	kafkaDefaultURL         = "localhost:9092"
+	influxDefaultURL        = "http://localhost:8086"
 )
 
 // build vars
@@ -36,10 +39,12 @@ var (
 	clientSecret     string
 	kafkaURL         string
 	influxURL        string
+	isService	 bool
 )
 
 func parseFlags() {
 	// set up flags
+	flag.BoolVar(&isService, "service", false, "Launched as a service into swarm network")
 	flag.StringVarP(&port, "port", "p", defaultPort, "server port (default '"+defaultPort+"')")
 	flag.StringVarP(&etcdEndpoints, "endpoints", "e", etcdDefaultEndpoints, "etcd comma-separated endpoints")
 	flag.StringVarP(&elasticsearchURL, "elasticsearchURL", "s", elasticsearchDefaultURL, "elasticsearch URL (default '"+elasticsearchDefaultURL+"')")
@@ -50,6 +55,14 @@ func parseFlags() {
 
 	// parse command line flags
 	flag.Parse()
+
+	//Update url is service usage
+	if isService {
+		etcdEndpoints    = "http://etcd:2379"
+		elasticsearchURL = "http://elasticsearch:9200"
+		kafkaURL         = "kafka:9092"
+		influxURL        = "http://influxdb:8086"
+	}
 
 	// update config
 	config.Port = port

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -10,12 +10,12 @@ import (
 
 const (
 	defaultPort             = ":50101"
-	etcdDefaultEndpoints    = "http://localhost:2379"
-	elasticsearchDefaultURL = "http://localhost:9200"
+	etcdDefaultEndpoints    = "http://etcd:2379"
+	elasticsearchDefaultURL = "http://elasticsearch:9200"
 	defaultClientID         = ""
 	defaultClientSecret     = ""
-	kafkaDefaultURL         = "localhost:9092"
-	influxDefaultURL        = "http://localhost:8086"
+	kafkaDefaultURL         = "kafka:9092"
+	influxDefaultURL        = "http://influxdb:8086"
 )
 
 // build vars

--- a/swarm
+++ b/swarm
@@ -236,7 +236,6 @@ ampui() { # Owner: freignat91
   docker service create --network amp-swarm --name amp-ui \
     --label amp.swarm="infrastructure" \
     --constraint "node.role == manager" \
-    -p 8080:8080 \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     appcelerator/amp-ui:latest
 }

--- a/swarm
+++ b/swarm
@@ -235,6 +235,7 @@ amplogworker() { # Owner: bertrand-quenin
 ampui() { # Owner: freignat91
   docker service create --network amp-swarm --name amp-ui \
     --label amp.swarm="infrastructure" \
+    --constraint "node.role == manager" \
     -p 8080:8080 \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     appcelerator/amp-ui:latest

--- a/swarm
+++ b/swarm
@@ -211,7 +211,6 @@ monitor() {
 amplifier() {
   docker service create --network amp-swarm,amp-public --name amplifier \
     --label amp.swarm="infrastructure" \
-    -p 50101:50101 \
     appcelerator/amplifier:latest
 }
 
@@ -230,7 +229,6 @@ amplogworker() { # Owner: bertrand-quenin
     --label amp.swarm="infrastructure" \
     appcelerator/amp-log-worker:latest
 }
-
 
 ampui() { # Owner: freignat91
   docker service create --network amp-swarm --name amp-ui \

--- a/swarm
+++ b/swarm
@@ -321,7 +321,7 @@ haproxy() { # Owner: freignat91
   docker service create --network amp-swarm,amp-public --name haproxy \
     --label amp.swarm="infrastructure" \
     -p 80:80 \
-    -p 81:81 \
+    -p 8080:8080 \  #For GRPC HAPROXY and by-pass Firewall to reach AWS
     appcelerator/haproxy:latest
 }
 

--- a/swarm
+++ b/swarm
@@ -153,7 +153,6 @@ main() {
   fi
 }
 
-
 # initialize / join swarm as manager
 initswarm() {
   docker node inspect self > /dev/null 2>&1 || docker swarm inspect > /dev/null 2>&1 || (echo "> Initializing swarm" && docker swarm init)

--- a/swarm
+++ b/swarm
@@ -317,10 +317,11 @@ kibana() { # Owner: ndegory
 }
 
 haproxy() { # Owner: freignat91
-  docker service create --network amp-swarm --name haproxy \
+  docker service create --network amp-swarm,amp-public --name haproxy \
     --label amp.swarm="infrastructure" \
     -p 80:80 \
-    appcelerator/haproxy:latest
+    -p 81:81 \
+    appcelerator/haproxy:test
 }
 
 telegrafagent() { # Owner: ndegory

--- a/swarm
+++ b/swarm
@@ -15,6 +15,7 @@ ZOOKEEPER_VERSION=3.4.8
 
 # please keep sorted
 IMAGES=(
+  appcelerator/amplifier:latest
   appcelerator/amp-agent:latest
   appcelerator/amp-log-worker:latest
   appcelerator/amp-ui:latest
@@ -31,6 +32,7 @@ IMAGES=(
 )
 
 MINIMAGES=(
+  appcelerator/amplifier:latest  
   appcelerator/amp-agent:latest
   appcelerator/amp-log-worker:latest
   appcelerator/elasticsearch-amp:latest
@@ -45,6 +47,7 @@ MINIMAGES=(
 
 # please keep sorted
 SERVICES=(
+  amplifier
   ampagent
   amplogworker
   ampui
@@ -61,6 +64,7 @@ SERVICES=(
 )
 
 MINSERVICES=(
+  amplifier
   ampagent
   amplogworker
   etcd
@@ -158,6 +162,7 @@ initswarm() {
 # set up the amp-swarm overlay network
 createnetwork() {
   docker network ls | grep amp-swarm || (echo "> Creating overlay network 'amp-swarm'" && docker network create -d overlay amp-swarm)
+  docker network ls | grep amp-public || (echo "> Creating overlay network 'amp-public'" && docker network create -d overlay amp-public)
 }
 
 # pull the latest AMP images to local docker cache
@@ -202,6 +207,13 @@ ls() {
 monitor() {
   interval=${1:-5}
   clear; while true; do tput cup 0 0; docker service ls; sleep $interval; done
+}
+
+amplifier() {
+  docker service create --network amp-swarm,amp-public --name amplifier \
+    --label amp.swarm="infrastructure" \
+    -p 50101:50101 \
+    appcelerator/amplifier:latest
 }
 
 ampagent() { # Owner: freignat91

--- a/swarm
+++ b/swarm
@@ -232,6 +232,7 @@ amplogworker() { # Owner: bertrand-quenin
     appcelerator/amp-log-worker:latest
 }
 
+
 ampui() { # Owner: freignat91
   docker service create --network amp-swarm --name amp-ui \
     --label amp.swarm="infrastructure" \

--- a/swarm
+++ b/swarm
@@ -320,7 +320,7 @@ haproxy() { # Owner: freignat91
   docker service create --network amp-swarm,amp-public --name haproxy \
     --label amp.swarm="infrastructure" \
     -p 80:80 \
-    -p 8080:8080 \  #For GRPC HAPROXY and by-pass Firewall to reach AWS
+    -p 8080:8080 \
     appcelerator/haproxy:latest
 }
 

--- a/swarm
+++ b/swarm
@@ -322,7 +322,7 @@ haproxy() { # Owner: freignat91
     --label amp.swarm="infrastructure" \
     -p 80:80 \
     -p 81:81 \
-    appcelerator/haproxy:test
+    appcelerator/haproxy:latest
 }
 
 telegrafagent() { # Owner: ndegory

--- a/swarm
+++ b/swarm
@@ -248,6 +248,7 @@ elasticsearch() { # Owner: bertrand-quenin
     appcelerator/elasticsearch-amp:latest
 }
 
+
 etcd() { # Owner: subfuzion
   docker service create --network amp-swarm --name etcd \
     --label amp.swarm="infrastructure" \

--- a/swarm
+++ b/swarm
@@ -308,6 +308,7 @@ kapacitor() { # Owner: ndegory
     appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
 }
 
+
 kibana() { # Owner: ndegory
   docker service create --network amp-swarm --name kibana \
     --replicas 1 \

--- a/swarm
+++ b/swarm
@@ -325,7 +325,6 @@ haproxy() { # Owner: freignat91
     appcelerator/haproxy:latest
 }
 
-
 telegrafagent() { # Owner: ndegory
   docker service create --network amp-swarm --name telegraf-agent \
     --mode global \

--- a/swarm
+++ b/swarm
@@ -319,8 +319,8 @@ kibana() { # Owner: ndegory
 haproxy() { # Owner: freignat91
   docker service create --network amp-swarm,amp-public --name haproxy \
     --label amp.swarm="infrastructure" \
-    -p 80:80 \
     -p 8080:8080 \
+    -p 80:80 \
     appcelerator/haproxy:latest
 }
 

--- a/swarm
+++ b/swarm
@@ -325,6 +325,7 @@ haproxy() { # Owner: freignat91
     appcelerator/haproxy:latest
 }
 
+
 telegrafagent() { # Owner: ndegory
   docker service create --network amp-swarm --name telegraf-agent \
     --mode global \

--- a/vendor/github.com/docker/distribution/contrib/docker-integration/tokenserver-oauth/.htpasswd
+++ b/vendor/github.com/docker/distribution/contrib/docker-integration/tokenserver-oauth/.htpasswd
@@ -1,0 +1,1 @@
+testuser:$2y$05$T2MlBvkN1R/yICNnLuf1leOlOfAY0DvybctbbWUFKlojfkShVgn4m

--- a/vendor/github.com/docker/distribution/contrib/docker-integration/tokenserver/.htpasswd
+++ b/vendor/github.com/docker/distribution/contrib/docker-integration/tokenserver/.htpasswd
@@ -1,0 +1,1 @@
+testuser:$2y$05$T2MlBvkN1R/yICNnLuf1leOlOfAY0DvybctbbWUFKlojfkShVgn4m


### PR DESCRIPTION
#112
- add option --service for amplifier, if exist it uses swarm addresses, if not it uses localhost addresses
- add option --server for amp, if exist it uses the value to found amplifier server, if not it use localhost:50101
- add build-server-image entry in Makefile to build the appcelerator/amplifier:lastest image
- update swarm file to create network amp-public and add amplifier service on networtk amp-public
- update HAProxy to reserse proxy GRPC connection from 8080 to amplifier

test on the 'haproxy' branch
- rm -rf vendor
- glide install
- make
- ./swarm pull
- ./swarm start

the image appcelerator/amplifier:latest is used for the service amplifier.
It's possible to rebuild it using the command:
make build-server-image

when all services are started:
- ./amp logs  --server localhost:8080 ->  call the service amplifier through HAProxy and run the command logs
- ./amp logs -> try to reach local amplifier server and generate error
- ./amplifier --clientid [your id] -- clientsecret [your secret]  -> launch local amplifier server
- ./amp logs -> call the local amplifier server and execute the command logs
- ./amp logs  --server localhost:8080 -> verify that the command on the amplifier service still works

To test on Amazon try (only if your firewall policy let port 8080 open for AWS IP, if not needs IT Request)
- ./amp stats --server 52.210.103.91:8080 --service

you should get the AWS amp test environment services stats

AWS amp test UI is available here: http://52.210.103.91/ui/
(need firewall port 80 open for aws machines)
