### PR TITLE
update group by to get sum not avg

### DIFF
--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -15,11 +15,11 @@ const (
 
 // Configuration is for all configurable client settings
 type Configuration struct {
-	Verbose bool
-	Github  string
-	Target  string
-	Images  []string
-	Port   string
+	Verbose       bool
+	Github        string
+	Target        string
+	Images        []string
+	Port          string
 	ServerAddress string
 }
 

--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -153,13 +153,12 @@ func (s *Stats) statQueryMetric(req *StatsRequest, metric string) (*StatsReply, 
 		return nil, errors.New("No result found")
 	}
 
-	cpuReply := StatsReply{}
 	if len(res.Results[0].Series) == 0 {
 		return nil, errors.New("No result found")
 	}
 	list := res.Results[0].Series[0].Values
-	cpuReply.Entries = make([]*StatsEntry, len(list))
-	for i, row := range list {
+	containerMap := make(map[string]*StatsEntry)
+	for _, row := range list {
 		entry := StatsEntry{
 			Time:           s.getTimeFieldValue(row[0]),
 			Datacenter:     s.getStringFieldValue(row[1]),
@@ -188,34 +187,62 @@ func (s *Stats) statQueryMetric(req *StatsRequest, metric string) (*StatsReply, 
 			entry.NetTxBytes = s.getNumberFieldValue(row[11])
 			entry.NetRxBytes = s.getNumberFieldValue(row[12])
 		}
-
-		cpuReply.Entries[i] = &entry
+		s.avgInContainerMap(containerMap, &entry)
 	}
-	return s.computeData(req, &cpuReply)
+	return s.addByKeyUsingContainerData(req, containerMap)
 }
 
-func (s *Stats) computeData(req *StatsRequest, data *StatsReply) (*StatsReply, error) {
+func (s *Stats) avgInContainerMap(containerMap map[string]*StatsEntry, row *StatsEntry) {
+	key := row.ContainerId
+	aggr, ok := containerMap[key]
+	if !ok {
+		containerMap[key] = row
+		if row.Cpu != 0 || row.Mem != 0 || row.IoRead != 0 || row.IoWrite != 0 || row.NetTxBytes != 0 || row.NetRxBytes != 0 {
+			row.Number = 1
+		}
+	} else {
+		aggr.Cpu += row.Cpu
+		aggr.Mem += row.Mem
+		aggr.MemUsage += row.MemUsage
+		aggr.MemLimit += row.MemLimit
+		aggr.IoRead += row.IoRead
+		aggr.IoWrite += row.IoWrite
+		aggr.NetTxBytes += row.NetTxBytes
+		aggr.NetRxBytes += row.NetRxBytes
+		if row.Cpu != 0 || row.Mem != 0 {
+			aggr.Number++
+		}
+	}
+}
+
+
+func (s *Stats) addByKeyUsingContainerData(req *StatsRequest, containerMap map[string]*StatsEntry) (*StatsReply, error) {
 	// aggreggate rows in map per id concidering req (containner_id | service_id | task_id | nodeId)
 	resultMap := make(map[string]*StatsEntry)
-	for _, row := range data.Entries {
-		key := s.getKey(req, row)
-		aggr, ok := resultMap[key]
-		if !ok {
-			resultMap[key] = row
-			if row.Cpu != 0 || row.Mem != 0 || row.IoRead != 0 || row.IoWrite != 0 || row.NetTxBytes != 0 || row.NetRxBytes != 0 {
-				row.Number = 1
-			}
-		} else {
-			aggr.Cpu += row.Cpu
-			aggr.Mem += row.Mem
-			aggr.MemUsage += row.MemUsage
-			aggr.MemLimit += row.MemLimit
-			aggr.IoRead += row.IoRead
-			aggr.IoWrite += row.IoWrite
-			aggr.NetTxBytes += row.NetTxBytes
-			aggr.NetRxBytes += row.NetRxBytes
-			if row.Cpu != 0 || row.Mem != 0 {
-				aggr.Number++
+	for _, row := range containerMap {
+		if row.Number > 0 {
+			key := s.getKey(req, row)
+			aggr, ok := resultMap[key]
+			if !ok {
+				aggr = row
+				aggr.Cpu = (row.Cpu / row.Number)
+				aggr.Mem = (row.Mem / row.Number)
+				aggr.MemUsage = (row.MemUsage / row.Number)
+				aggr.MemLimit = (row.MemLimit / row.Number)
+				aggr.IoRead = (row.IoRead / row.Number)
+				aggr.IoWrite = (row.IoWrite / row.Number)
+				aggr.NetTxBytes = (row.NetTxBytes / row.Number)
+				aggr.NetRxBytes = (row.NetRxBytes / row.Number)
+				resultMap[key] = aggr
+			} else {
+				aggr.Cpu += (row.Cpu / row.Number)
+				aggr.Mem += (row.Mem / row.Number)
+				aggr.MemUsage += (row.MemUsage / row.Number)
+				aggr.MemLimit += (row.MemLimit / row.Number)
+				aggr.IoRead += (row.IoRead / row.Number)
+				aggr.IoWrite += (row.IoWrite / row.Number)
+				aggr.NetTxBytes += (row.NetTxBytes / row.Number)
+				aggr.NetRxBytes += (row.NetRxBytes / row.Number)
 			}
 		}
 	}
@@ -224,8 +251,10 @@ func (s *Stats) computeData(req *StatsRequest, data *StatsReply) (*StatsReply, e
 	result.Entries = make([]*StatsEntry, len(resultMap))
 	var ii int32
 	for key := range resultMap {
-		result.Entries[ii] = resultMap[key]
-		ii++
+		if key != "" {
+			result.Entries[ii] = resultMap[key]
+			ii++
+		}
 	}
 	// copmute cpu usage value for each row
 	s.computeMetric(&result)

--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -215,7 +215,6 @@ func (s *Stats) avgInContainerMap(containerMap map[string]*StatsEntry, row *Stat
 	}
 }
 
-
 func (s *Stats) addByKeyUsingContainerData(req *StatsRequest, containerMap map[string]*StatsEntry) (*StatsReply, error) {
 	// aggreggate rows in map per id concidering req (containner_id | service_id | task_id | nodeId)
 	resultMap := make(map[string]*StatsEntry)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	cobra.OnInitialize(func() {
 		InitConfig(configFile, &Config, verbose, serverAddr)
-		fmt.Println("Server: "+Config.ServerAddress)
+		fmt.Println("Server: " + Config.ServerAddress)
 		AMP = client.NewAMP(&Config)
 		AMP.Connect()
 		cli.AtExit(func() {

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"github.com/appcelerator/amp/api/server"
 	flag "github.com/spf13/pflag"
+	"strings"
 )
 
 const (
-	defaultPort             = ":50101"
-	defaultClientID         = ""
-	defaultClientSecret     = ""
+	defaultPort         = ":50101"
+	defaultClientID     = ""
+	defaultClientSecret = ""
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 	clientSecret     string
 	kafkaURL         string
 	influxURL        string
-	isService	 bool
+	isService        bool
 )
 
 func parseFlags() {
@@ -58,10 +58,10 @@ func parseFlags() {
 
 	//Update url is service usage
 	if isService {
-		etcdEndpoints    = "http://etcd:2379"
+		etcdEndpoints = "http://etcd:2379"
 		elasticsearchURL = "http://elasticsearch:9200"
-		kafkaURL         = "kafka:9092"
-		influxURL        = "http://influxdb:8086"
+		kafkaURL = "kafka:9092"
+		influxURL = "http://influxdb:8086"
 	}
 
 	// update config


### PR DESCRIPTION
amp stats was returning stats for nodes with avg values of the containers
this update make amp stats returns stats with sum of the containers

test:
- ./amp stats --mem - > get stats memory for local node
- ./amp stats --containers --mem -> get stats memory by containers
- the sum of all container used memory should be about equal to the memory used for the node.
