### PR TITLE
propagate registry auth on all Swarm nodes

### DIFF
--- a/swarm
+++ b/swarm
@@ -221,13 +221,13 @@ registry() { # Owner: freignat91
 }
 
 amplifier() {
-  docker service create --network amp-swarm,amp-public --name amplifier \
+  docker service create --with-registry-auth --network amp-swarm,amp-public --name amplifier \
     --label amp.swarm="infrastructure" \
     appcelerator/amplifier:latest
 }
 
 ampagent() { # Owner: freignat91
-  docker service create --network amp-swarm --name amp-agent \
+  docker service create --with-registry-auth --network amp-swarm --name amp-agent \
     --mode global \
     --label amp.swarm="infrastructure" \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
@@ -236,13 +236,13 @@ ampagent() { # Owner: freignat91
 
 # DEPENDENCIES kafka
 amplogworker() { # Owner: bertrand-quenin
-  docker service create --network amp-swarm --name amp-log-worker \
+  docker service create --with-registry-auth --network amp-swarm --name amp-log-worker \
     --label amp.swarm="infrastructure" \
     appcelerator/amp-log-worker:latest
 }
 
 ampui() { # Owner: freignat91
-  docker service create --network amp-swarm --name amp-ui \
+  docker service create --with-registry-auth --network amp-swarm --name amp-ui \
     --label amp.swarm="infrastructure" \
     --constraint "node.role == manager" \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
@@ -250,7 +250,7 @@ ampui() { # Owner: freignat91
 }
 
 elasticsearch() { # Owner: bertrand-quenin
-  docker service create --network amp-swarm --name elasticsearch \
+  docker service create --with-registry-auth --network amp-swarm --name elasticsearch \
     --label amp.swarm="infrastructure" \
     -p 9200:9200 \
     -p 9300:9300 \
@@ -259,7 +259,7 @@ elasticsearch() { # Owner: bertrand-quenin
 
 
 etcd() { # Owner: subfuzion
-  docker service create --network amp-swarm --name etcd \
+  docker service create --with-registry-auth --network amp-swarm --name etcd \
     --label amp.swarm="infrastructure" \
     -p 2379:2379 \
     -p 2380:2380 \
@@ -270,7 +270,7 @@ etcd() { # Owner: subfuzion
   }
 
 grafana() { # Owner: ndegory
-  docker service create --network amp-swarm --name grafana \
+  docker service create --with-registry-auth --network amp-swarm --name grafana \
     --label amp.swarm="infrastructure" \
     -p 6001:3000 \
     -e INFLUXDB_HOST=influxdb \
@@ -281,7 +281,7 @@ grafana() { # Owner: ndegory
 }
 
 influxdb() { # Owner: ndegory
-  docker service create --network amp-swarm --name influxdb \
+  docker service create --with-registry-auth --network amp-swarm --name influxdb \
     --label amp.swarm="infrastructure" \
     -p 8086:8086 \
     -p 8083:8083 \
@@ -293,7 +293,7 @@ influxdb() { # Owner: ndegory
 
 # DEPENDENCIES zookeepeer
 kafka() { # Owner: bertrand-quenin
-  docker service create --network amp-swarm --name kafka \
+  docker service create --with-registry-auth --network amp-swarm --name kafka \
     --label amp.swarm="infrastructure" \
     -p 9092:9092 \
     -e ZOOKEEPER_CONNECT=zookeeper:2181 \
@@ -302,7 +302,7 @@ kafka() { # Owner: bertrand-quenin
 }
 
 kapacitor() { # Owner: ndegory
-  docker service create --network amp-swarm --name kapacitor \
+  docker service create --with-registry-auth --network amp-swarm --name kapacitor \
     --label amp.swarm="infrastructure" \
     -e INFLUXDB_URL=http://influxdb:8086 \
     -e KAPACITOR_HOSTNAME=auto \
@@ -318,7 +318,7 @@ kapacitor() { # Owner: ndegory
 
 
 kibana() { # Owner: ndegory
-  docker service create --network amp-swarm --name kibana \
+  docker service create --with-registry-auth --network amp-swarm --name kibana \
     --replicas 1 \
     --label amp.swarm="infrastructure" \
     -p 5601:5601 \
@@ -328,7 +328,7 @@ kibana() { # Owner: ndegory
 }
 
 haproxy() { # Owner: freignat91
-  docker service create --network amp-swarm,amp-public --name haproxy \
+  docker service create --with-registry-auth --network amp-swarm,amp-public --name haproxy \
     --label amp.swarm="infrastructure" \
     -p 8080:8080 \
     -p 80:80 \
@@ -337,7 +337,7 @@ haproxy() { # Owner: freignat91
 
 
 telegrafagent() { # Owner: ndegory
-  docker service create --network amp-swarm --name telegraf-agent \
+  docker service create --with-registry-auth --network amp-swarm --name telegraf-agent \
     --mode global \
     --label amp.swarm="infrastructure" \
     -e OUTPUT_INFLUXDB_ENABLED=true \
@@ -360,7 +360,7 @@ telegrafagent() { # Owner: ndegory
 }
 
 zookeeper() { # Owner: bertrand-quenin
-  docker service create --network amp-swarm --name zookeeper \
+  docker service create --with-registry-auth --network amp-swarm --name zookeeper \
     --label amp.swarm="infrastructure" \
     -p 2181:2181 \
     -p 2888:2888 \


### PR DESCRIPTION
When the Swarm cluster is on more than one node, private Docker images won't be pulled.
This PR adds the flag do the docker service create call so that nodes have the Docker registry auth.
