### PR TITLE
fix issue and minor updates

### DIFF
--- a/api/rpc/service/service.go
+++ b/api/rpc/service/service.go
@@ -59,14 +59,20 @@ func CreateService(docker *client.Client, ctx context.Context, req *ServiceCreat
 		Annotations:  annotations,
 		TaskTemplate: taskSpec,
 	}
-	if req.ServiceSpec.PublishSpecs != nil && len(req.ServiceSpec.PublishSpecs) > 0 {
-		swarmSpec.EndpointSpec.Ports = make([]swarm.PortConfig, len(req.ServiceSpec.PublishSpecs), len(req.ServiceSpec.PublishSpecs))
-		for i, publish := range req.ServiceSpec.PublishSpecs {
-			swarmSpec.EndpointSpec.Ports[i] = swarm.PortConfig{
-				Name:          publish.Name,
-				Protocol:      swarm.PortConfigProtocol(publish.Protocol),
-				TargetPort:    publish.InternalPort,
-				PublishedPort: publish.PublishPort,
+	if req.ServiceSpec.PublishSpecs != nil {
+		nn := len(req.ServiceSpec.PublishSpecs)
+		if nn > 0 {
+			swarmSpec.EndpointSpec = &swarm.EndpointSpec{
+				Mode:  swarm.ResolutionModeVIP,
+				Ports: make([]swarm.PortConfig, nn, nn),
+			}
+			for i, publish := range req.ServiceSpec.PublishSpecs {
+				swarmSpec.EndpointSpec.Ports[i] = swarm.PortConfig{
+					Name:          publish.Name,
+					Protocol:      swarm.PortConfigProtocol(publish.Protocol),
+					TargetPort:    publish.InternalPort,
+					PublishedPort: publish.PublishPort,
+				}
 			}
 		}
 	}

--- a/api/rpc/stack/parse_test.go
+++ b/api/rpc/stack/parse_test.go
@@ -11,7 +11,7 @@ var examples = []string{
   public:
     - name: www
       protocol: tcp
-      publish_port: 80
+      publish_port: 90
       internalPort: 3000
   replicas: 3
   environment:

--- a/api/rpc/stack/parse_test.go
+++ b/api/rpc/stack/parse_test.go
@@ -12,7 +12,7 @@ var examples = []string{
     - name: www
       protocol: tcp
       publish_port: 90
-      internalPort: 3000
+      internal_port: 3000
   replicas: 3
   environment:
     REDIS_PASSWORD: password
@@ -28,6 +28,7 @@ func TestParseStackYaml(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		fmt.Print("Out: ", out)
 		t.Log(out)
 	}
 }

--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -58,11 +58,11 @@ func (s *Server) processService(ctx context.Context, stackID string, serv *servi
 		ServiceSpec: serv,
 	}
 	server := service.Service{}
-	fmt.Printf("Create service: %s\n", serv.Name)
 	reply, err := server.Create(ctx, request)
 	if err != nil {
 		return "", err
 	}
+	fmt.Printf("Service: %s created, id=%s\n", serv.Name, reply.Id)
 	createErr := s.Store.Create(ctx, path.Join(servicesRootKey, "/", reply.Id), serv, nil, 0)
 	if createErr != nil {
 		return "", createErr

--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/appcelerator/amp/api/rpc/service"
@@ -26,11 +27,11 @@ func (s *Server) Up(ctx context.Context, in *UpRequest) (*UpReply, error) {
 	}
 	stack.Name = in.StackName
 	stackID := stringid.GenerateNonCryptoID()
+	s.Store.Delete(ctx, path.Join(stackRootKey, "/", stackID, servicesRootKey), true, nil)
 	s.Store.Create(ctx, path.Join(stackRootKey, "/", stackID), stack, nil, 0)
 	reply := UpReply{
 		StackId: stack.Id,
 	}
-	s.Store.Delete(ctx, path.Join(stackRootKey, "/", stackID+servicesRootKey), true, nil)
 	serviceIDList := make([]string, len(stack.Services), len(stack.Services))
 	for i, service := range stack.Services {
 		serviceID, err := s.processService(ctx, stackID, service)
@@ -57,6 +58,7 @@ func (s *Server) processService(ctx context.Context, stackID string, serv *servi
 		ServiceSpec: serv,
 	}
 	server := service.Service{}
+	fmt.Printf("Create service: %s\n", serv.Name)
 	reply, err := server.Create(ctx, request)
 	if err != nil {
 		return "", err

--- a/api/rpc/stack/stack_test.go
+++ b/api/rpc/stack/stack_test.go
@@ -26,7 +26,7 @@ const (
   public:
     - name: www
       protocol: tcp
-      publish_port: 80
+      publish_port: 90
       internal_port: 3000
   replicas: 3
   environment:


### PR DESCRIPTION
fix one ETCD services written issue and add minor updates

test:
- pull all images, especially HAProxy
- execute amp stack up test -f stack.yaml

with stack.yaml is
pinger:
  image: appcelerator/pinger
  replicas: 2
pingerExt:
  image: appcelerator/pinger
  replicas: 2
  public:
    - name: www
      protocol: tcp
      internal_port: 3000

amp create and starts the two services, ampExt is accessible from outside using host prfix 'www' and both have the label io.amp.stack.id equal to the stack id
in etcd we have:
amp/services/[id pinger] -> struct service pinger
amp/services/[id pingerExt] -> struct service pingerExt
amp/stacks/[stack id] -> struct stack
amp/stacks/[stack id]/services -> [ id pinger, id pingerExt]
