### PR TITLE
add amplifier constraint

### DIFF
--- a/swarm
+++ b/swarm
@@ -223,6 +223,7 @@ registry() { # Owner: freignat91
 amplifier() {
   docker service create --with-registry-auth --network amp-swarm,amp-public --name amplifier \
     --label amp.swarm="infrastructure" \
+    --constraint "node.role == manager" \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     appcelerator/amplifier:latest
 }


### PR DESCRIPTION
add amplifier constraint to have it on a manager node, otherwise it can't create services on a distributed network:

test with AWS test env:
- amp stack up essai1 -f [stack.file] --server admin.amp.axwaytest.net:8080
  and after a while (10 seconds) or see result using UI: ui.amp.axwaytest.net
- amp stats essai1- --server admin.amp.axwaytest.net:8080
  to see the stats on the essai1 stack

where [stack.file] containts:
pinger:
  image: appcelerator/pinger
  replicas: 2
pingerExt1:
  image: appcelerator/pinger
  replicas: 2
  public:
    - name: www1
      protocol: tcp
      internal_port: 3000
pingerExt2:
  image: appcelerator/pinger
  replicas: 2
  public:
    - name: www2
      protocol: tcp
      publish_port: 90
      internal_port: 3000
