### PR TITLE
fix issues 272 and 273

### DIFF
--- a/api/rpc/stack/parse.go
+++ b/api/rpc/stack/parse.go
@@ -96,8 +96,8 @@ func ParseStackfile(ctx context.Context, in string) (stack *Stack, err error) {
 		replicas := spec.Replicas
 		mode := spec.Mode
 
-		// supply a default value for mode only if it is empty and replicas is positive
-		if mode == "" && replicas > 0 {
+		// supply a default value for mode
+		if mode == "" {
 			mode = "replicated"
 		}
 

--- a/api/rpc/stack/test_samples/sample-05-1-env.yml
+++ b/api/rpc/stack/test_samples/sample-05-1-env.yml
@@ -1,6 +1,6 @@
 pinger:
   image: appcelerator/pinger
-  env:
+  environment:
     - "foo=bar"
   public:
     - publish_port: 3000

--- a/api/rpc/stack/test_samples/sample-05-2-env.yml
+++ b/api/rpc/stack/test_samples/sample-05-2-env.yml
@@ -1,6 +1,6 @@
 pinger:
   image: appcelerator/pinger
-  env:
+  environment:
     foo: bar
   public:
     - publish_port: 3000


### PR DESCRIPTION
related to #272 and #273
issue 272:  fix sample-05-1-env and sample-05-2-env syntax
issue 273: replicas not mandatory anymore in stack file syntax

test:
- make install (after rm -rf vendor and glide install)
- start amp: sudo ./swarm start
- launch local amplifier
- amp stack up test1 -f api/rpc/stack/test_samples/sample-05-1-env.yml
- docker ps | grep test1-pinger (get containerId)
- docker exec -it [containerId] sh
- inside container: execute: set
- see the variable foo = bar
- amp stack rm -f test1
- amp stack up test2 -f api/rpc/stack/test_samples/sample-05-2-env.yml
- docker ps | grep test2-pinger (get containerId)
- docker exec -it [containerId] sh
- inside container: execute: set
- see the variable foo = bar

regression test:
- make test
