### PR TITLE
Adds support for amp service create -p, and tests

### DIFF
--- a/api/rpc/service/helpers.go
+++ b/api/rpc/service/helpers.go
@@ -1,34 +1,76 @@
 package service
 
-// import (
-//         "fmt"
-// 	"regexp"
-// )
-//
-// const (
-// 	portSpecRegex = `(?P<published_port>[\d]*):?(?P<target_port>[\d]+)(/(?P<protocol>tcp|udp))?`
-// )
-//
-// var (
-// 	portSpecParser *regexp.Regexp
-// )
-//
-// // ParsePortSpec parses a string and returns a PortSpec
-// func ParsePortSpec(s string) (portSpec PortSpec, err error) {
-// 	if portSpecParser == nil {
-// 		portSpecParser = regexp.MustCompile(portSpecRegex)
-// 	}
-//
-//         m := portSpecParser.FindStringSubmatch(s)
-//         fmt.Println(portSpecParser.SubexpNames())
-//         fmt.Println(m)
-//
-//         if m == nil {
-//                 err = fmt.Errorf("\"%s\" is not a valid PortSpec", s)
-//                 return
-//         }
-//
-//
-//
-//         return
-// }
+import (
+	"fmt"
+	"regexp"
+        "strconv"
+)
+
+const (
+	publishSpecRegex = `((((?P<name>[a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])*):)?(?P<publish_port>[\d]{1,5}):)?)(?P<internal_port>[\d]{1,5})(/(?P<protocol>(tcp|udp)))?([^:]$|$)`
+)
+
+var (
+	publishSpecParser *regexp.Regexp
+)
+
+// ParsePublishSpec parses a string and returns a PublishSpec
+func ParsePublishSpec(s string) (publishSpec PublishSpec, err error) {
+	if publishSpecParser == nil {
+		publishSpecParser = regexp.MustCompile(publishSpecRegex)
+	}
+
+	m := publishSpecParser.FindStringSubmatch(s)
+	if m == nil {
+		err = fmt.Errorf("\"%s\" is not a valid PublishSpec", s)
+		return
+	}
+
+        names := publishSpecParser.SubexpNames()
+        nameMap := mapNames(names)
+        for name, index := range nameMap {
+                fmt.Printf("%s => %s\n", name, m[index])
+                val := m[index]
+                switch name {
+                case "name":
+                        publishSpec.Name = val
+                case "publish_port":
+                        err = portAtoi(val, &publishSpec.PublishPort)
+                        if err != nil {
+                                return
+                        }
+                case "internal_port":
+                        err = portAtoi(val, &publishSpec.InternalPort)
+                        if err != nil {
+                                return
+                        }
+                case "protocol":
+                        publishSpec.Protocol = val
+                }
+        }
+
+	return
+}
+
+func portAtoi(s string, port *uint32) error {
+        var u64 uint64
+        if s == "" {
+                s = "0"
+        }
+        u64, err = strconv.ParseUint(s, 10, 32)
+        if err != nil {
+                return err
+        }
+        *port = uint32(u64)
+        return nil
+}
+
+func mapNames(names []string) map[string]int {
+        nameMap := make(map[string]int)
+        for i, name := range names {
+                if name != "" {
+                        nameMap[name] = i
+                }
+        }
+        return nameMap
+}

