### PR TITLE
add registry to amp with HAProxy reverse proxy

### DIFF
--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -1,61 +1,61 @@
 package main
 
 import (
-  "errors"
-  "fmt"
-  "os"
-  "os/exec"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 
-  "github.com/appcelerator/amp/api/client"
-  "github.com/spf13/cobra"
+	"github.com/appcelerator/amp/api/client"
+	"github.com/spf13/cobra"
 )
 
 var pushCmd = &cobra.Command{
-  Use:   "push",
-  Short: "push an image in the amp registry",
-  Long:  `push an image to the amp registry`,
-  Run: func(cmd *cobra.Command, args []string) {
-    err := RegistryPush(AMP, cmd, args)
-    if err != nil {
-      fmt.Println(err)
-    }
-  },
+	Use:   "push",
+	Short: "push an image in the amp registry",
+	Long:  `push an image to the amp registry`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RegistryPush(AMP, cmd, args)
+		if err != nil {
+			fmt.Println(err)
+		}
+	},
 }
 
 func init() {
-  RootCmd.AddCommand(pushCmd)
+	RootCmd.AddCommand(pushCmd)
 }
 
 // RegistryPush displays resource usage statistcs
 func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
-  _, err := amp.GetAuthorizedContext()
-  if err != nil {
-    return err
-  }
+	_, err := amp.GetAuthorizedContext()
+	if err != nil {
+		return err
+	}
 
-  image := args[0]
+	image := args[0]
 
-  if amp.Verbose() {
-    fmt.Println("Execute registry push command with:")
-    fmt.Printf("image: %s\n", image)
-  }
+	if amp.Verbose() {
+		fmt.Println("Execute registry push command with:")
+		fmt.Printf("image: %s\n", image)
+	}
 
-  if err = validateRegistryImage(image); err != nil {
-    return err
-  }
-  cmdexe := exec.Command("docker", "push", image)
-  cmdexe.Stdout = os.Stdout
-  cmdexe.Stderr = os.Stderr
-  err = cmdexe.Run()
-  if err != nil {
-    return err
-  }
-  return err
+	if err = validateRegistryImage(image); err != nil {
+		return err
+	}
+	cmdexe := exec.Command("docker", "push", image)
+	cmdexe.Stdout = os.Stdout
+	cmdexe.Stderr = os.Stderr
+	err = cmdexe.Run()
+	if err != nil {
+		return err
+	}
+	return err
 }
 
 func validateRegistryImage(image string) error {
-  if image == "" {
-    return errors.New("need a valid image name")
-  }
-  return nil
+	if image == "" {
+		return errors.New("need a valid image name")
+	}
+	return nil
 }

--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+  "errors"
+  "fmt"
+  "os"
+  "os/exec"
+
+  "github.com/appcelerator/amp/api/client"
+  "github.com/spf13/cobra"
+)
+
+var pushCmd = &cobra.Command{
+  Use:   "push",
+  Short: "push an image in the amp registry",
+  Long:  `push an image to the amp registry`,
+  Run: func(cmd *cobra.Command, args []string) {
+    err := RegistryPush(AMP, cmd, args)
+    if err != nil {
+      fmt.Println(err)
+    }
+  },
+}
+
+func init() {
+  RootCmd.AddCommand(pushCmd)
+}
+
+// RegistryPush displays resource usage statistcs
+func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
+  _, err := amp.GetAuthorizedContext()
+  if err != nil {
+    return err
+  }
+
+  image := args[0]
+
+  if amp.Verbose() {
+    fmt.Println("Execute registry push command with:")
+    fmt.Printf("image: %s\n", image)
+  }
+
+  if err = validateRegistryImage(image); err != nil {
+    return err
+  }
+  cmdexe := exec.Command("docker", "push", image)
+  cmdexe.Stdout = os.Stdout
+  cmdexe.Stderr = os.Stderr
+  err = cmdexe.Run()
+  if err != nil {
+    return err
+  }
+  return err
+}
+
+func validateRegistryImage(image string) error {
+  if image == "" {
+    return errors.New("need a valid image name")
+  }
+  return nil
+}

--- a/swarm
+++ b/swarm
@@ -27,7 +27,7 @@ IMAGES=(
   appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
   appcelerator/kibana:latest
   appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
-  appcelerator/registry:2
+  registry:2
   appcelerator/zookeeper:${ZOOKEEPER_VERSION}
   quay.io/coreos/etcd:v3.0.4
 )
