### PR TITLE
Stack rm q

### DIFF
--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -49,7 +49,7 @@ func (s *Server) Up(ctx context.Context, in *UpRequest) (*UpReply, error) {
 		return nil, errStart
 	}
 	fmt.Printf("Stack is up: %s\n", stack.Id)
-	reply := UpReply{
+	reply := UpR3eply{
 		StackId: stack.Id,
 	}
 	return &reply, nil
@@ -111,7 +111,7 @@ func (s *Server) processService(ctx context.Context, stack *Stack, serv *service
 	}
 	serv.Labels[stackIDLabelName] = stack.Id
 	serv.Labels[stackNameLabelName] = stack.Name
-	serv.Name = stack.Name + "-" + serv.Name
+	//serv.Name = stack.Name + "-" + serv.Name
 	request := &service.ServiceCreateRequest{
 		ServiceSpec: serv,
 	}

--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -49,7 +49,7 @@ func (s *Server) Up(ctx context.Context, in *UpRequest) (*UpReply, error) {
 		return nil, errStart
 	}
 	fmt.Printf("Stack is up: %s\n", stack.Id)
-	reply := UpR3eply{
+	reply := UpReply{
 		StackId: stack.Id,
 	}
 	return &reply, nil

--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -111,7 +111,7 @@ func (s *Server) processService(ctx context.Context, stack *Stack, serv *service
 	}
 	serv.Labels[stackIDLabelName] = stack.Id
 	serv.Labels[stackNameLabelName] = stack.Name
-	//serv.Name = stack.Name + "-" + serv.Name
+	serv.Name = stack.Name + "-" + serv.Name
 	request := &service.ServiceCreateRequest{
 		ServiceSpec: serv,
 	}

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -33,8 +33,6 @@ var (
 
 // All main does is process commands and flags and invoke the app
 func main() {
-	fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
-
 	cobra.OnInitialize(func() {
 		InitConfig(configFile, &Config, verbose, serverAddr)
 		if addr := RootCmd.Flag("server").Value.String(); addr != "" {
@@ -43,7 +41,6 @@ func main() {
 		if Config.ServerAddress == "" {
 			Config.ServerAddress = client.DefaultServerAddress
 		}
-		fmt.Println("Server: " + Config.ServerAddress)
 		AMP = client.NewAMP(&Config)
 		AMP.Connect()
 		cli.AtExit(func() {
@@ -62,7 +59,16 @@ func main() {
 			fmt.Println(Config)
 		},
 	}
-
+	// infoCmd represents the amp information
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Display amp version and server information",
+		Long:  `Display amp version and server information.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
+			fmt.Printf("Server: %s\n", Config.ServerAddress)
+		},
+	}
 	RootCmd.SetUsageTemplate(usageTemplate)
 	RootCmd.SetHelpTemplate(helpTemplate)
 
@@ -70,6 +76,7 @@ func main() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `Verbose output`)
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "Server address")
 	RootCmd.AddCommand(configCmd)
+	RootCmd.AddCommand(infoCmd)
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		cli.Exit(-1)

--- a/cmd/amp/stack.go
+++ b/cmd/amp/stack.go
@@ -82,7 +82,7 @@ func init() {
 	RootCmd.AddCommand(StackCmd)
 	flags := upCmd.Flags()
 	flags.StringVarP(&stackfile, "file", "f", stackfile, "The name of the stackfile")
-	rmCmd.Flags().Bool("force", false, "Remove the stack whatever condition")
+	rmCmd.Flags().BoolP("force", "f", false, "Remove the stack whatever condition")
 	listCmd.Flags().BoolP("quiet", "q", false, "return only stack id to be use with grep")
 	StackCmd.AddCommand(upCmd)
 	StackCmd.AddCommand(startCmd)
@@ -186,18 +186,20 @@ func remove(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	if cmd.Flag("force").Value.String() == "true" {
 		force = true
 	}
-	request := &stack.RemoveRequest{
-		StackIdent: ident,
-		Force:      force,
-	}
+	for _, stackIdent := range args {
+		request := &stack.RemoveRequest{
+			StackIdent: stackIdent,
+			Force:      force,
+		}
 
-	client := stack.NewStackServiceClient(amp.Conn)
-	reply, err := client.Remove(context.Background(), request)
-	if err != nil {
-		return err
-	}
+		client := stack.NewStackServiceClient(amp.Conn)
+		reply, err := client.Remove(context.Background(), request)
+		if err != nil {
+			return err
+		}
 
-	fmt.Println(reply)
+		fmt.Println(reply.StackId)
+	}
 	return nil
 }
 

--- a/swarm
+++ b/swarm
@@ -334,7 +334,7 @@ haproxy() { # Owner: freignat91
     --label amp.swarm="infrastructure" \
     -p 8080:8080 \
     -p 80:80 \
-    appcelerator/haproxy:latest
+    appcelerator/haproxy:test2
 }
 
 


### PR DESCRIPTION
add command: amp ls -q
to list the available stack id
can be use with amp rm to remove all stacks using:
amp stack rm -f $(amp stack ls -q)

added command amp info to display amp version
amp version is not anymore displayed at each command (not compatible with grep usage)

test: make test
