### PR TITLE
Add stack volume support

### DIFF
--- a/api/rpc/stack/parse.go
+++ b/api/rpc/stack/parse.go
@@ -263,6 +263,7 @@ func copyServices(stack *Stack, specs map[string]serviceSpec, networkMap map[str
 			Labels:          labels,
 			ContainerLabels: containerLabels,
 			Networks:        networkAttachment,
+			Mounts:          spec.Mounts,
 		})
 	}
 	return nil

--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -303,8 +303,13 @@ func (s *Server) isNetworkExit(ctx context.Context, name string) (string, bool) 
 	if err != nil || len(list) == 0 {
 		return "", false
 	}
-	fmt.Printf("Network %s exists, reuse it\n", name)
-	return list[0].ID, true
+	for _, net := range list {
+		if net.Name == name {
+			fmt.Printf("Network %s exists, reuse it\n", name)
+			return net.ID, true
+		}
+	}
+	return "", false
 }
 
 // create the private stack network and if needed the public stack network

--- a/api/rpc/stack/test_samples/sample-14.yml
+++ b/api/rpc/stack/test_samples/sample-14.yml
@@ -1,0 +1,9 @@
+services:
+  pinger:
+    image: appcelerator/pinger
+    replicas: 1
+    volumes:
+      - /tmp2
+
+
+

--- a/api/rpc/stack/test_samples/sample-15.yml
+++ b/api/rpc/stack/test_samples/sample-15.yml
@@ -1,0 +1,9 @@
+services:
+  pinger:
+    image: appcelerator/pinger
+    replicas: 1
+    volumes:
+      - /tmp:/tmp2
+
+
+

--- a/api/rpc/stack/test_samples/sample-16.yml
+++ b/api/rpc/stack/test_samples/sample-16.yml
@@ -1,0 +1,9 @@
+services:
+  pinger:
+    image: appcelerator/pinger
+    replicas: 1
+    volumes:
+      - myvolume:/tmp2
+
+
+


### PR DESCRIPTION
related to Engage team request: #354 

add volume management in stack file

test:
- make install
  - ./swarm start

test 1: create service with internal volume 
- amp stack up test1 -f  api/rpc/stack/test_samples/sample-14.yml
- docker ps | grep test1.pinger  -> get the id
- docker exec -it [id] sh
- cd /tmp2  : to verify that we well have a dir /tmp2 in the container created by the volume

test 2: create service with volume linked to host directory
- amp stack up test2 -f  api/rpc/stack/test_samples/sample-15.yml
- docker ps | grep test2.pinger  -> get the id
- docker exec -it [id] sh
- ls /tmp2  :  list the host /tmp files

test 3: create service with a named volume 
- amp stack up test3 -f  api/rpc/stack/test_samples/sample-16.yml
- docker volume ls -> show "myvolume" in the list
- docker ps | grep test3.pinger  -> get the id
- docker exec -it [id] sh
- cd /tmp2  :  to verify that we well have a dir /tmp2 in the container created by the volume
