### PR TITLE
gRPC Service for Project data storage

### DIFF
--- a/api/rpc/project/project.go
+++ b/api/rpc/project/project.go
@@ -43,7 +43,7 @@ func (p *Proj) Update(ctx context.Context, req *ProjectRequest) (*ProjectReply, 
 func (p *Proj) Get(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
 	// Build The Key for the Project
 	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
-	reply := &ProjectReply{Project: &Project{}}
+	reply := &ProjectReply{Project: &ProjectEntry{}}
 	// Retrieve the Value for the Given Key
 	err := p.Store.Get(ctx, key, reply.Project, true)
 	return reply, err
@@ -53,7 +53,7 @@ func (p *Proj) Get(ctx context.Context, req *ProjectRequest) (*ProjectReply, err
 func (p *Proj) Delete(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
 	// Build The Key for the Project
 	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
-	reply := &ProjectReply{Project: &Project{}}
+	reply := &ProjectReply{Project: &ProjectEntry{}}
 	// Delete the Key and Value from the Store
 	err := p.Store.Delete(ctx, key, reply.Project)
 	return reply, err
@@ -63,8 +63,8 @@ func (p *Proj) Delete(ctx context.Context, req *ProjectRequest) (*ProjectReply, 
 func (p *Proj) List(ctx context.Context, req *Empty) (*ProjectsReply, error) {
 	// Build the Key based on the prefix only
 	key := fmt.Sprintf("%s", prefix)
-	obj := &Project{}
-	reply := &ProjectsReply{Projects: []*Project{}}
+	obj := &ProjectEntry{}
+	reply := &ProjectsReply{Projects: []*ProjectEntry{}}
 	var out []proto.Message
 	// Return all of the entries for the given Key Pattern
 	err := p.Store.List(ctx, key, storage.Everything, obj, &out)
@@ -75,7 +75,7 @@ func (p *Proj) List(ctx context.Context, req *Empty) (*ProjectsReply, error) {
 	// 	reply.Projects = out.([]*Project) <-- Illegal Syntax
 
 	for i := 0; i < len(out); i++ {
-		resp, ok := out[i].(*Project)
+		resp, ok := out[i].(*ProjectEntry)
 		if !ok {
 
 			return reply, fmt.Errorf("Inavlid Type Conversion")

--- a/api/rpc/project/project.go
+++ b/api/rpc/project/project.go
@@ -1,40 +1,86 @@
 package project
 
-// import (
-//
-// 	"encoding/json"
-// 	"golang.org/x/net/context"
-// 	"log"
-// )
-//
-// const (
-// 	keySpace = "/amp/project"
-// )
-//
-// // Service is used to implement ProjectServer
-// type Service struct {
-// }
-//
-// // CreateProject implements ProjectServer
-// func (s *Service) Create(ctx context.Context, in *CreateRequest) (*CreateReply, error) {
-// 	// Storing the project
-// 	etc.Put(keySpace, in)
-//
-// 	// Iterate through all entries
-// 	all, err := etc.All(keySpace)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	for _, node := range all {
-// 		// Deserialize node value into a CreateRequest (could also be just a map[string]interface{}).
-// 		var cr project.CreateRequest
-// 		err := json.Unmarshal([]byte(node.Value), &cr)
-// 		cr.Id = node.Key
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 		log.Printf("%+v\n", cr)
-// 	}
-//
-// 	return &CreateReply{Message: "Hello " + in.Name}, nil
-// }
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/appcelerator/amp/data/storage"
+	"github.com/golang/protobuf/proto"
+)
+
+const (
+	defTimeout = 5 * time.Second
+	prefix     = "project"
+)
+
+// Proj structure to implement ProjServer interface
+type Proj struct {
+	Store storage.Interface
+}
+
+// Create adds a new entry to the k,v data store
+func (p *Proj) Create(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
+	ttl := int64(0)
+	reply := &ProjectReply{}
+	err := p.Store.Create(ctx, key, req.Project, reply.Project, ttl)
+	return reply, err
+}
+
+//Update removes the entry for the specified Key
+func (p *Proj) Update(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+	// Build The Key for the Project
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
+	reply := &ProjectReply{}
+	ttl := int64(0)
+	// Update the Value for the given Key
+	err := p.Store.Update(ctx, key, req.Project, ttl)
+	return reply, err
+}
+
+//Get fetches the entry for the specified Key
+func (p *Proj) Get(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+	// Build The Key for the Project
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
+	reply := &ProjectReply{Project: &Project{}}
+	// Retrieve the Value for the Given Key
+	err := p.Store.Get(ctx, key, reply.Project, true)
+	return reply, err
+}
+
+//Delete removes the entry for the specified Key
+func (p *Proj) Delete(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+	// Build The Key for the Project
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
+	reply := &ProjectReply{Project: &Project{}}
+	// Delete the Key and Value from the Store
+	err := p.Store.Delete(ctx, key, reply.Project)
+	return reply, err
+}
+
+//List retrieves all of the values for a specified Key range
+func (p *Proj) List(ctx context.Context, req *Empty) (*ProjectsReply, error) {
+	// Build the Key based on the prefix only
+	key := fmt.Sprintf("%s", prefix)
+	obj := &Project{}
+	reply := &ProjectsReply{Projects: []*Project{}}
+	var out []proto.Message
+	// Return all of the entries for the given Key Pattern
+	err := p.Store.List(ctx, key, storage.Everything, obj, &out)
+	if err != nil {
+		return reply, err
+	}
+	// TODO Could not avoid the wire type error without explicit type conversion
+	// 	reply.Projects = out.([]*Project) <-- Illegal Syntax
+
+	for i := 0; i < len(out); i++ {
+		resp, ok := out[i].(*Project)
+		if !ok {
+
+			return reply, fmt.Errorf("Inavlid Type Conversion")
+		}
+		reply.Projects = append(reply.Projects, resp)
+	}
+	return reply, err
+}

--- a/api/rpc/project/project.go
+++ b/api/rpc/project/project.go
@@ -3,15 +3,12 @@ package project
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/appcelerator/amp/data/storage"
 	"github.com/golang/protobuf/proto"
 )
 
 const (
-	defTimeout = 5 * time.Second
-	prefix     = "project"
+	prefix = "project"
 )
 
 // Proj structure to implement ProjServer interface
@@ -20,67 +17,71 @@ type Proj struct {
 }
 
 // Create adds a new entry to the k,v data store
-func (p *Proj) Create(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
-	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
+func (p *Proj) Create(ctx context.Context, req *CreateRequest) (*CreateReply, error) {
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.Id)
 	ttl := int64(0)
-	reply := &ProjectReply{}
+	reply := CreateReply{Project: &ProjectEntry{}}
 	err := p.Store.Create(ctx, key, req.Project, reply.Project, ttl)
-	return reply, err
+	return &reply, err
 }
 
 //Update removes the entry for the specified Key
-func (p *Proj) Update(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+func (p *Proj) Update(ctx context.Context, req *UpdateRequest) (*UpdateReply, error) {
 	// Build The Key for the Project
-	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
-	reply := &ProjectReply{}
+	key := fmt.Sprintf("%s/%v", prefix, req.Project.Id)
 	ttl := int64(0)
+	reply := UpdateReply{Project: &ProjectEntry{}}
 	// Update the Value for the given Key
 	err := p.Store.Update(ctx, key, req.Project, ttl)
-	return reply, err
+	return &reply, err
 }
 
 //Get fetches the entry for the specified Key
-func (p *Proj) Get(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+func (p *Proj) Get(ctx context.Context, req *GetRequest) (*GetReply, error) {
 	// Build The Key for the Project
-	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
-	reply := &ProjectReply{Project: &ProjectEntry{}}
+	key := fmt.Sprintf("%s/%v", prefix, req.Id)
+	reply := GetReply{Project: &ProjectEntry{}}
 	// Retrieve the Value for the Given Key
 	err := p.Store.Get(ctx, key, reply.Project, true)
-	return reply, err
+	return &reply, err
 }
 
 //Delete removes the entry for the specified Key
-func (p *Proj) Delete(ctx context.Context, req *ProjectRequest) (*ProjectReply, error) {
+func (p *Proj) Delete(ctx context.Context, req *DeleteRequest) (*DeleteReply, error) {
 	// Build The Key for the Project
-	key := fmt.Sprintf("%s/%v", prefix, req.Project.RepoId)
-	reply := &ProjectReply{Project: &ProjectEntry{}}
+	key := fmt.Sprintf("%s/%v", prefix, req.Id)
+	reply := DeleteReply{Project: &ProjectEntry{}}
 	// Delete the Key and Value from the Store
 	err := p.Store.Delete(ctx, key, reply.Project)
-	return reply, err
+	return &reply, err
 }
 
 //List retrieves all of the values for a specified Key range
-func (p *Proj) List(ctx context.Context, req *Empty) (*ProjectsReply, error) {
+func (p *Proj) List(ctx context.Context, req *ListRequest) (*ListReply, error) {
 	// Build the Key based on the prefix only
 	key := fmt.Sprintf("%s", prefix)
-	obj := &ProjectEntry{}
-	reply := &ProjectsReply{Projects: []*ProjectEntry{}}
+	obj := ProjectEntry{}
 	var out []proto.Message
+	reply := ListReply{}
 	// Return all of the entries for the given Key Pattern
-	err := p.Store.List(ctx, key, storage.Everything, obj, &out)
+	err := p.Store.List(ctx, key, storage.Everything, &obj, &out)
 	if err != nil {
-		return reply, err
+		return &reply, err
 	}
-	// TODO Could not avoid the wire type error without explicit type conversion
-	// 	reply.Projects = out.([]*Project) <-- Illegal Syntax
-
-	for i := 0; i < len(out); i++ {
-		resp, ok := out[i].(*ProjectEntry)
-		if !ok {
-
-			return reply, fmt.Errorf("Inavlid Type Conversion")
-		}
-		reply.Projects = append(reply.Projects, resp)
+	reply.Projects = make([]*ProjectEntry, len(out))
+	for i, project := range out {
+		reply.Projects[i] = project.(*ProjectEntry)
 	}
-	return reply, err
+
+	//// TODO Could not avoid the wire type error without explicit type conversion
+	//// 	reply.Projects = out.([]*ProjectEntry) <-- Illegal Syntax
+	//
+	//for i := range out {
+	//	p, ok := out[i].(*ProjectEntry)
+	//	if !ok {
+	//		return reply, fmt.Errorf("Invalid Type Conversion")
+	//	}
+	//	reply.Projects = append(reply.Projects, p)
+	//}
+	return &reply, err
 }

--- a/api/rpc/project/project.pb.go
+++ b/api/rpc/project/project.pb.go
@@ -9,7 +9,7 @@ It is generated from these files:
 	project.proto
 
 It has these top-level messages:
-	Project
+	ProjectEntry
 	Empty
 	ProjectRequest
 	ProjectReply
@@ -37,17 +37,17 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type Project struct {
+type ProjectEntry struct {
 	RepoId    int32  `protobuf:"varint,1,opt,name=repo_id,json=repoId" json:"repo_id,omitempty"`
 	OwnerName string `protobuf:"bytes,2,opt,name=owner_name,json=ownerName" json:"owner_name,omitempty"`
 	RepoName  string `protobuf:"bytes,3,opt,name=repo_name,json=repoName" json:"repo_name,omitempty"`
 	Token     string `protobuf:"bytes,4,opt,name=token" json:"token,omitempty"`
 }
 
-func (m *Project) Reset()                    { *m = Project{} }
-func (m *Project) String() string            { return proto.CompactTextString(m) }
-func (*Project) ProtoMessage()               {}
-func (*Project) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *ProjectEntry) Reset()                    { *m = ProjectEntry{} }
+func (m *ProjectEntry) String() string            { return proto.CompactTextString(m) }
+func (*ProjectEntry) ProtoMessage()               {}
+func (*ProjectEntry) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
 type Empty struct {
 }
@@ -58,7 +58,7 @@ func (*Empty) ProtoMessage()               {}
 func (*Empty) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
 type ProjectRequest struct {
-	Project *Project `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
 }
 
 func (m *ProjectRequest) Reset()                    { *m = ProjectRequest{} }
@@ -66,7 +66,7 @@ func (m *ProjectRequest) String() string            { return proto.CompactTextSt
 func (*ProjectRequest) ProtoMessage()               {}
 func (*ProjectRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
-func (m *ProjectRequest) GetProject() *Project {
+func (m *ProjectRequest) GetProject() *ProjectEntry {
 	if m != nil {
 		return m.Project
 	}
@@ -74,7 +74,7 @@ func (m *ProjectRequest) GetProject() *Project {
 }
 
 type ProjectReply struct {
-	Project *Project `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
 }
 
 func (m *ProjectReply) Reset()                    { *m = ProjectReply{} }
@@ -82,7 +82,7 @@ func (m *ProjectReply) String() string            { return proto.CompactTextStri
 func (*ProjectReply) ProtoMessage()               {}
 func (*ProjectReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
 
-func (m *ProjectReply) GetProject() *Project {
+func (m *ProjectReply) GetProject() *ProjectEntry {
 	if m != nil {
 		return m.Project
 	}
@@ -90,7 +90,7 @@ func (m *ProjectReply) GetProject() *Project {
 }
 
 type ProjectsReply struct {
-	Projects []*Project `protobuf:"bytes,1,rep,name=projects" json:"projects,omitempty"`
+	Projects []*ProjectEntry `protobuf:"bytes,1,rep,name=projects" json:"projects,omitempty"`
 }
 
 func (m *ProjectsReply) Reset()                    { *m = ProjectsReply{} }
@@ -98,7 +98,7 @@ func (m *ProjectsReply) String() string            { return proto.CompactTextStr
 func (*ProjectsReply) ProtoMessage()               {}
 func (*ProjectsReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
-func (m *ProjectsReply) GetProjects() []*Project {
+func (m *ProjectsReply) GetProjects() []*ProjectEntry {
 	if m != nil {
 		return m.Projects
 	}
@@ -106,7 +106,7 @@ func (m *ProjectsReply) GetProjects() []*Project {
 }
 
 func init() {
-	proto.RegisterType((*Project)(nil), "project.Project")
+	proto.RegisterType((*ProjectEntry)(nil), "project.ProjectEntry")
 	proto.RegisterType((*Empty)(nil), "project.Empty")
 	proto.RegisterType((*ProjectRequest)(nil), "project.ProjectRequest")
 	proto.RegisterType((*ProjectReply)(nil), "project.ProjectReply")
@@ -121,9 +121,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion3
 
-// Client API for ProjectSvc service
+// Client API for Project service
 
-type ProjectSvcClient interface {
+type ProjectClient interface {
 	Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
 	Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
 	List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error)
@@ -131,62 +131,62 @@ type ProjectSvcClient interface {
 	Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
 }
 
-type projectSvcClient struct {
+type projectClient struct {
 	cc *grpc.ClientConn
 }
 
-func NewProjectSvcClient(cc *grpc.ClientConn) ProjectSvcClient {
-	return &projectSvcClient{cc}
+func NewProjectClient(cc *grpc.ClientConn) ProjectClient {
+	return &projectClient{cc}
 }
 
-func (c *projectSvcClient) Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+func (c *projectClient) Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
 	out := new(ProjectReply)
-	err := grpc.Invoke(ctx, "/project.ProjectSvc/Create", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/project.Project/Create", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *projectSvcClient) Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+func (c *projectClient) Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
 	out := new(ProjectReply)
-	err := grpc.Invoke(ctx, "/project.ProjectSvc/Delete", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/project.Project/Delete", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *projectSvcClient) List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error) {
+func (c *projectClient) List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error) {
 	out := new(ProjectsReply)
-	err := grpc.Invoke(ctx, "/project.ProjectSvc/List", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/project.Project/List", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *projectSvcClient) Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+func (c *projectClient) Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
 	out := new(ProjectReply)
-	err := grpc.Invoke(ctx, "/project.ProjectSvc/Get", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/project.Project/Get", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *projectSvcClient) Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+func (c *projectClient) Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
 	out := new(ProjectReply)
-	err := grpc.Invoke(ctx, "/project.ProjectSvc/Update", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/project.Project/Update", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for ProjectSvc service
+// Server API for Project service
 
-type ProjectSvcServer interface {
+type ProjectServer interface {
 	Create(context.Context, *ProjectRequest) (*ProjectReply, error)
 	Delete(context.Context, *ProjectRequest) (*ProjectReply, error)
 	List(context.Context, *Empty) (*ProjectsReply, error)
@@ -194,123 +194,123 @@ type ProjectSvcServer interface {
 	Update(context.Context, *ProjectRequest) (*ProjectReply, error)
 }
 
-func RegisterProjectSvcServer(s *grpc.Server, srv ProjectSvcServer) {
-	s.RegisterService(&_ProjectSvc_serviceDesc, srv)
+func RegisterProjectServer(s *grpc.Server, srv ProjectServer) {
+	s.RegisterService(&_Project_serviceDesc, srv)
 }
 
-func _ProjectSvc_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Project_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ProjectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectSvcServer).Create(ctx, in)
+		return srv.(ProjectServer).Create(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.ProjectSvc/Create",
+		FullMethod: "/project.Project/Create",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectSvcServer).Create(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Create(ctx, req.(*ProjectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ProjectSvc_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Project_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ProjectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectSvcServer).Delete(ctx, in)
+		return srv.(ProjectServer).Delete(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.ProjectSvc/Delete",
+		FullMethod: "/project.Project/Delete",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectSvcServer).Delete(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Delete(ctx, req.(*ProjectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ProjectSvc_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Project_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(Empty)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectSvcServer).List(ctx, in)
+		return srv.(ProjectServer).List(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.ProjectSvc/List",
+		FullMethod: "/project.Project/List",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectSvcServer).List(ctx, req.(*Empty))
+		return srv.(ProjectServer).List(ctx, req.(*Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ProjectSvc_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Project_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ProjectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectSvcServer).Get(ctx, in)
+		return srv.(ProjectServer).Get(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.ProjectSvc/Get",
+		FullMethod: "/project.Project/Get",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectSvcServer).Get(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Get(ctx, req.(*ProjectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ProjectSvc_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Project_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ProjectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectSvcServer).Update(ctx, in)
+		return srv.(ProjectServer).Update(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.ProjectSvc/Update",
+		FullMethod: "/project.Project/Update",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectSvcServer).Update(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Update(ctx, req.(*ProjectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _ProjectSvc_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "project.ProjectSvc",
-	HandlerType: (*ProjectSvcServer)(nil),
+var _Project_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "project.Project",
+	HandlerType: (*ProjectServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
 			MethodName: "Create",
-			Handler:    _ProjectSvc_Create_Handler,
+			Handler:    _Project_Create_Handler,
 		},
 		{
 			MethodName: "Delete",
-			Handler:    _ProjectSvc_Delete_Handler,
+			Handler:    _Project_Delete_Handler,
 		},
 		{
 			MethodName: "List",
-			Handler:    _ProjectSvc_List_Handler,
+			Handler:    _Project_List_Handler,
 		},
 		{
 			MethodName: "Get",
-			Handler:    _ProjectSvc_Get_Handler,
+			Handler:    _Project_Get_Handler,
 		},
 		{
 			MethodName: "Update",
-			Handler:    _ProjectSvc_Update_Handler,
+			Handler:    _Project_Update_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -320,23 +320,23 @@ var _ProjectSvc_serviceDesc = grpc.ServiceDesc{
 func init() { proto.RegisterFile("project.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
-	// 283 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x9c, 0x92, 0x41, 0x4b, 0xc3, 0x40,
-	0x10, 0x85, 0x4d, 0xd3, 0x24, 0xcd, 0x68, 0x8b, 0x2c, 0x6a, 0x43, 0x45, 0x08, 0x39, 0x15, 0x91,
-	0x22, 0xf5, 0x20, 0x14, 0x3d, 0xa9, 0x88, 0x20, 0x22, 0x11, 0xcf, 0x25, 0x36, 0x73, 0xa8, 0x26,
-	0xd9, 0x75, 0x77, 0x55, 0xf2, 0x9b, 0xfc, 0x93, 0x92, 0xc9, 0x26, 0x07, 0xeb, 0xc5, 0xdc, 0x76,
-	0xde, 0x7b, 0x1f, 0xfb, 0x66, 0x59, 0x18, 0x0a, 0xc9, 0x5f, 0x71, 0xa5, 0x67, 0x42, 0x72, 0xcd,
-	0x99, 0x67, 0xc6, 0x48, 0x83, 0xf7, 0x58, 0x1f, 0xd9, 0x18, 0x3c, 0x89, 0x82, 0x2f, 0xd7, 0x69,
-	0x60, 0x85, 0xd6, 0xd4, 0x89, 0xdd, 0x6a, 0xbc, 0x4b, 0xd9, 0x11, 0x00, 0xff, 0x2a, 0x50, 0x2e,
-	0x8b, 0x24, 0xc7, 0xa0, 0x17, 0x5a, 0x53, 0x3f, 0xf6, 0x49, 0x79, 0x48, 0x72, 0x64, 0x87, 0xe0,
-	0x13, 0x47, 0xae, 0x4d, 0xee, 0xa0, 0x12, 0xc8, 0xdc, 0x03, 0x47, 0xf3, 0x37, 0x2c, 0x82, 0x3e,
-	0x19, 0xf5, 0x10, 0x79, 0xe0, 0xdc, 0xe4, 0x42, 0x97, 0xd1, 0x05, 0x8c, 0xcc, 0xf5, 0x31, 0xbe,
-	0x7f, 0xa0, 0xd2, 0xec, 0x18, 0x9a, 0x6e, 0xd4, 0x62, 0x7b, 0xbe, 0x3b, 0x6b, 0xaa, 0x37, 0xc9,
-	0xb6, 0xfc, 0x02, 0x76, 0x5a, 0x5a, 0x64, 0xe5, 0xbf, 0xd8, 0x4b, 0x18, 0x1a, 0x4d, 0xd5, 0xf0,
-	0x09, 0x0c, 0x8c, 0xa7, 0x02, 0x2b, 0xb4, 0xff, 0xa4, 0xdb, 0xc4, 0xfc, 0xbb, 0x07, 0x60, 0xd4,
-	0xa7, 0xcf, 0x15, 0x5b, 0x80, 0x7b, 0x25, 0x31, 0xd1, 0xc8, 0xc6, 0x1b, 0x50, 0xbd, 0xd8, 0x64,
-	0x7f, 0xd3, 0x10, 0x59, 0x19, 0x6d, 0x55, 0xec, 0x35, 0x66, 0xd8, 0x89, 0x3d, 0x85, 0xfe, 0xfd,
-	0x5a, 0x69, 0x36, 0x6a, 0x03, 0xf4, 0xae, 0x93, 0x83, 0xdf, 0x80, 0x6a, 0x88, 0x73, 0xb0, 0x6f,
-	0x51, 0x77, 0xab, 0xf9, 0x2c, 0xd2, 0x4e, 0x2b, 0xbe, 0xb8, 0xf4, 0xeb, 0xce, 0x7e, 0x02, 0x00,
-	0x00, 0xff, 0xff, 0x1e, 0xe3, 0xf8, 0xfa, 0x86, 0x02, 0x00, 0x00,
+	// 287 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x9c, 0x92, 0x4f, 0x4b, 0xc3, 0x40,
+	0x10, 0xc5, 0x4d, 0xd3, 0x24, 0xcd, 0x68, 0x7b, 0x58, 0xac, 0x0d, 0x15, 0x21, 0xe4, 0xd4, 0x53,
+	0xd5, 0x7a, 0x10, 0xbc, 0x88, 0x7f, 0x8a, 0x08, 0x22, 0xb2, 0xe0, 0xb9, 0x44, 0x33, 0x87, 0x6a,
+	0x92, 0x5d, 0x77, 0x57, 0x64, 0xbf, 0x91, 0x1f, 0x53, 0xb2, 0xd9, 0x04, 0xa9, 0x78, 0x68, 0x6e,
+	0x99, 0xf9, 0xcd, 0x7b, 0xbc, 0x17, 0x16, 0x86, 0x5c, 0xb0, 0x37, 0x7c, 0x55, 0x73, 0x2e, 0x98,
+	0x62, 0x24, 0xb0, 0x63, 0xa2, 0x61, 0xef, 0xa9, 0xfe, 0x5c, 0x96, 0x4a, 0x68, 0x32, 0x81, 0x40,
+	0x20, 0x67, 0xab, 0x75, 0x16, 0x39, 0xb1, 0x33, 0xf3, 0xa8, 0x5f, 0x8d, 0xf7, 0x19, 0x39, 0x02,
+	0x60, 0x5f, 0x25, 0x8a, 0x55, 0x99, 0x16, 0x18, 0xf5, 0x62, 0x67, 0x16, 0xd2, 0xd0, 0x6c, 0x1e,
+	0xd3, 0x02, 0xc9, 0x21, 0x84, 0x46, 0x67, 0xa8, 0x6b, 0xe8, 0xa0, 0x5a, 0x18, 0xb8, 0x0f, 0x9e,
+	0x62, 0xef, 0x58, 0x46, 0x7d, 0x03, 0xea, 0x21, 0x09, 0xc0, 0x5b, 0x16, 0x5c, 0xe9, 0xe4, 0x0a,
+	0x46, 0x36, 0x03, 0xc5, 0x8f, 0x4f, 0x94, 0x8a, 0x1c, 0x43, 0x13, 0xd0, 0xa4, 0xd8, 0x5d, 0x8c,
+	0xe7, 0x4d, 0xfe, 0xdf, 0x69, 0x69, 0x5b, 0xe3, 0xb2, 0xad, 0x41, 0x91, 0xe7, 0x7a, 0x7b, 0x83,
+	0x6b, 0x18, 0x5a, 0x20, 0x6b, 0x87, 0x53, 0x18, 0x58, 0x26, 0x23, 0x27, 0x76, 0xff, 0xb7, 0x68,
+	0xcf, 0x16, 0xdf, 0x3d, 0x08, 0x2c, 0x22, 0x17, 0xe0, 0xdf, 0x08, 0x4c, 0x15, 0x92, 0xc9, 0xa6,
+	0xcc, 0x96, 0x9c, 0x8e, 0xff, 0x02, 0x9e, 0xeb, 0x64, 0xa7, 0xd2, 0xde, 0x62, 0x8e, 0x9d, 0xb4,
+	0x27, 0xd0, 0x7f, 0x58, 0x4b, 0x45, 0x46, 0xed, 0x81, 0xf9, 0xc7, 0xd3, 0x83, 0x4d, 0x81, 0x6c,
+	0x14, 0xe7, 0xe0, 0xde, 0xa1, 0xea, 0x16, 0xf3, 0x99, 0x67, 0x9d, 0x2a, 0xbe, 0xf8, 0xe6, 0x19,
+	0x9e, 0xfd, 0x04, 0x00, 0x00, 0xff, 0xff, 0x55, 0xd8, 0xac, 0x46, 0x97, 0x02, 0x00, 0x00,
 }

--- a/api/rpc/project/project.pb.go
+++ b/api/rpc/project/project.pb.go
@@ -10,10 +10,16 @@ It is generated from these files:
 
 It has these top-level messages:
 	ProjectEntry
-	Empty
-	ProjectRequest
-	ProjectReply
-	ProjectsReply
+	CreateRequest
+	CreateReply
+	DeleteRequest
+	DeleteReply
+	ListRequest
+	ListReply
+	GetRequest
+	GetReply
+	UpdateRequest
+	UpdateReply
 */
 package project
 
@@ -38,7 +44,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type ProjectEntry struct {
-	RepoId    int32  `protobuf:"varint,1,opt,name=repo_id,json=repoId" json:"repo_id,omitempty"`
+	Id        int32  `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
 	OwnerName string `protobuf:"bytes,2,opt,name=owner_name,json=ownerName" json:"owner_name,omitempty"`
 	RepoName  string `protobuf:"bytes,3,opt,name=repo_name,json=repoName" json:"repo_name,omitempty"`
 	Token     string `protobuf:"bytes,4,opt,name=token" json:"token,omitempty"`
@@ -49,68 +55,156 @@ func (m *ProjectEntry) String() string            { return proto.CompactTextStri
 func (*ProjectEntry) ProtoMessage()               {}
 func (*ProjectEntry) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
-type Empty struct {
-}
-
-func (m *Empty) Reset()                    { *m = Empty{} }
-func (m *Empty) String() string            { return proto.CompactTextString(m) }
-func (*Empty) ProtoMessage()               {}
-func (*Empty) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-
-type ProjectRequest struct {
+type CreateRequest struct {
 	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
 }
 
-func (m *ProjectRequest) Reset()                    { *m = ProjectRequest{} }
-func (m *ProjectRequest) String() string            { return proto.CompactTextString(m) }
-func (*ProjectRequest) ProtoMessage()               {}
-func (*ProjectRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (m *CreateRequest) Reset()                    { *m = CreateRequest{} }
+func (m *CreateRequest) String() string            { return proto.CompactTextString(m) }
+func (*CreateRequest) ProtoMessage()               {}
+func (*CreateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
-func (m *ProjectRequest) GetProject() *ProjectEntry {
+func (m *CreateRequest) GetProject() *ProjectEntry {
 	if m != nil {
 		return m.Project
 	}
 	return nil
 }
 
-type ProjectReply struct {
+type CreateReply struct {
 	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
 }
 
-func (m *ProjectReply) Reset()                    { *m = ProjectReply{} }
-func (m *ProjectReply) String() string            { return proto.CompactTextString(m) }
-func (*ProjectReply) ProtoMessage()               {}
-func (*ProjectReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+func (m *CreateReply) Reset()                    { *m = CreateReply{} }
+func (m *CreateReply) String() string            { return proto.CompactTextString(m) }
+func (*CreateReply) ProtoMessage()               {}
+func (*CreateReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
-func (m *ProjectReply) GetProject() *ProjectEntry {
+func (m *CreateReply) GetProject() *ProjectEntry {
 	if m != nil {
 		return m.Project
 	}
 	return nil
 }
 
-type ProjectsReply struct {
+type DeleteRequest struct {
+	Id int32 `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
+}
+
+func (m *DeleteRequest) Reset()                    { *m = DeleteRequest{} }
+func (m *DeleteRequest) String() string            { return proto.CompactTextString(m) }
+func (*DeleteRequest) ProtoMessage()               {}
+func (*DeleteRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+type DeleteReply struct {
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *DeleteReply) Reset()                    { *m = DeleteReply{} }
+func (m *DeleteReply) String() string            { return proto.CompactTextString(m) }
+func (*DeleteReply) ProtoMessage()               {}
+func (*DeleteReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *DeleteReply) GetProject() *ProjectEntry {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
+type ListRequest struct {
+}
+
+func (m *ListRequest) Reset()                    { *m = ListRequest{} }
+func (m *ListRequest) String() string            { return proto.CompactTextString(m) }
+func (*ListRequest) ProtoMessage()               {}
+func (*ListRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+type ListReply struct {
 	Projects []*ProjectEntry `protobuf:"bytes,1,rep,name=projects" json:"projects,omitempty"`
 }
 
-func (m *ProjectsReply) Reset()                    { *m = ProjectsReply{} }
-func (m *ProjectsReply) String() string            { return proto.CompactTextString(m) }
-func (*ProjectsReply) ProtoMessage()               {}
-func (*ProjectsReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+func (m *ListReply) Reset()                    { *m = ListReply{} }
+func (m *ListReply) String() string            { return proto.CompactTextString(m) }
+func (*ListReply) ProtoMessage()               {}
+func (*ListReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
 
-func (m *ProjectsReply) GetProjects() []*ProjectEntry {
+func (m *ListReply) GetProjects() []*ProjectEntry {
 	if m != nil {
 		return m.Projects
 	}
 	return nil
 }
 
+type GetRequest struct {
+	Id int32 `protobuf:"varint,1,opt,name=id" json:"id,omitempty"`
+}
+
+func (m *GetRequest) Reset()                    { *m = GetRequest{} }
+func (m *GetRequest) String() string            { return proto.CompactTextString(m) }
+func (*GetRequest) ProtoMessage()               {}
+func (*GetRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
+
+type GetReply struct {
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *GetReply) Reset()                    { *m = GetReply{} }
+func (m *GetReply) String() string            { return proto.CompactTextString(m) }
+func (*GetReply) ProtoMessage()               {}
+func (*GetReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
+
+func (m *GetReply) GetProject() *ProjectEntry {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
+type UpdateRequest struct {
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *UpdateRequest) Reset()                    { *m = UpdateRequest{} }
+func (m *UpdateRequest) String() string            { return proto.CompactTextString(m) }
+func (*UpdateRequest) ProtoMessage()               {}
+func (*UpdateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
+
+func (m *UpdateRequest) GetProject() *ProjectEntry {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
+type UpdateReply struct {
+	Project *ProjectEntry `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *UpdateReply) Reset()                    { *m = UpdateReply{} }
+func (m *UpdateReply) String() string            { return proto.CompactTextString(m) }
+func (*UpdateReply) ProtoMessage()               {}
+func (*UpdateReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{10} }
+
+func (m *UpdateReply) GetProject() *ProjectEntry {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*ProjectEntry)(nil), "project.ProjectEntry")
-	proto.RegisterType((*Empty)(nil), "project.Empty")
-	proto.RegisterType((*ProjectRequest)(nil), "project.ProjectRequest")
-	proto.RegisterType((*ProjectReply)(nil), "project.ProjectReply")
-	proto.RegisterType((*ProjectsReply)(nil), "project.ProjectsReply")
+	proto.RegisterType((*CreateRequest)(nil), "project.CreateRequest")
+	proto.RegisterType((*CreateReply)(nil), "project.CreateReply")
+	proto.RegisterType((*DeleteRequest)(nil), "project.DeleteRequest")
+	proto.RegisterType((*DeleteReply)(nil), "project.DeleteReply")
+	proto.RegisterType((*ListRequest)(nil), "project.ListRequest")
+	proto.RegisterType((*ListReply)(nil), "project.ListReply")
+	proto.RegisterType((*GetRequest)(nil), "project.GetRequest")
+	proto.RegisterType((*GetReply)(nil), "project.GetReply")
+	proto.RegisterType((*UpdateRequest)(nil), "project.UpdateRequest")
+	proto.RegisterType((*UpdateReply)(nil), "project.UpdateReply")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -124,11 +218,11 @@ const _ = grpc.SupportPackageIsVersion3
 // Client API for Project service
 
 type ProjectClient interface {
-	Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
-	Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
-	List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error)
-	Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
-	Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
+	Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateReply, error)
+	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteReply, error)
+	List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListReply, error)
+	Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetReply, error)
+	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateReply, error)
 }
 
 type projectClient struct {
@@ -139,8 +233,8 @@ func NewProjectClient(cc *grpc.ClientConn) ProjectClient {
 	return &projectClient{cc}
 }
 
-func (c *projectClient) Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
-	out := new(ProjectReply)
+func (c *projectClient) Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateReply, error) {
+	out := new(CreateReply)
 	err := grpc.Invoke(ctx, "/project.Project/Create", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -148,8 +242,8 @@ func (c *projectClient) Create(ctx context.Context, in *ProjectRequest, opts ...
 	return out, nil
 }
 
-func (c *projectClient) Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
-	out := new(ProjectReply)
+func (c *projectClient) Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteReply, error) {
+	out := new(DeleteReply)
 	err := grpc.Invoke(ctx, "/project.Project/Delete", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -157,8 +251,8 @@ func (c *projectClient) Delete(ctx context.Context, in *ProjectRequest, opts ...
 	return out, nil
 }
 
-func (c *projectClient) List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error) {
-	out := new(ProjectsReply)
+func (c *projectClient) List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListReply, error) {
+	out := new(ListReply)
 	err := grpc.Invoke(ctx, "/project.Project/List", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -166,8 +260,8 @@ func (c *projectClient) List(ctx context.Context, in *Empty, opts ...grpc.CallOp
 	return out, nil
 }
 
-func (c *projectClient) Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
-	out := new(ProjectReply)
+func (c *projectClient) Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetReply, error) {
+	out := new(GetReply)
 	err := grpc.Invoke(ctx, "/project.Project/Get", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -175,8 +269,8 @@ func (c *projectClient) Get(ctx context.Context, in *ProjectRequest, opts ...grp
 	return out, nil
 }
 
-func (c *projectClient) Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
-	out := new(ProjectReply)
+func (c *projectClient) Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateReply, error) {
+	out := new(UpdateReply)
 	err := grpc.Invoke(ctx, "/project.Project/Update", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -187,11 +281,11 @@ func (c *projectClient) Update(ctx context.Context, in *ProjectRequest, opts ...
 // Server API for Project service
 
 type ProjectServer interface {
-	Create(context.Context, *ProjectRequest) (*ProjectReply, error)
-	Delete(context.Context, *ProjectRequest) (*ProjectReply, error)
-	List(context.Context, *Empty) (*ProjectsReply, error)
-	Get(context.Context, *ProjectRequest) (*ProjectReply, error)
-	Update(context.Context, *ProjectRequest) (*ProjectReply, error)
+	Create(context.Context, *CreateRequest) (*CreateReply, error)
+	Delete(context.Context, *DeleteRequest) (*DeleteReply, error)
+	List(context.Context, *ListRequest) (*ListReply, error)
+	Get(context.Context, *GetRequest) (*GetReply, error)
+	Update(context.Context, *UpdateRequest) (*UpdateReply, error)
 }
 
 func RegisterProjectServer(s *grpc.Server, srv ProjectServer) {
@@ -199,7 +293,7 @@ func RegisterProjectServer(s *grpc.Server, srv ProjectServer) {
 }
 
 func _Project_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ProjectRequest)
+	in := new(CreateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -211,13 +305,13 @@ func _Project_Create_Handler(srv interface{}, ctx context.Context, dec func(inte
 		FullMethod: "/project.Project/Create",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).Create(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Create(ctx, req.(*CreateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Project_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ProjectRequest)
+	in := new(DeleteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -229,13 +323,13 @@ func _Project_Delete_Handler(srv interface{}, ctx context.Context, dec func(inte
 		FullMethod: "/project.Project/Delete",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).Delete(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Delete(ctx, req.(*DeleteRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Project_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Empty)
+	in := new(ListRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -247,13 +341,13 @@ func _Project_List_Handler(srv interface{}, ctx context.Context, dec func(interf
 		FullMethod: "/project.Project/List",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).List(ctx, req.(*Empty))
+		return srv.(ProjectServer).List(ctx, req.(*ListRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Project_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ProjectRequest)
+	in := new(GetRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -265,13 +359,13 @@ func _Project_Get_Handler(srv interface{}, ctx context.Context, dec func(interfa
 		FullMethod: "/project.Project/Get",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).Get(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Get(ctx, req.(*GetRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _Project_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ProjectRequest)
+	in := new(UpdateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -283,7 +377,7 @@ func _Project_Update_Handler(srv interface{}, ctx context.Context, dec func(inte
 		FullMethod: "/project.Project/Update",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).Update(ctx, req.(*ProjectRequest))
+		return srv.(ProjectServer).Update(ctx, req.(*UpdateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -320,23 +414,27 @@ var _Project_serviceDesc = grpc.ServiceDesc{
 func init() { proto.RegisterFile("project.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
-	// 287 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x9c, 0x92, 0x4f, 0x4b, 0xc3, 0x40,
-	0x10, 0xc5, 0x4d, 0xd3, 0x24, 0xcd, 0x68, 0x7b, 0x58, 0xac, 0x0d, 0x15, 0x21, 0xe4, 0xd4, 0x53,
-	0xd5, 0x7a, 0x10, 0xbc, 0x88, 0x7f, 0x8a, 0x08, 0x22, 0xb2, 0xe0, 0xb9, 0x44, 0x33, 0x87, 0x6a,
-	0x92, 0x5d, 0x77, 0x57, 0x64, 0xbf, 0x91, 0x1f, 0x53, 0xb2, 0xd9, 0x04, 0xa9, 0x78, 0x68, 0x6e,
-	0x99, 0xf9, 0xcd, 0x7b, 0xbc, 0x17, 0x16, 0x86, 0x5c, 0xb0, 0x37, 0x7c, 0x55, 0x73, 0x2e, 0x98,
-	0x62, 0x24, 0xb0, 0x63, 0xa2, 0x61, 0xef, 0xa9, 0xfe, 0x5c, 0x96, 0x4a, 0x68, 0x32, 0x81, 0x40,
-	0x20, 0x67, 0xab, 0x75, 0x16, 0x39, 0xb1, 0x33, 0xf3, 0xa8, 0x5f, 0x8d, 0xf7, 0x19, 0x39, 0x02,
-	0x60, 0x5f, 0x25, 0x8a, 0x55, 0x99, 0x16, 0x18, 0xf5, 0x62, 0x67, 0x16, 0xd2, 0xd0, 0x6c, 0x1e,
-	0xd3, 0x02, 0xc9, 0x21, 0x84, 0x46, 0x67, 0xa8, 0x6b, 0xe8, 0xa0, 0x5a, 0x18, 0xb8, 0x0f, 0x9e,
-	0x62, 0xef, 0x58, 0x46, 0x7d, 0x03, 0xea, 0x21, 0x09, 0xc0, 0x5b, 0x16, 0x5c, 0xe9, 0xe4, 0x0a,
-	0x46, 0x36, 0x03, 0xc5, 0x8f, 0x4f, 0x94, 0x8a, 0x1c, 0x43, 0x13, 0xd0, 0xa4, 0xd8, 0x5d, 0x8c,
-	0xe7, 0x4d, 0xfe, 0xdf, 0x69, 0x69, 0x5b, 0xe3, 0xb2, 0xad, 0x41, 0x91, 0xe7, 0x7a, 0x7b, 0x83,
-	0x6b, 0x18, 0x5a, 0x20, 0x6b, 0x87, 0x53, 0x18, 0x58, 0x26, 0x23, 0x27, 0x76, 0xff, 0xb7, 0x68,
-	0xcf, 0x16, 0xdf, 0x3d, 0x08, 0x2c, 0x22, 0x17, 0xe0, 0xdf, 0x08, 0x4c, 0x15, 0x92, 0xc9, 0xa6,
-	0xcc, 0x96, 0x9c, 0x8e, 0xff, 0x02, 0x9e, 0xeb, 0x64, 0xa7, 0xd2, 0xde, 0x62, 0x8e, 0x9d, 0xb4,
-	0x27, 0xd0, 0x7f, 0x58, 0x4b, 0x45, 0x46, 0xed, 0x81, 0xf9, 0xc7, 0xd3, 0x83, 0x4d, 0x81, 0x6c,
-	0x14, 0xe7, 0xe0, 0xde, 0xa1, 0xea, 0x16, 0xf3, 0x99, 0x67, 0x9d, 0x2a, 0xbe, 0xf8, 0xe6, 0x19,
-	0x9e, 0xfd, 0x04, 0x00, 0x00, 0xff, 0xff, 0x55, 0xd8, 0xac, 0x46, 0x97, 0x02, 0x00, 0x00,
+	// 339 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xa4, 0x93, 0x4b, 0x4b, 0xc3, 0x40,
+	0x10, 0xc7, 0x49, 0xfa, 0xcc, 0xd4, 0x08, 0xae, 0x55, 0x42, 0x55, 0x2c, 0x39, 0xf5, 0x62, 0xd5,
+	0x0a, 0xbd, 0x08, 0xa5, 0xa0, 0xd2, 0x8b, 0x88, 0x04, 0x3c, 0x4b, 0x34, 0x73, 0x88, 0xb6, 0xd9,
+	0x75, 0xb3, 0x22, 0xfd, 0x1a, 0x7e, 0x62, 0xd9, 0xdd, 0x3c, 0x36, 0x95, 0x1e, 0x8c, 0xb7, 0xcc,
+	0xfc, 0xe7, 0xf1, 0xcb, 0xfc, 0x13, 0x70, 0x19, 0xa7, 0x6f, 0xf8, 0x2a, 0xc6, 0x8c, 0x53, 0x41,
+	0x49, 0x27, 0x0b, 0x7d, 0x06, 0x3b, 0x8f, 0xfa, 0xf1, 0x2e, 0x11, 0x7c, 0x4d, 0x76, 0xc1, 0x8e,
+	0x23, 0xcf, 0x1a, 0x5a, 0xa3, 0x56, 0x60, 0xc7, 0x11, 0x39, 0x01, 0xa0, 0x5f, 0x09, 0xf2, 0xe7,
+	0x24, 0x5c, 0xa1, 0x67, 0x0f, 0xad, 0x91, 0x13, 0x38, 0x2a, 0xf3, 0x10, 0xae, 0x90, 0x1c, 0x81,
+	0xc3, 0x91, 0x51, 0xad, 0x36, 0x94, 0xda, 0x95, 0x09, 0x25, 0xf6, 0xa1, 0x25, 0xe8, 0x3b, 0x26,
+	0x5e, 0x53, 0x09, 0x3a, 0xf0, 0xe7, 0xe0, 0xde, 0x70, 0x0c, 0x05, 0x06, 0xf8, 0xf1, 0x89, 0xa9,
+	0x20, 0xe7, 0x90, 0xd3, 0xa8, 0xbd, 0xbd, 0xc9, 0xc1, 0x38, 0x87, 0x35, 0xd1, 0x82, 0x82, 0x79,
+	0x06, 0xbd, 0x7c, 0x02, 0x5b, 0xae, 0xff, 0xde, 0x7f, 0x0a, 0xee, 0x2d, 0x2e, 0xb1, 0x24, 0xd8,
+	0x78, 0x69, 0xb9, 0x20, 0x2f, 0xa8, 0xb5, 0xc0, 0x85, 0xde, 0x7d, 0x9c, 0x8a, 0x6c, 0xbc, 0x3f,
+	0x03, 0x47, 0x87, 0x72, 0xd8, 0x25, 0x74, 0xb3, 0xb2, 0xd4, 0xb3, 0x86, 0x8d, 0xed, 0xd3, 0x8a,
+	0x32, 0xff, 0x18, 0x60, 0x81, 0x62, 0x1b, 0xec, 0x35, 0x74, 0x95, 0x5a, 0x8b, 0x74, 0x0e, 0xee,
+	0x13, 0x8b, 0xfe, 0x69, 0x46, 0x3e, 0xa1, 0x0e, 0xc1, 0xe4, 0xdb, 0x86, 0x4e, 0xa6, 0x90, 0x29,
+	0xb4, 0xb5, 0xb1, 0xe4, 0xb0, 0xe8, 0xaa, 0x7c, 0x2b, 0x83, 0xfe, 0xaf, 0xbc, 0x5c, 0x3a, 0x85,
+	0xb6, 0xf6, 0xcb, 0xe8, 0xab, 0x38, 0x6c, 0xf4, 0x99, 0xc6, 0x5e, 0x40, 0x53, 0x1a, 0x43, 0x4a,
+	0xd5, 0xb0, 0x6d, 0x40, 0x36, 0xb2, 0xb2, 0xe3, 0x0c, 0x1a, 0x0b, 0x14, 0x64, 0xbf, 0x90, 0x4a,
+	0x63, 0x06, 0x7b, 0xd5, 0x64, 0x06, 0xa6, 0x8f, 0x63, 0x80, 0x55, 0xee, 0x6d, 0x80, 0x19, 0x57,
+	0x7c, 0x69, 0xab, 0xbf, 0xf4, 0xea, 0x27, 0x00, 0x00, 0xff, 0xff, 0x9a, 0x52, 0x04, 0x2d, 0xb6,
+	0x03, 0x00, 0x00,
 }

--- a/api/rpc/project/project.pb.go
+++ b/api/rpc/project/project.pb.go
@@ -9,8 +9,11 @@ It is generated from these files:
 	project.proto
 
 It has these top-level messages:
-	CreateRequest
-	CreateReply
+	Project
+	Empty
+	ProjectRequest
+	ProjectReply
+	ProjectsReply
 */
 package project
 
@@ -34,28 +37,80 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type CreateRequest struct {
-	Id   string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
-	Name string `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+type Project struct {
+	RepoId    int32  `protobuf:"varint,1,opt,name=repo_id,json=repoId" json:"repo_id,omitempty"`
+	OwnerName string `protobuf:"bytes,2,opt,name=owner_name,json=ownerName" json:"owner_name,omitempty"`
+	RepoName  string `protobuf:"bytes,3,opt,name=repo_name,json=repoName" json:"repo_name,omitempty"`
+	Token     string `protobuf:"bytes,4,opt,name=token" json:"token,omitempty"`
 }
 
-func (m *CreateRequest) Reset()                    { *m = CreateRequest{} }
-func (m *CreateRequest) String() string            { return proto.CompactTextString(m) }
-func (*CreateRequest) ProtoMessage()               {}
-func (*CreateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *Project) Reset()                    { *m = Project{} }
+func (m *Project) String() string            { return proto.CompactTextString(m) }
+func (*Project) ProtoMessage()               {}
+func (*Project) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
-type CreateReply struct {
-	Message string `protobuf:"bytes,1,opt,name=message" json:"message,omitempty"`
+type Empty struct {
 }
 
-func (m *CreateReply) Reset()                    { *m = CreateReply{} }
-func (m *CreateReply) String() string            { return proto.CompactTextString(m) }
-func (*CreateReply) ProtoMessage()               {}
-func (*CreateReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *Empty) Reset()                    { *m = Empty{} }
+func (m *Empty) String() string            { return proto.CompactTextString(m) }
+func (*Empty) ProtoMessage()               {}
+func (*Empty) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+
+type ProjectRequest struct {
+	Project *Project `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *ProjectRequest) Reset()                    { *m = ProjectRequest{} }
+func (m *ProjectRequest) String() string            { return proto.CompactTextString(m) }
+func (*ProjectRequest) ProtoMessage()               {}
+func (*ProjectRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+
+func (m *ProjectRequest) GetProject() *Project {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
+type ProjectReply struct {
+	Project *Project `protobuf:"bytes,1,opt,name=project" json:"project,omitempty"`
+}
+
+func (m *ProjectReply) Reset()                    { *m = ProjectReply{} }
+func (m *ProjectReply) String() string            { return proto.CompactTextString(m) }
+func (*ProjectReply) ProtoMessage()               {}
+func (*ProjectReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *ProjectReply) GetProject() *Project {
+	if m != nil {
+		return m.Project
+	}
+	return nil
+}
+
+type ProjectsReply struct {
+	Projects []*Project `protobuf:"bytes,1,rep,name=projects" json:"projects,omitempty"`
+}
+
+func (m *ProjectsReply) Reset()                    { *m = ProjectsReply{} }
+func (m *ProjectsReply) String() string            { return proto.CompactTextString(m) }
+func (*ProjectsReply) ProtoMessage()               {}
+func (*ProjectsReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *ProjectsReply) GetProjects() []*Project {
+	if m != nil {
+		return m.Projects
+	}
+	return nil
+}
 
 func init() {
-	proto.RegisterType((*CreateRequest)(nil), "project.CreateRequest")
-	proto.RegisterType((*CreateReply)(nil), "project.CreateReply")
+	proto.RegisterType((*Project)(nil), "project.Project")
+	proto.RegisterType((*Empty)(nil), "project.Empty")
+	proto.RegisterType((*ProjectRequest)(nil), "project.ProjectRequest")
+	proto.RegisterType((*ProjectReply)(nil), "project.ProjectReply")
+	proto.RegisterType((*ProjectsReply)(nil), "project.ProjectsReply")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -66,64 +121,196 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion3
 
-// Client API for Project service
+// Client API for ProjectSvc service
 
-type ProjectClient interface {
-	Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateReply, error)
+type ProjectSvcClient interface {
+	Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
+	Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
+	List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error)
+	Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
+	Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error)
 }
 
-type projectClient struct {
+type projectSvcClient struct {
 	cc *grpc.ClientConn
 }
 
-func NewProjectClient(cc *grpc.ClientConn) ProjectClient {
-	return &projectClient{cc}
+func NewProjectSvcClient(cc *grpc.ClientConn) ProjectSvcClient {
+	return &projectSvcClient{cc}
 }
 
-func (c *projectClient) Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateReply, error) {
-	out := new(CreateReply)
-	err := grpc.Invoke(ctx, "/project.Project/Create", in, out, c.cc, opts...)
+func (c *projectSvcClient) Create(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+	out := new(ProjectReply)
+	err := grpc.Invoke(ctx, "/project.ProjectSvc/Create", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for Project service
-
-type ProjectServer interface {
-	Create(context.Context, *CreateRequest) (*CreateReply, error)
+func (c *projectSvcClient) Delete(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+	out := new(ProjectReply)
+	err := grpc.Invoke(ctx, "/project.ProjectSvc/Delete", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
-func RegisterProjectServer(s *grpc.Server, srv ProjectServer) {
-	s.RegisterService(&_Project_serviceDesc, srv)
+func (c *projectSvcClient) List(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ProjectsReply, error) {
+	out := new(ProjectsReply)
+	err := grpc.Invoke(ctx, "/project.ProjectSvc/List", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
-func _Project_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateRequest)
+func (c *projectSvcClient) Get(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+	out := new(ProjectReply)
+	err := grpc.Invoke(ctx, "/project.ProjectSvc/Get", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *projectSvcClient) Update(ctx context.Context, in *ProjectRequest, opts ...grpc.CallOption) (*ProjectReply, error) {
+	out := new(ProjectReply)
+	err := grpc.Invoke(ctx, "/project.ProjectSvc/Update", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Server API for ProjectSvc service
+
+type ProjectSvcServer interface {
+	Create(context.Context, *ProjectRequest) (*ProjectReply, error)
+	Delete(context.Context, *ProjectRequest) (*ProjectReply, error)
+	List(context.Context, *Empty) (*ProjectsReply, error)
+	Get(context.Context, *ProjectRequest) (*ProjectReply, error)
+	Update(context.Context, *ProjectRequest) (*ProjectReply, error)
+}
+
+func RegisterProjectSvcServer(s *grpc.Server, srv ProjectSvcServer) {
+	s.RegisterService(&_ProjectSvc_serviceDesc, srv)
+}
+
+func _ProjectSvc_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProjectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProjectServer).Create(ctx, in)
+		return srv.(ProjectSvcServer).Create(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/project.Project/Create",
+		FullMethod: "/project.ProjectSvc/Create",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProjectServer).Create(ctx, req.(*CreateRequest))
+		return srv.(ProjectSvcServer).Create(ctx, req.(*ProjectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _Project_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "project.Project",
-	HandlerType: (*ProjectServer)(nil),
+func _ProjectSvc_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProjectRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectSvcServer).Delete(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/project.ProjectSvc/Delete",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectSvcServer).Delete(ctx, req.(*ProjectRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ProjectSvc_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectSvcServer).List(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/project.ProjectSvc/List",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectSvcServer).List(ctx, req.(*Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ProjectSvc_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProjectRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectSvcServer).Get(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/project.ProjectSvc/Get",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectSvcServer).Get(ctx, req.(*ProjectRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ProjectSvc_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProjectRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectSvcServer).Update(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/project.ProjectSvc/Update",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectSvcServer).Update(ctx, req.(*ProjectRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _ProjectSvc_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "project.ProjectSvc",
+	HandlerType: (*ProjectSvcServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
 			MethodName: "Create",
-			Handler:    _Project_Create_Handler,
+			Handler:    _ProjectSvc_Create_Handler,
+		},
+		{
+			MethodName: "Delete",
+			Handler:    _ProjectSvc_Delete_Handler,
+		},
+		{
+			MethodName: "List",
+			Handler:    _ProjectSvc_List_Handler,
+		},
+		{
+			MethodName: "Get",
+			Handler:    _ProjectSvc_Get_Handler,
+		},
+		{
+			MethodName: "Update",
+			Handler:    _ProjectSvc_Update_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -133,15 +320,23 @@ var _Project_serviceDesc = grpc.ServiceDesc{
 func init() { proto.RegisterFile("project.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
-	// 148 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xe2, 0x2d, 0x28, 0xca, 0xcf,
-	0x4a, 0x4d, 0x2e, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x87, 0x72, 0x95, 0x8c, 0xb9,
-	0x78, 0x9d, 0x8b, 0x52, 0x13, 0x4b, 0x52, 0x83, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0xf8,
-	0xb8, 0x98, 0x32, 0x53, 0x24, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x98, 0x32, 0x53, 0x84, 0x84,
-	0xb8, 0x58, 0xf2, 0x12, 0x73, 0x53, 0x25, 0x98, 0xc0, 0x22, 0x60, 0xb6, 0x92, 0x3a, 0x17, 0x37,
-	0x4c, 0x53, 0x41, 0x4e, 0xa5, 0x90, 0x04, 0x17, 0x7b, 0x6e, 0x6a, 0x71, 0x71, 0x62, 0x7a, 0x2a,
-	0x54, 0x1f, 0x8c, 0x6b, 0xe4, 0xcc, 0xc5, 0x1e, 0x00, 0xb1, 0x48, 0xc8, 0x82, 0x8b, 0x0d, 0xa2,
-	0x47, 0x48, 0x4c, 0x0f, 0xe6, 0x16, 0x14, 0x9b, 0xa5, 0x44, 0x30, 0xc4, 0x0b, 0x72, 0x2a, 0x95,
-	0x18, 0x92, 0xd8, 0xc0, 0x4e, 0x36, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x1c, 0x74, 0x60, 0x63,
-	0xc3, 0x00, 0x00, 0x00,
+	// 283 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x9c, 0x92, 0x41, 0x4b, 0xc3, 0x40,
+	0x10, 0x85, 0x4d, 0xd3, 0x24, 0xcd, 0x68, 0x8b, 0x2c, 0x6a, 0x43, 0x45, 0x08, 0x39, 0x15, 0x91,
+	0x22, 0xf5, 0x20, 0x14, 0x3d, 0xa9, 0x88, 0x20, 0x22, 0x11, 0xcf, 0x25, 0x36, 0x73, 0xa8, 0x26,
+	0xd9, 0x75, 0x77, 0x55, 0xf2, 0x9b, 0xfc, 0x93, 0x92, 0xc9, 0x26, 0x07, 0xeb, 0xc5, 0xdc, 0x76,
+	0xde, 0x7b, 0x1f, 0xfb, 0x66, 0x59, 0x18, 0x0a, 0xc9, 0x5f, 0x71, 0xa5, 0x67, 0x42, 0x72, 0xcd,
+	0x99, 0x67, 0xc6, 0x48, 0x83, 0xf7, 0x58, 0x1f, 0xd9, 0x18, 0x3c, 0x89, 0x82, 0x2f, 0xd7, 0x69,
+	0x60, 0x85, 0xd6, 0xd4, 0x89, 0xdd, 0x6a, 0xbc, 0x4b, 0xd9, 0x11, 0x00, 0xff, 0x2a, 0x50, 0x2e,
+	0x8b, 0x24, 0xc7, 0xa0, 0x17, 0x5a, 0x53, 0x3f, 0xf6, 0x49, 0x79, 0x48, 0x72, 0x64, 0x87, 0xe0,
+	0x13, 0x47, 0xae, 0x4d, 0xee, 0xa0, 0x12, 0xc8, 0xdc, 0x03, 0x47, 0xf3, 0x37, 0x2c, 0x82, 0x3e,
+	0x19, 0xf5, 0x10, 0x79, 0xe0, 0xdc, 0xe4, 0x42, 0x97, 0xd1, 0x05, 0x8c, 0xcc, 0xf5, 0x31, 0xbe,
+	0x7f, 0xa0, 0xd2, 0xec, 0x18, 0x9a, 0x6e, 0xd4, 0x62, 0x7b, 0xbe, 0x3b, 0x6b, 0xaa, 0x37, 0xc9,
+	0xb6, 0xfc, 0x02, 0x76, 0x5a, 0x5a, 0x64, 0xe5, 0xbf, 0xd8, 0x4b, 0x18, 0x1a, 0x4d, 0xd5, 0xf0,
+	0x09, 0x0c, 0x8c, 0xa7, 0x02, 0x2b, 0xb4, 0xff, 0xa4, 0xdb, 0xc4, 0xfc, 0xbb, 0x07, 0x60, 0xd4,
+	0xa7, 0xcf, 0x15, 0x5b, 0x80, 0x7b, 0x25, 0x31, 0xd1, 0xc8, 0xc6, 0x1b, 0x50, 0xbd, 0xd8, 0x64,
+	0x7f, 0xd3, 0x10, 0x59, 0x19, 0x6d, 0x55, 0xec, 0x35, 0x66, 0xd8, 0x89, 0x3d, 0x85, 0xfe, 0xfd,
+	0x5a, 0x69, 0x36, 0x6a, 0x03, 0xf4, 0xae, 0x93, 0x83, 0xdf, 0x80, 0x6a, 0x88, 0x73, 0xb0, 0x6f,
+	0x51, 0x77, 0xab, 0xf9, 0x2c, 0xd2, 0x4e, 0x2b, 0xbe, 0xb8, 0xf4, 0xeb, 0xce, 0x7e, 0x02, 0x00,
+	0x00, 0xff, 0xff, 0x1e, 0xe3, 0xf8, 0xfa, 0x86, 0x02, 0x00, 0x00,
 }

--- a/api/rpc/project/project.proto
+++ b/api/rpc/project/project.proto
@@ -2,15 +2,29 @@ syntax = "proto3";
 
 package project;
 
-service Project {
-  rpc Create (CreateRequest) returns (CreateReply) {}
+service ProjectSvc {
+  rpc Create (ProjectRequest) returns (ProjectReply) {}
+  rpc Delete (ProjectRequest) returns (ProjectReply) {}
+  rpc List   (Empty) returns (ProjectsReply) {}
+  rpc Get   (ProjectRequest) returns  (ProjectReply) {}
+  rpc Update (ProjectRequest) returns (ProjectReply) {}
 }
 
-message CreateRequest {
-  string id = 1;
-  string name = 2;
+message Project {
+  int32  repo_id = 1;
+  string owner_name = 2;
+  string repo_name = 3;
+  string token = 4;
 }
 
-message CreateReply {
-  string message = 1;
+message Empty{}
+
+message ProjectRequest {
+  Project project=1;
+}
+message ProjectReply {
+    Project project=1;
+}
+message ProjectsReply {
+    repeated Project projects=1;
 }

--- a/api/rpc/project/project.proto
+++ b/api/rpc/project/project.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package project;
 
-service ProjectSvc {
+service Project {
   rpc Create (ProjectRequest) returns (ProjectReply) {}
   rpc Delete (ProjectRequest) returns (ProjectReply) {}
   rpc List   (Empty) returns (ProjectsReply) {}
@@ -10,7 +10,7 @@ service ProjectSvc {
   rpc Update (ProjectRequest) returns (ProjectReply) {}
 }
 
-message Project {
+message ProjectEntry {
   int32  repo_id = 1;
   string owner_name = 2;
   string repo_name = 3;
@@ -20,11 +20,11 @@ message Project {
 message Empty{}
 
 message ProjectRequest {
-  Project project=1;
+  ProjectEntry project=1;
 }
 message ProjectReply {
-    Project project=1;
+    ProjectEntry project=1;
 }
 message ProjectsReply {
-    repeated Project projects=1;
+    repeated ProjectEntry projects=1;
 }

--- a/api/rpc/project/project.proto
+++ b/api/rpc/project/project.proto
@@ -3,28 +3,55 @@ syntax = "proto3";
 package project;
 
 service Project {
-  rpc Create (ProjectRequest) returns (ProjectReply) {}
-  rpc Delete (ProjectRequest) returns (ProjectReply) {}
-  rpc List   (Empty) returns (ProjectsReply) {}
-  rpc Get   (ProjectRequest) returns  (ProjectReply) {}
-  rpc Update (ProjectRequest) returns (ProjectReply) {}
+  rpc Create (CreateRequest) returns (CreateReply);
+  rpc Delete (DeleteRequest) returns (DeleteReply);
+  rpc List (ListRequest) returns (ListReply);
+  rpc Get (GetRequest) returns (GetReply);
+  rpc Update (UpdateRequest) returns (UpdateReply);
 }
 
 message ProjectEntry {
-  int32  repo_id = 1;
+  int32 id = 1;
   string owner_name = 2;
   string repo_name = 3;
   string token = 4;
 }
 
-message Empty{}
+message CreateRequest {
+  ProjectEntry project = 1;
+}
 
-message ProjectRequest {
-  ProjectEntry project=1;
+message CreateReply {
+  ProjectEntry project = 1;
 }
-message ProjectReply {
-    ProjectEntry project=1;
+
+message DeleteRequest {
+  int32 id = 1;
 }
-message ProjectsReply {
-    repeated ProjectEntry projects=1;
+
+message DeleteReply {
+  ProjectEntry project = 1;
+}
+
+message ListRequest {
+}
+
+message ListReply {
+  repeated ProjectEntry projects = 1;
+}
+
+message GetRequest {
+  int32 id = 1;
+}
+
+message GetReply {
+  ProjectEntry project = 1;
+}
+
+message UpdateRequest {
+  ProjectEntry project = 1;
+}
+
+message UpdateReply {
+  ProjectEntry project = 1;
 }

--- a/api/rpc/project/project_test.go
+++ b/api/rpc/project/project_test.go
@@ -19,9 +19,9 @@ const (
 var (
 	etcdEndpoints    = []string{etcdDefaultEndpoint}
 	proj             *Proj
-	sampleProject    = &ProjectRequest{&Project{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
-	updSampleProject = &ProjectRequest{&Project{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo2", Token: "FakeToken"}}
-	sampleProject2   = &ProjectRequest{&Project{RepoId: 12346, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
+	sampleProject    = &ProjectRequest{&ProjectEntry{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
+	updSampleProject = &ProjectRequest{&ProjectEntry{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo2", Token: "FakeToken"}}
+	sampleProject2   = &ProjectRequest{&ProjectEntry{RepoId: 12346, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
 )
 
 func TestMain(m *testing.M) {

--- a/api/rpc/project/project_test.go
+++ b/api/rpc/project/project_test.go
@@ -1,30 +1,139 @@
 package project
 
-// import (
-// 	"github.com/satori/go.uuid"
-// 	"golang.org/x/net/context"
-// 	"google.golang.org/grpc"
-// 	"testing"
-// )
-//
-// const (
-// 	address = "localhost:50101"
-// )
-//
-// func TestShouldSucceedWhenProvidingAValidCreateRequest(t *testing.T) {
-// 	// Set up a connection to the server.
-// 	conn, err := grpc.Dial(address, grpc.WithInsecure())
-// 	if err != nil {
-// 		t.Fatalf("did not connect: %v", err)
-// 	}
-//
-// 	// Contact the server and print out its response.
-// 	c := project.NewProjectClient(conn)
-// 	r, err := c.Create(context.Background(), &project.CreateRequest{Name: "test-project-" + uuid.NewV4().String()})
-// 	if err != nil {
-// 		t.Fatalf("could not greet: %v", err)
-// 	}
-// 	t.Logf("Greeting: %s", r.Message)
-//
-// 	conn.Close()
-// }
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/appcelerator/amp/data/storage/etcd"
+	"github.com/golang/protobuf/proto"
+)
+
+const (
+	etcdDefaultEndpoint = "http://localhost:2379"
+)
+
+var (
+	etcdEndpoints    = []string{etcdDefaultEndpoint}
+	proj             *Proj
+	sampleProject    = &ProjectRequest{&Project{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
+	updSampleProject = &ProjectRequest{&Project{RepoId: 12345, OwnerName: "amp", RepoName: "amp-repo2", Token: "FakeToken"}}
+	sampleProject2   = &ProjectRequest{&Project{RepoId: 12346, OwnerName: "amp", RepoName: "amp-repo", Token: "FakeToken"}}
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(os.Stdout)
+	log.SetFlags(log.Lshortfile)
+	log.SetPrefix("test: ")
+	proj = createProjectServer()
+	os.Exit(m.Run())
+}
+
+func TestCreate(t *testing.T) {
+	proj.Delete(context.Background(), sampleProject)
+	resp, err := proj.Create(context.Background(), sampleProject)
+	if err != nil {
+		t.Error(err)
+	}
+	resp, err = proj.Get(context.Background(), sampleProject)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(resp.Project, sampleProject.Project) {
+		t.Errorf("expected %v, got %v", sampleProject.Project, resp.Project)
+	}
+}
+
+func TestCreateAlreadyExists(t *testing.T) {
+	// Guarantee no data exists
+	proj.Delete(context.Background(), sampleProject)
+	// Create new Entry
+	proj.Create(context.Background(), sampleProject)
+	// Attempt to create a duplicate
+	_, err := proj.Create(context.Background(), sampleProject)
+	// Should result in a duplicate entry
+	if !strings.Contains(err.Error(), "key already exists") {
+		t.Error("Duplicate Key Error was not detected")
+	}
+}
+
+func TestGet(t *testing.T) {
+	// Guarantee no data exists
+	proj.Delete(context.Background(), sampleProject)
+	// Create new Entry
+	proj.Create(context.Background(), sampleProject)
+	// Fetch The Entry
+
+	resp, err := proj.Get(context.Background(), sampleProject)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(resp.Project, sampleProject.Project) {
+		t.Errorf("expected %v, got %v", sampleProject.Project, resp.Project)
+	}
+}
+func TestUpdate(t *testing.T) {
+	// Guarantee no data exists
+	proj.Delete(context.Background(), sampleProject)
+	// Create new Entry
+	proj.Create(context.Background(), sampleProject)
+	// Update The Entry
+	resp, err := proj.Update(context.Background(), updSampleProject)
+	if err != nil {
+		t.Error(err)
+	}
+	resp, _ = proj.Get(context.Background(), sampleProject)
+	if !proto.Equal(resp.Project, updSampleProject.Project) {
+		t.Errorf("expected %v, got %v", updSampleProject.Project, resp.Project)
+	}
+}
+
+func TestList(t *testing.T) {
+	// Guarantee no data exists
+	proj.Delete(context.Background(), sampleProject)
+	proj.Delete(context.Background(), sampleProject2)
+	// Create new Entries
+	proj.Create(context.Background(), sampleProject)
+	proj.Create(context.Background(), sampleProject2)
+	// Fetch The Entry
+	resp, err := proj.List(context.Background(), &Empty{})
+	if err != nil {
+		t.Error(err)
+	} else if len(resp.Projects) != 2 {
+		t.Errorf("Expected length of 2, got %v\n", len(resp.Projects))
+	}
+
+}
+
+func TestDelete(t *testing.T) {
+	// Guarantee no data exists
+	proj.Delete(context.Background(), sampleProject)
+	// Create new Entry
+	proj.Create(context.Background(), sampleProject)
+	// Delete The Entry
+	resp, err := proj.Delete(context.Background(), sampleProject)
+	if err != nil {
+		t.Error(err)
+	}
+	if !proto.Equal(resp.Project, sampleProject.Project) {
+		t.Errorf("expected %v, got %v", sampleProject.Project, resp.Project)
+	}
+}
+
+// Create the ProjectServer as a local struct that can be excercised directly over the call stack
+func createProjectServer() *Proj {
+	//Create the config
+	var proj = &Proj{}
+
+	if endpoints := os.Getenv("endpoints"); endpoints != "" {
+		etcdEndpoints = strings.Split(endpoints, ",")
+	}
+	proj.Store = etcd.New(etcdEndpoints, "amp")
+	if err := proj.Store.Connect(5 * time.Second); err != nil {
+		panic(err)
+	}
+	return proj
+}


### PR DESCRIPTION
This is an initial submission with limited scope to address the conversion of the CI storage from mongo to etcd via gRPC service. To start, this addresses only the "project" data model and its storage within etcd.  
## Verification

`sudo ./swarm start`
`# from amp root dir`
`go test -v ./api/rpc/project`
## TODO
- [ ] Needs to be added to amplifier. Current tests are not exercising remote calls, but are using gRPC/proto
- [ ] Tests should be added to Makefile, once solution matures.
