### PR TITLE
improve stats command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,4 @@ test:
 	@go test $(REPO)/data/storage/etcd
 	@go test $(REPO)/api/rpc/stack
 	@go test $(REPO)/data/influx
-#	@go test $(REPO)/api/rpc/stat
+	@go test $(REPO)/api/rpc/stats


### PR DESCRIPTION
amp stats default is now "service"
amp stats [serviceName] is equivalent to amp stats --service-name=[serviceName]

we can use part of the service name
'amp stats amp' will return all services starting by 'amp'
same behavior with arguments:
- service-id
- task-id
- task-name
- container-id
- container-name
- node-id

added stats tests

test:  make test
