### PR TITLE
Added reference to new version of configuration URL 0.2.1

### DIFF
--- a/swarm
+++ b/swarm
@@ -309,7 +309,7 @@ kapacitor() { # Owner: ndegory
     -e OUTPUT_SLACK_CHANNEL=kapacitor-test \
     -e OUTPUT_SLACK_GLOBAL="true" \
     -e OUTPUT_SLACK_STATE_CHANGE_ONLY="true" \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/0.2.0.tar.gz" \
+    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/0.2.1.tar.gz" \
     appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
 }
 


### PR DESCRIPTION
Fixes #261 
- Added new field entries to the tick files and created new release for:
  `"https://github.com/appcelerator/amp-config/archive/0.2.1.tar.gz"`
## Verification

`sudo ./swarm up`
### kapacitor-alert channel should have a name after the `AMP/` :

`AMP/<some-swarm-service>/docker_container_cpu ...`
