### PR TITLE
Make backend services accessible

### DIFF
--- a/api/runtime/configuration.go
+++ b/api/runtime/configuration.go
@@ -1,0 +1,22 @@
+package runtime
+
+import (
+	"github.com/appcelerator/amp/data/elasticsearch"
+	"github.com/appcelerator/amp/data/influx"
+	"github.com/appcelerator/amp/data/kafka"
+	"github.com/appcelerator/amp/data/storage"
+)
+
+var (
+	// Store is the interface used to access the key/value storage backend
+	Store storage.Interface
+
+	// Elasticsearch is the elasticsearch client
+	Elasticsearch elasticsearch.Elasticsearch
+
+	// Kafka is the kafka client
+	Kafka kafka.Kafka
+
+	// Influx is the influxDB client
+	Influx influx.Influx
+)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -12,26 +12,10 @@ import (
 	"github.com/appcelerator/amp/api/rpc/service"
 	"github.com/appcelerator/amp/api/rpc/stack"
 	"github.com/appcelerator/amp/api/rpc/stats"
-	"github.com/appcelerator/amp/data/elasticsearch"
+	"github.com/appcelerator/amp/api/runtime"
 	"github.com/appcelerator/amp/data/influx"
-	"github.com/appcelerator/amp/data/kafka"
-	"github.com/appcelerator/amp/data/storage"
 	"github.com/appcelerator/amp/data/storage/etcd"
 	"google.golang.org/grpc"
-)
-
-var (
-	// Store is the interface used to access the key/value storage backend
-	Store storage.Interface
-
-	// Elasticsearch is the elasticsearch client
-	Elasticsearch elasticsearch.Elasticsearch
-
-	// Kafka is the kafka client
-	Kafka kafka.Kafka
-
-	//Influx is the influxDB client
-	Influx influx.Influx
 )
 
 // Start starts the server
@@ -47,22 +31,22 @@ func Start(config Config) {
 	s := grpc.NewServer()
 	// project.RegisterProjectServer(s, &project.Service{})
 	logs.RegisterLogsServer(s, &logs.Logs{
-		Es:    Elasticsearch,
-		Store: Store,
-		Kafka: Kafka,
+		Es:    runtime.Elasticsearch,
+		Store: runtime.Store,
+		Kafka: runtime.Kafka,
 	})
 	stats.RegisterStatsServer(s, &stats.Stats{
-		Influx: Influx,
+		Influx: runtime.Influx,
 	})
 	oauth.RegisterGithubServer(s, &oauth.Oauth{
-		Store:        Store,
+		Store:        runtime.Store,
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 	})
 	build.RegisterAmpBuildServer(s, &build.Proxy{})
 	service.RegisterServiceServer(s, &service.Service{})
 	stack.RegisterStackServiceServer(s, &stack.Server{
-		Store: Store,
+		Store: runtime.Store,
 	})
 
 	// start listening
@@ -76,16 +60,16 @@ func Start(config Config) {
 
 func initEtcd(config Config) {
 	log.Printf("connecting to etcd at %v", strings.Join(config.EtcdEndpoints, ","))
-	Store = etcd.New(config.EtcdEndpoints, "amp")
-	if err := Store.Connect(5 * time.Second); err != nil {
+	runtime.Store = etcd.New(config.EtcdEndpoints, "amp")
+	if err := runtime.Store.Connect(5 * time.Second); err != nil {
 		panic(err)
 	}
-	log.Printf("connected to etcd at %v", strings.Join(Store.Endpoints(), ","))
+	log.Printf("connected to etcd at %v", strings.Join(runtime.Store.Endpoints(), ","))
 }
 
 func initElasticsearch(config Config) {
 	log.Printf("connecting to elasticsearch at %s\n", config.ElasticsearchURL)
-	err := Elasticsearch.Connect(config.ElasticsearchURL)
+	err := runtime.Elasticsearch.Connect(config.ElasticsearchURL)
 	if err != nil {
 		log.Panicf("amplifer is unable to connect to elasticsearch on: %s\n%v", config.ElasticsearchURL, err)
 	}
@@ -94,7 +78,7 @@ func initElasticsearch(config Config) {
 
 func initKafka(config Config) {
 	log.Printf("connecting to kafka at %s\n", config.KafkaURL)
-	err := Kafka.Connect(config.KafkaURL)
+	err := runtime.Kafka.Connect(config.KafkaURL)
 	if err != nil {
 		log.Panicf("amplifer is unable to connect to kafka on: %s\n%v", config.KafkaURL, err)
 	}
@@ -103,8 +87,8 @@ func initKafka(config Config) {
 
 func initInfluxDB(config Config) {
 	log.Printf("connecting to InfluxDB at %s\n", config.InfluxURL)
-	Influx = influx.New(config.InfluxURL, "telegraf", "", "")
-	if err := Influx.Connect(5 * time.Second); err != nil {
+	runtime.Influx = influx.New(config.InfluxURL, "telegraf", "", "")
+	if err := runtime.Influx.Connect(5 * time.Second); err != nil {
 		log.Panicf("amplifer is unable to connect to influxDB on: %s\n%v", config.InfluxURL, err)
 	}
 	log.Printf("connected to influxDB at %s\n", config.InfluxURL)


### PR DESCRIPTION
This PR moves backend objects out of server to avoid cycles for dependents.
## Verification

make install, start amplifier, make test
