### PR TITLE
Revert "fix issue #302"

### DIFF
--- a/swarm
+++ b/swarm
@@ -245,7 +245,8 @@ ls() {
 
 monitor() {
   interval=${1:-5}
-  clear; while true; do tput cup 0 0; docker service ls; sleep $interval; done
+  # will cause a screen flash, but `tput ed` doesn't work on the mac
+  while true; do clear; docker service ls; tput cup 0 0; sleep $interval; done
 }
 
 registry() { # Owner: freignat91

--- a/swarm
+++ b/swarm
@@ -245,7 +245,7 @@ ls() {
 
 monitor() {
   interval=${1:-5}
-  while true; do tput cup 0 0; tput ed; docker service ls; sleep $interval; done
+  clear; while true; do tput cup 0 0; docker service ls; sleep $interval; done
 }
 
 registry() { # Owner: freignat91


### PR DESCRIPTION
Reverts appcelerator/amp#303

@bertrand-quenin @hagantzer This is broken on the Mac (`tput ed`). Anyway, no point in homing the cursor and then clearing to the end of the terminal screen -- that's basically `tput clear` (or just `clear`). I can probably get clear to end of the screen working with just raw terminal codes. Reverting this for now and will experiment a bit.

Also closes #309 which was just got created.
