### PR TITLE
stack rollback on error

### DIFF
--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -45,7 +45,7 @@ func (s *Server) Up(ctx context.Context, in *UpRequest) (*UpReply, error) {
 	_, errStart := s.Start(ctx, &startRequest)
 	if errStart != nil {
 		fmt.Printf("Error found during service creation: %v \n", err)
-		s.rollbackETCDStack(ctx, stack.Id)
+		s.rollbackETCDStack(ctx, stack)
 		return nil, errStart
 	}
 	fmt.Printf("Stack is up: %s\n", stack.Id)
@@ -97,10 +97,11 @@ func (s *Server) rollbackServiceStack(ctx context.Context, stackID string, servi
 }
 
 // clean up if error happended during stack creation, delete all created services and all etcd data
-func (s *Server) rollbackETCDStack(ctx context.Context, stackID string) {
-	fmt.Printf("Cleanning up ETCD storage %s\n", stackID)
-	s.Store.Delete(ctx, path.Join(stackRootKey, stackID), true, nil)
-	fmt.Printf("ETCD cleaned %s\n", stackID)
+func (s *Server) rollbackETCDStack(ctx context.Context, stack *Stack) {
+	fmt.Printf("Cleanning up ETCD storage %s\n", stack.Id)
+	s.Store.Delete(ctx, path.Join(stackRootKey, stack.Id), true, nil)
+	s.Store.Delete(ctx, path.Join(stackRootNameKey, stack.Name), true, nil)
+	fmt.Printf("ETCD cleaned %s\n", stack.Id)
 }
 
 // start one service and if ok store it in ETCD:

--- a/api/rpc/stack/stack_test.go
+++ b/api/rpc/stack/stack_test.go
@@ -141,7 +141,7 @@ func TestShouldManageStackLifeCycleSuccessfully(t *testing.T) {
 	}
 	assert.NotEmpty(t, rUp1.StackId, "Stack essai1 StackId should not be empty")
 	assert.NotEmpty(t, rUp2.StackId, "Stack essai2 StackId should not be empty")
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 	//verifyusing ls
 	t.Log("perform stack ls")
 	listRequest := stack.ListRequest{}
@@ -171,7 +171,7 @@ func TestShouldManageStackLifeCycleSuccessfully(t *testing.T) {
 		t.Fatal(errRestart1)
 	}
 	assert.NotEmpty(t, rRestart1.StackId, "Stack essai1 StackId should not be empty")
-	time.Sleep(3 * time.Second)
+	time.Sleep(1 * time.Second)
 	//Stop again stack essai1
 	t.Log("stop again stack essai1")
 	rStop12, errStop12 := client.Stop(ctx, &stackRequest1)


### PR DESCRIPTION
Rollback stack on error when bringing it up

prerequisite:
- have a [stack yaml file] with a service publishing a port

test:
- amp stack up test1 -f [stack yaml file]

The stack test1 is created
- amp stack up test2 -f [stack yaml file]

The stack test2 should failed because use the same port is published, then the test2 stack creation is rollbacked
- amp stack ls

Shows only the stack test1
