### PR TITLE
add env in service

### DIFF
--- a/api/rpc/service/service.go
+++ b/api/rpc/service/service.go
@@ -92,6 +92,15 @@ func CreateService(docker *client.Client, ctx context.Context, req *ServiceCreat
 		},
 		EndpointSpec: nil, // &EndpointSpec
 	}
+	//add env
+	if serv.Env != nil {
+		service.TaskTemplate.ContainerSpec.Env = make([]string, len(serv.Env))
+		i := 0
+		for key, val := range serv.Env {
+			service.TaskTemplate.ContainerSpec.Env[i] = fmt.Sprintf("%s=%s", key, val)
+			i++
+		}
+	}
 	//add common labels
 	if service.Annotations.Labels == nil {
 		service.Annotations.Labels = make(map[string]string)


### PR DESCRIPTION
#235

add env variable in service creation
translated the map[string]string of the service.ptoto to []string of swarm.ServiceSpec

test: make test
