### PR TITLE
update amp CLI serverAddress defaults

### DIFF
--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -37,6 +37,12 @@ func main() {
 
 	cobra.OnInitialize(func() {
 		InitConfig(configFile, &Config, verbose, serverAddr)
+		if addr := RootCmd.Flag("server").Value.String(); addr != "" {
+			Config.ServerAddress = addr
+		}
+		if Config.ServerAddress == "" {
+			Config.ServerAddress = client.DefaultServerAddress
+		}
 		fmt.Println("Server: " + Config.ServerAddress)
 		AMP = client.NewAMP(&Config)
 		AMP.Connect()
@@ -62,10 +68,8 @@ func main() {
 
 	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `Verbose output`)
-	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", client.DefaultServerAddress, "Server address")
-
+	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "Server address")
 	RootCmd.AddCommand(configCmd)
-
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		cli.Exit(-1)


### PR DESCRIPTION
update behavior for default value of amp CLI  ServerAddress:

there are 3 possibles value for the serverAddress in amp CLI
- ServerAdresss value in amp config file ($HOME/.amp.yaml)
- Argument --server = xxxx, in amp command
- default value: localhost:50101
- if ServerAddress in conf file exists && !serverAddress as amp argument, then 
  serverAddress = ServerAddress in conffile
- if serverAddress as amp argument, then no matter serverAddress in conf file:
  serverAddress = ServerAddress as amp argument
- if !ServerAddress in conf file  && !serverAddress as amp argument, then 
  serverAddress = default value (localhost:50101
