### PR TITLE
add telegraf service and grafana dashboard for haproxy stats

### DIFF
--- a/swarm
+++ b/swarm
@@ -10,8 +10,10 @@
 set -euo pipefail
 # INFLUXDATA_VERSION should be the Major.minor version, e.g 0.13 or 1.0
 INFLUXDATA_VERSION=1.0
-ETCD_VERSION=3.0.10
+ETCD_VERSION=3.0
 NATS_VERSION=latest
+HAPROXY_VERSION=1.0.1
+TICK_CONFIG_VERSION=0.3.0
 
 # please keep sorted
 IMAGES=(
@@ -21,7 +23,7 @@ IMAGES=(
   appcelerator/amp-ui:latest
   appcelerator/elasticsearch-amp:latest
   appcelerator/grafana:latest
-  appcelerator/haproxy:1.0.1
+  appcelerator/haproxy:${HAPROXY_VERSION}
   appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
   appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
   appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
@@ -58,6 +60,7 @@ SERVICES=(
   kapacitor
   nats
   telegrafagent
+  telegrafhaproxy
   registry
 )
 
@@ -305,7 +308,7 @@ grafana() { # Owner: ndegory
     -e INFLUXDB_HOST=influxdb \
     -e INFLUXDB_PASS=changeme \
     -e FORCE_HOSTNAME=auto \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/0.2.0.tar.gz" \
+    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
     appcelerator/grafana:latest
 }
 
@@ -316,7 +319,7 @@ influxdb() { # Owner: ndegory
     -p 8083:8083 \
     -e FORCE_HOSTNAME=auto \
     -e PRE_CREATE_DB=telegraf \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/0.2.0.tar.gz" \
+    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
     appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
 }
 
@@ -331,7 +334,7 @@ kapacitor() { # Owner: ndegory
     -e OUTPUT_SLACK_CHANNEL=kapacitor-test \
     -e OUTPUT_SLACK_GLOBAL="true" \
     -e OUTPUT_SLACK_STATE_CHANGE_ONLY="true" \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/0.2.1.tar.gz" \
+    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
     appcelerator/kapacitor:kapacitor-${INFLUXDATA_VERSION}
 }
 
@@ -340,7 +343,7 @@ haproxy() { # Owner: freignat91
     --label io.amp.role="infrastructure" \
     -p 8080:8080 \
     -p 80:80 \
-    appcelerator/haproxy:1.0.1
+    appcelerator/haproxy:${HAPROXY_VERSION}
 }
 
 nats() { # Owner: bertrand-quenin
@@ -368,10 +371,32 @@ telegrafagent() { # Owner: ndegory
     -e INPUT_PROCESS_ENABLED=true \
     -e INPUT_SWAP_ENABLED=true \
     -e INPUT_SYSTEM_ENABLED=true \
+    -e INPUT_NET_ENABLED=true \
+    -e INPUT_HAPROXY_ENABLED=false \
     -e INFLUXDB_TIMEOUT=20 \
     --mount type=bind,source=/var/run/utmp,target=/var/run/utmp \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
 }
 
+telegrafhaproxy() { # Owner: ndegory
+  docker service create --with-registry-auth --network amp-infra --name telegraf-haproxy \
+    --label io.amp.role="infrastructure" \
+    -e OUTPUT_INFLUXDB_ENABLED=true \
+    -e INFLUXDB_URL=http://influxdb:8086 \
+    -e INPUT_DOCKER_ENABLED=false \
+    -e INPUT_CPU_ENABLED=false \
+    -e INPUT_NET_ENABLED=false \
+    -e INPUT_DISK_ENABLED=false \
+    -e INPUT_DISKIO_ENABLED=false \
+    -e INPUT_KERNEL_ENABLED=false \
+    -e INPUT_MEM_ENABLED=false \
+    -e INPUT_PROCESS_ENABLED=false \
+    -e INPUT_SWAP_ENABLED=false \
+    -e INPUT_SYSTEM_ENABLED=false \
+    -e INPUT_HAPROXY_ENABLED=true \
+    -e INPUT_HAPROXY_SERVER=http://haproxy:8082/admin?stats \
+    -e INFLUXDB_TIMEOUT=20 \
+    appcelerator/telegraf:telegraf-${INFLUXDATA_VERSION}
+}
 main $@


### PR DESCRIPTION
Warning: https://github.com/appcelerator/docker-haproxy/pull/2 (stats listener updates for haproxy:1.0.1) should be merged before this one.
- new telegraf-haproxy service, gathering stats from the haproxy service
- new Grafana dashboard for Haproxy stats

How to test:
$ swarm pull
$ swarm start
$ swarm monitor
once all services are up, connect to grafana (localhost:6001), authenticate with the admin login, and check the Load Balancer dashboard, data should be displayed.
