### PR TITLE
add registry ls and auto tag

### DIFF
--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -55,7 +55,7 @@ func init() {
 	RegCmd.AddCommand(reglsCmd)
 }
 
-// RegistryPush displays resource usage statistcs
+// RegistryPush displays resource usage statistics
 func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	_, err := amp.GetAuthorizedContext()
 	if err != nil {
@@ -76,7 +76,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	if !strings.HasPrefix(image, "registry."+domain) {
 		nn := strings.Index(image, "/")
 		if (nn < 0) {
-			return fmt.Errorf("Invalide image name %s", image)
+			return fmt.Errorf("Invalid image name %s", image)
 		}
 		taggedImage = "registry."+domain+"/"+image[nn+1:]
 		fmt.Printf("Tag image from %s to %s\n", image, taggedImage)
@@ -99,7 +99,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	return err
 }
 
-// RegistryPush displays resource usage statistcs: localhost:5000/v2/_catalog
+// RegistryPush displays resource usage statistics: localhost:5000/v2/_catalog
 func RegistryLs(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	_, err := amp.GetAuthorizedContext()
 	if err != nil {

--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -5,25 +5,54 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
+	"net/http"
+	"io/ioutil"
 
 	"github.com/appcelerator/amp/api/client"
 	"github.com/spf13/cobra"
 )
 
-var pushCmd = &cobra.Command{
-	Use:   "push",
-	Short: "Push an image in the amp registry",
-	Long:  `Push an image to the amp registry`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RegistryPush(AMP, cmd, args)
-		if err != nil {
-			fmt.Println(err)
-		}
-	},
+// Registry is the main command for attaching registry subcommands.
+var RegCmd = &cobra.Command{
+	Use:   "registry operations",
+	Short: "Registry operations",
+	Long:  `Manage registry-related operations.`,
 }
 
+var (
+	domain = "local.appcelerator.io"
+	pushCmd = &cobra.Command{
+		Use:   "push [image]",
+		Short: "Push an image to the amp registry",
+		Long:  `Push an image to the amp registry`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := RegistryPush(AMP, cmd, args)
+			if err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+	reglsCmd = &cobra.Command{
+		Use:   "ls",
+		Short: "List the amp registry images",
+		Long:  `List the amp registry images`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := RegistryLs(AMP, cmd, args)
+			if err != nil {
+				fmt.Println(err)
+			}
+		},
+	}	
+)
+
+
+
 func init() {
-	RootCmd.AddCommand(pushCmd)
+	RootCmd.AddCommand(RegCmd)
+	pushCmd.Flags().StringVar(&domain, "domain", domain, "The amp domain")
+	RegCmd.AddCommand(pushCmd)
+	RegCmd.AddCommand(reglsCmd)
 }
 
 // RegistryPush displays resource usage statistcs
@@ -43,13 +72,46 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	if err = validateRegistryImage(image); err != nil {
 		return err
 	}
-	cmdexe := exec.Command("docker", "push", image)
+	taggedImage := image
+	if !strings.HasPrefix(image, "registry."+domain) {
+		nn := strings.Index(image, "/")
+		if (nn < 0) {
+			return fmt.Errorf("Invalide image name %s", image)
+		}
+		taggedImage = "registry."+domain+"/"+image[nn+1:]
+		fmt.Printf("Tag image from %s to %s\n", image, taggedImage)
+		cmdexe := exec.Command("docker", "tag", image, taggedImage)
+		cmdexe.Stdout = os.Stdout
+		cmdexe.Stderr = os.Stderr
+		err = cmdexe.Run()
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("push image %s\n", taggedImage)
+	cmdexe := exec.Command("docker", "push", taggedImage)
 	cmdexe.Stdout = os.Stdout
 	cmdexe.Stderr = os.Stderr
 	err = cmdexe.Run()
 	if err != nil {
 		return err
 	}
+	return err
+}
+
+// RegistryPush displays resource usage statistcs: localhost:5000/v2/_catalog
+func RegistryLs(amp *client.AMP, cmd *cobra.Command, args []string) error {
+	_, err := amp.GetAuthorizedContext()
+	if err != nil {
+		return err
+	}
+	resp, err := http.Get("http://registry."+domain+"/v2/_catalog")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	fmt.Println(string(body))
 	return err
 }
 


### PR DESCRIPTION
to make easier the `amp push usage` to be able to push any images included the ones with different domain name:
- amp registry push [image] --domain [app domain]  
- amp registry ls

by default the app domain is `local.amplifier.io`
the domain allow to re-tag automatically if needed the image with the amp domain name.
For instance:

amp registry push appcelerator/pinger:latest
will push the image registry.local.appelerator.io/pinger:latest in the amp registry
(with auto tag from appcelerator/... to registry.local.appcelerator.io/...)

test:
- build amp: rm -rf vendor && glide install && make install
- start amp: sudo ./swarm start
- start local amplifier
- push image: amp registry push appcelerator/pinger:latest
- verify ok: amp registry ls
- display: {"repositories":["pinger"]}

the services using the amp registry image should use by default the host: 
`registry.local.appcelerator.io`
so for instance in stack file:

```
pinger:
   image: registry.local.appcelerator.io/pinger:latest
...
```