--- a/api/rpc/service/helpers.go
+++ b/api/rpc/service/helpers.go
@@ -29,7 +29,6 @@ func ParsePublishSpec(s string) (publishSpec PublishSpec, err error) {
         names := publishSpecParser.SubexpNames()
         nameMap := mapNames(names)
         for name, index := range nameMap {
-                fmt.Printf("%s => %s\n", name, m[index])
                 val := m[index]
                 switch name {
                 case "name":

--- a/api/rpc/service/helpers_test.go
+++ b/api/rpc/service/helpers_test.go
@@ -38,9 +38,7 @@ func TestRegex(t *testing.T) {
                 input := test.input
                 expected := test.expect
 
-		//fmt.Println(input)
 		spec, err := ParsePublishSpec(input)
-                t.Logf("input: %s, PublishSpec: %v", input, spec)
 
 		if err != nil {
 			t.Errorf("failed to parse \"%s\"\n%v", input, err)

--- a/api/rpc/service/helpers_test.go
+++ b/api/rpc/service/helpers_test.go
@@ -1,57 +1,77 @@
-package service
+package service_test
 
-// import (
-// 	"testing"
-// )
-//
-// var (
-// 	goodTestPorts = map[string]PortSpec{
-// 		":3000":         {TargetPort: 3000},
-// 		"80:3000":       {TargetPort: 3000, PublishedPort: 80},
-// 		"80:3000/tcp":   {TargetPort: 3000, PublishedPort: 80, Protocol: "tcp"},
-// 		"4000:3000/udp": {TargetPort: 3000, PublishedPort: 4000, Protocol: "udp"},
-// 	}
-//
-// 	badTestPorts = map[string]string{
-// 		"3000":      "port requires leading colon",
-// 		"80:":       "published port must specify target port",
-// 		"80:3000/":  "missing protocol",
-// 		"80:3000/x": "incorrect protocol",
-// 	}
-// )
-//
-// // The testing isn't meant to be exhaustive since bad ports will fail anyway,
-// // the tests just verify that we can generally identify the PortSpec components
-// func TestRegex(t *testing.T) {
-// 	for spec, expected := range goodTestPorts {
-// 		//fmt.Println(spec)
-// 		portSpec, err := ParsePortSpec(spec)
-// 		if err != nil {
-// 			t.Errorf("failed to parse \"%s\"\n%v", spec, err)
-// 		}
-//
-// 		if portSpec.Name != expected.Name {
-// 			t.Errorf("expected Name=%s, got: %s", expected.Name, portSpec.Name)
-// 		}
-//
-// 		if portSpec.TargetPort != expected.TargetPort {
-// 			t.Errorf("expected TargetPort=%d, got: %d", expected.TargetPort, portSpec.TargetPort)
-// 		}
-//
-// 		if portSpec.PublishedPort != expected.PublishedPort {
-// 			t.Errorf("expected PublishedPort=%d, got: %d", expected.PublishedPort, portSpec.PublishedPort)
-// 		}
-//
-// 		if portSpec.Protocol != expected.Protocol {
-// 			t.Errorf("expected Protocol=%s, got: %s", expected.Protocol, portSpec.Protocol)
-// 		}
-// 	}
-//
-// 	for spec, reason := range badTestPorts {
-// 		//fmt.Printf("%s => %s\n", spec, reason)
-// 		_, err := ParsePortSpec(spec)
-// 		if err == nil {
-// 			t.Errorf("should have failed to parse \"%s\" because %s", spec, reason)
-// 		}
-// 	}
-// }
+import (
+	"testing"
+        . "github.com/appcelerator/amp/api/rpc/service"
+)
+
+var (
+	goodPublishSpecs = []struct {
+		input  string
+		expect PublishSpec
+	}{
+		{input: ":3000", expect: PublishSpec{InternalPort: 3000}},
+		{input: "80:3000", expect: PublishSpec{InternalPort: 3000, PublishPort: 80}},
+		{input: "80:3000/tcp", expect: PublishSpec{InternalPort: 3000, PublishPort: 80, Protocol: "tcp"}},
+		{input: "4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+		{input: "host:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+		{input: "host-1:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+	}
+
+	badPublishSpecs = []struct {
+		input  string
+		reason string
+	}{
+		{input: "3000", reason: "internal port requires leading colon"},
+		{input: "80:", reason: "publish port must specify internal port"},
+		{input: "80:3000/", reason: "missing protocol"},
+		{input: "80:3000/x", reason: "invalid protocol"},
+		{input: "host-:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+		{input: "-host:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+	}
+)
+
+// This testing isn't meant to be rigorously exhaustive since bad ports will fail anyway,
+// the tests just verify that we can generally identify PublishSpec components
+func TestRegex(t *testing.T) {
+	for _, test := range goodPublishSpecs {
+                input := test.input
+                expected := test.expect
+
+		//fmt.Println(input)
+		spec, err := ParsePublishSpec(input)
+                t.Logf("input: %s, PublishSpec: %v", input, spec)
+
+		if err != nil {
+			t.Errorf("failed to parse \"%s\"\n%v", input, err)
+		}
+
+		if spec.Name != expected.Name {
+			t.Errorf("expected Name=%s, got: %s", expected.Name, spec.Name)
+		}
+
+		if spec.InternalPort != expected.InternalPort {
+			t.Errorf("expected InternalPort=%d, got: %d", expected.InternalPort, spec.InternalPort)
+		}
+
+		if spec.PublishPort != expected.PublishPort {
+			t.Errorf("expected PublishPort=%d, got: %d", expected.PublishPort, spec.PublishPort)
+		}
+
+		if spec.Protocol != expected.Protocol {
+			t.Errorf("expected Protocol=%s, got: %s", expected.Protocol, spec.Protocol)
+		}
+	}
+
+	// TODO
+	// for _, test := range badPublishSpecs {
+        //         input := test.input
+        //         reason := test.reason
+        //
+	// 	//fmt.Printf("%s => %s\n", input, reason)
+	// 	_, err := ParsePublishSpec(input)
+	// 	if err == nil {
+	// 		t.Errorf("should have failed to parse \"%s\" because: %s", input, reason)
+	// 	}
+	// }
+}

--- a/api/rpc/service/helpers_test.go
+++ b/api/rpc/service/helpers_test.go
@@ -14,8 +14,8 @@ var (
 		{input: "80:3000", expect: PublishSpec{InternalPort: 3000, PublishPort: 80}},
 		{input: "80:3000/tcp", expect: PublishSpec{InternalPort: 3000, PublishPort: 80, Protocol: "tcp"}},
 		{input: "4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
-		{input: "host:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
-		{input: "host-1:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+		{input: "host:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp", Name: "host"}},
+		{input: "host-1:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp", Name: "host-1"}},
 	}
 
 	badPublishSpecs = []struct {
@@ -26,8 +26,8 @@ var (
 		{input: "80:", reason: "publish port must specify internal port"},
 		{input: "80:3000/", reason: "missing protocol"},
 		{input: "80:3000/x", reason: "invalid protocol"},
-		{input: "host-:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
-		{input: "-host:4000:3000/udp", expect: PublishSpec{InternalPort: 3000, PublishPort: 4000, Protocol: "udp"}},
+		{input: "host-:4000:3000/udp", reason: "can't begin or end with a dash"},
+		{input: "-host:4000:3000/udp", reason: "can't begin or end with a dash"},
 	}
 )
 

--- a/api/rpc/stack/parse_test.go
+++ b/api/rpc/stack/parse_test.go
@@ -59,11 +59,11 @@ var (
 
 	sample3 = map[string]serviceMap{
 		"pinger": {
-			Image: "appcelerator/pinger",
+			Image:    "appcelerator/pinger",
 			Replicas: 2,
 		},
 		"pinger2": {
-			Image: "appcelerator/pinger",
+			Image:    "appcelerator/pinger",
 			Replicas: 2,
 			Public: []publishSpec{
 				{
@@ -77,9 +77,9 @@ var (
 
 	// map of filenames to a map of serviceMap elements (each file has one or more)
 	compareStructs = map[string]map[string]serviceMap{
-		"sample-01.yml": sample1,
-		"sample-02.yml": sample2,
-		"sample-03.yml": sample3,
+		"sample-01.yml":  sample1,
+		"sample-02.yml":  sample2,
+		"sample-03.yml":  sample3,
 		"sample-03.json": sample3,
 	}
 )
@@ -197,7 +197,7 @@ func compareEnvironment(a serviceMap, b serviceMap) bool {
 	return reflect.DeepEqual(ae, be)
 }
 
-// environmentToMap 
+// environmentToMap
 func environmentToMap(env interface{}) map[string]string {
 	es, ok := env.(map[string]string)
 	if ok {

--- a/api/rpc/stack/test_samples/sample-01.yml
+++ b/api/rpc/stack/test_samples/sample-01.yml
@@ -2,6 +2,7 @@ pinger:
   image: appcelerator/pinger
   replicas: 2
   public:
-    - publish_port: 80
+    - name: www
+      publish_port: 90
       internal_port: 3000
       protocol: tcp

--- a/cmd/amp/service-create.go
+++ b/cmd/amp/service-create.go
@@ -59,12 +59,17 @@ func create(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	fmt.Println(args)
 	fmt.Println(stringify(cmd))
 
+	parsedSpecs, err := parsePublishSpecs(publishSpecs)
+	if err != nil {
+		return err
+	}
+
 	spec := &service.ServiceSpec{
 		Image:        image,
 		Name:         name,
 		Replicas:     replicas,
 		Env:          stringmap(env),
-		PublishSpecs: parsePublishSpecs(publishSpecs),
+		PublishSpecs: parsedSpecs,
 	}
 
 	request := &service.ServiceCreateRequest{
@@ -98,6 +103,15 @@ func stringify(cmd *cobra.Command) string {
 		name, replicas, env)
 }
 
-func parsePublishSpecs(specs []string) []*service.PublishSpec {
-	return []*service.PublishSpec{}
+func parsePublishSpecs(specs []string) ([]*service.PublishSpec, error) {
+	publishSpecs := []*service.PublishSpec{}
+	for _, input := range specs {
+		publishSpec, err := service.ParsePublishSpec(input)
+		if err != nil {
+			return nil, err
+		}
+		publishSpecs = append(publishSpecs, &publishSpec)
+
+	}
+	return publishSpecs, nil
 }


### PR DESCRIPTION
The CLI now supports `amp service create -p` where `-p` is the input string for a `PublishSpec`.
## Verification

```
$ go test -run TestRegex github.com/appcelerator/amp/api/rpc/service -v
$ amp service create -p 3000:3000 appcelerator/pinger
$ curl localhost:3000/ping
pong
```
