### PR TITLE
Creating ~/registry/data folder in order to avoid log flooding

### DIFF
--- a/swarm
+++ b/swarm
@@ -117,6 +117,7 @@ main() {
   else
     case $1 in
       start)
+        mkdir -p ~/registry/data
         initswarm
         createnetwork
         startservices "${@:2}"


### PR DESCRIPTION
# Verification

```
$ rm -rf ~/registry/data
$ ./swarm start
```

Verify that the `~/registry/data` folder is created.
