### PR TITLE
Service labels

### DIFF
--- a/api/rpc/service/service.go
+++ b/api/rpc/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -30,15 +29,12 @@ func init() {
 	docker, err = client.NewClient(dockerSock, defaultVersion, nil, defaultHeaders)
 	if err != nil {
 		// fail fast
-		log.Println("new client ....")
 		panic(err)
 	}
 }
 
 // Create implements ServiceServer
 func (s *Service) Create(ctx context.Context, req *ServiceCreateRequest) (*ServiceCreateResponse, error) {
-	log.Println(req)
-
 	// TODO: pass-through right now, but will be refactored into a helper library
 	response, err := CreateService(docker, ctx, req)
 	return response, err
@@ -48,11 +44,10 @@ func (s *Service) Create(ctx context.Context, req *ServiceCreateRequest) (*Servi
 func CreateService(docker *client.Client, ctx context.Context, req *ServiceCreateRequest) (*ServiceCreateResponse, error) {
 
 	serv := req.ServiceSpec
-	//prepare swarm.ServiceSpec full instance
 	service := swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   serv.Name,
-			Labels: make(map[string]string),
+			Labels: serv.Labels,
 		},
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: swarm.ContainerSpec{
@@ -96,7 +91,7 @@ func CreateService(docker *client.Client, ctx context.Context, req *ServiceCreat
 	// add environment
 	service.TaskTemplate.ContainerSpec.Env = serv.Env
 
-	//add common labels
+	// ensure supplied service label map is not nil, then add custom amp labels
 	if service.Annotations.Labels == nil {
 		service.Annotations.Labels = make(map[string]string)
 	}

--- a/api/rpc/stack/test_samples/sample-05-labels.yml
+++ b/api/rpc/stack/test_samples/sample-05-labels.yml
@@ -1,0 +1,7 @@
+pinger:
+  image: appcelerator/pinger
+  label:
+    - "foo=bar"
+  public:
+    - publish_port: 3000
+      internal_port: 3000

--- a/api/rpc/stack/test_samples/sample-05-labels.yml
+++ b/api/rpc/stack/test_samples/sample-05-labels.yml
@@ -1,6 +1,6 @@
 pinger:
   image: appcelerator/pinger
-  label:
+  labels:
     - "foo=bar"
   public:
     - publish_port: 3000

--- a/api/rpc/stack/test_samples/sample-06-labels.yml
+++ b/api/rpc/stack/test_samples/sample-06-labels.yml
@@ -1,0 +1,7 @@
+pinger:
+  image: appcelerator/pinger
+  label:
+    foo: bar
+  public:
+    - publish_port: 3000
+      internal_port: 3000

--- a/api/rpc/stack/test_samples/sample-06-labels.yml
+++ b/api/rpc/stack/test_samples/sample-06-labels.yml
@@ -1,6 +1,6 @@
 pinger:
   image: appcelerator/pinger
-  label:
+  labels:
     foo: bar
   public:
     - publish_port: 3000

--- a/api/rpc/stack/test_samples/sample-07-env.yml
+++ b/api/rpc/stack/test_samples/sample-07-env.yml
@@ -1,0 +1,7 @@
+pinger:
+  image: appcelerator/pinger
+  env:
+    - "foo=bar"
+  public:
+    - publish_port: 3000
+      internal_port: 3000

--- a/api/rpc/stack/test_samples/sample-08-env.yml
+++ b/api/rpc/stack/test_samples/sample-08-env.yml
@@ -1,0 +1,7 @@
+pinger:
+  image: appcelerator/pinger
+  env:
+    foo: bar
+  public:
+    - publish_port: 3000
+      internal_port: 3000


### PR DESCRIPTION
Closes #248 

Adds service label option to CLI `service create` command, cleans up related service/stack code, updates test stackfiles.
## Verification

Merge #244 first

```
$ make test

$ make install
# start amplifier
$ amp service create -l foo=bar --label hello=world --name pinger appcelerator/pinger
# verify labels [foo:bar, hello:world]
$ docker service inspect -f '{{ .Spec.Labels }}' pinger
$ docker service rm pinger
```