@@ -42,7 +42,7 @@ MINIMAGES=(
   appcelerator/kafka:${KAFKA_VERSION}
   appcelerator/kibana:latest
   appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
-  appcelerator/registry:2
+  registry:2
   appcelerator/zookeeper:${ZOOKEEPER_VERSION}
   quay.io/coreos/etcd:v3.0.4
 )

--- a/swarm
+++ b/swarm
@@ -333,7 +333,7 @@ haproxy() { # Owner: freignat91
     --label amp.swarm="infrastructure" \
     -p 8080:8080 \
     -p 80:80 \
-    appcelerator/haproxy:test2
+    appcelerator/haproxy:latest
 }
 
 

--- a/swarm
+++ b/swarm
@@ -215,6 +215,7 @@ monitor() {
 registry() { # Owner: freignat91
   docker service create --network amp-swarm --name registry \
   --label amp.swarm="infrastructure" \
+  --mount type=bind,source=$HOME/registry/data,target=/var/lib/registry \
   -p 5000:5000 \
   registry:2
 }
@@ -229,7 +230,6 @@ ampagent() { # Owner: freignat91
   docker service create --network amp-swarm --name amp-agent \
     --mode global \
     --label amp.swarm="infrastructure" \
-    -p 5001:3000 \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     appcelerator/amp-agent:latest
 }

--- a/swarm
+++ b/swarm
@@ -216,7 +216,6 @@ registry() { # Owner: freignat91
   docker service create --network amp-swarm --name registry \
   --label amp.swarm="infrastructure" \
   -p 5000:5000 \
-  --mount type=bind,source=/data,target=/var/lib/registry \
   registry:2
 }
 

--- a/swarm
+++ b/swarm
@@ -27,12 +27,13 @@ IMAGES=(
   appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
   appcelerator/kibana:latest
   appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
+  appcelerator/registry:2
   appcelerator/zookeeper:${ZOOKEEPER_VERSION}
   quay.io/coreos/etcd:v3.0.4
 )
 
 MINIMAGES=(
-  appcelerator/amplifier:latest  
+  appcelerator/amplifier:latest
   appcelerator/amp-agent:latest
   appcelerator/amp-log-worker:latest
   appcelerator/elasticsearch-amp:latest
@@ -41,6 +42,7 @@ MINIMAGES=(
   appcelerator/kafka:${KAFKA_VERSION}
   appcelerator/kibana:latest
   appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
+  appcelerator/registry:2
   appcelerator/zookeeper:${ZOOKEEPER_VERSION}
   quay.io/coreos/etcd:v3.0.4
 )
@@ -60,6 +62,7 @@ SERVICES=(
   kibana
   kapacitor
   telegrafagent
+  registry
   zookeeper
 )
 
@@ -74,6 +77,7 @@ MINSERVICES=(
   influxdb
   kibana
   telegrafagent
+  registry
   zookeeper
 )
 
@@ -208,6 +212,14 @@ monitor() {
   clear; while true; do tput cup 0 0; docker service ls; sleep $interval; done
 }
 
+registry() { # Owner: freignat91
+  docker service create --network amp-swarm --name registry \
+  --label amp.swarm="infrastructure" \
+  -p 5000:5000 \
+  --mount type=bind,source=/data,target=/var/lib/registry \
+  registry:2
+}
+
 amplifier() {
   docker service create --network amp-swarm,amp-public --name amplifier \
     --label amp.swarm="infrastructure" \
@@ -321,7 +333,7 @@ haproxy() { # Owner: freignat91
     --label amp.swarm="infrastructure" \
     -p 8080:8080 \
     -p 80:80 \
-    appcelerator/haproxy:latest
+    appcelerator/haproxy:test2
 }
 
 


### PR DESCRIPTION
Add registry as a service

Test:
- pull swarm all images (should have registry:2 in the list): `./swarm pull`
- start amp swarm: `sudo ./swarm start`
- create or pull an image for instance: `docker pull alpine`
- tag it:  `docker tag alpine localhost:5000/alpine`
- push it: `docker push localhost:5000/alpine`
  image is pushed in the amp registry going through HAProxy
- verify you can pull it: `docker pull localhost:5000/alpine` ,having this console message: Image is up to date for localhost:5000/alpline:latest
- `make install` (rm -rf vendor and glide install, if needed)
- `amp push localhost:5000/alpine` -> push the image using amp command
