### PR TITLE
Added more CLI tests

### DIFF
--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -14,12 +15,14 @@ import (
 type TestSpec struct {
 	fileName string
 	contents []byte
+	valid    bool
 }
 
-type commandSpec struct {
-	Cmd     string   `yaml:"cmd"`
-	Args    []string `yaml:"args"`
-	Options []string `yaml:"options"`
+type CommandSpec struct {
+	Cmd         string   `yaml:"cmd"`
+	Args        []string `yaml:"args"`
+	Options     []string `yaml:"options"`
+	Expectation string   `yaml:"expectation"`
 }
 
 var (
@@ -34,7 +37,9 @@ func TestMain(t *testing.T) {
 func TestCmds(t *testing.T) {
 	tests := loadFiles(t)
 	for _, test := range tests {
-		parse(t, test)
+		t.Log("-----------------------------------------------------------------------------------------")
+		t.Logf("test %s\n", test.fileName)
+		parseCmd(t, test)
 	}
 }
 
@@ -48,6 +53,10 @@ func loadFiles(t *testing.T) []*TestSpec {
 	for _, f := range files {
 		name := f.Name()
 		t.Log("Loading file:", name)
+		valid := false
+		if !strings.HasPrefix(name, "00-") {
+			valid = true
+		}
 		contents, err := ioutil.ReadFile(path.Join(testDir, name))
 		if err != nil {
 			t.Errorf("unable to load test sample: %s. Error: %v", name, err)
@@ -55,53 +64,83 @@ func loadFiles(t *testing.T) []*TestSpec {
 		testSpec := &TestSpec{
 			fileName: name,
 			contents: contents,
+			valid:    valid,
 		}
 		tests = append(tests, testSpec)
 	}
 	return tests
 }
 
-func parse(t *testing.T, test *TestSpec) {
-	commandMap, err := parseCommandMap(test.contents)
+func parseCmd(t *testing.T, test *TestSpec) {
+	commandMap, err := generateCmdSpec(test.contents)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	for _, spec := range commandMap {
-		cmdSplit := strings.Fields(spec.Cmd)
-		optionsSplit := []string{}
-		for _, val := range spec.Options {
-			optionsSplit = append(optionsSplit, strings.Fields(val)...)
+	for _, cmdSpec := range commandMap {
+		cmdString := generateCmdString(cmdSpec)
+		t.Log(cmdString, "Command passed.")
+		for i := 0; i < 10; i++ {
+			t.Log(cmdString, "Running...")
+			t.Log(cmdString, "Iteration:", i+1)
+			result, err := runCmd(cmdString)
+			validID := regexp.MustCompile(cmdSpec.Expectation)
+			if test.valid == false {
+				if err == nil {
+					t.Log(cmdString, "Error:", err)
+					t.Log(cmdString, "Invalid Sample Command has failed, retrying.")
+					time.Sleep(1 * time.Second)
+				} else {
+					if !validID.MatchString(string(result)) {
+						t.Log(cmdString, "Error: miss matched expectation")
+						t.Fail()
+						break
+					}
+					t.Log(cmdString, "Invalid Sample Command result:\n", string(result))
+					break
+				}
+			} else {
+				if err != nil {
+					t.Log(cmdString, "Error:", err)
+					t.Log(cmdString, "Command failed, retrying.")
+					time.Sleep(1 * time.Second)
+				} else {
+					if !validID.MatchString(string(result)) {
+						t.Log(cmdString, "Error: miss matched expectation")
+						t.Fail()
+						break
+					}
+					t.Log(cmdString, "Command result:\n", string(result))
+					break
+				}
+			}
+			if i >= 9 {
+				t.Log(cmdString, "Error:", err)
+				t.Log(cmdString, "Command has failed, exiting.")
+				t.Fail()
+			}
 		}
-		commandFinal := append(cmdSplit, spec.Args...)
-		commandFinal = append(commandFinal, optionsSplit...)
-		t.Log(commandFinal, "Command passed.")
-		runCmd(t, commandFinal)
 	}
 }
 
-func runCmd(t *testing.T, cmdString []string) {
-	t.Log(cmdString, "Running...")
-	for i := 0; i < 10; i++ {
-		t.Log(cmdString, " Iteration:", i+1)
-		cmd := exec.Command(cmdString[0], cmdString[1:]...)
-		result, err := cmd.CombinedOutput()
-		if err != nil && i >= 9 {
-			t.Log(cmdString, " Error:", err)
-			t.Log(cmdString, " Command has failed, exiting.")
-			t.Fail()
-		} else if err != nil {
-			t.Log(cmdString, " Error:", err)
-			t.Log(cmdString, " Command failed, retrying.")
-			time.Sleep(1 * time.Second)
-		} else {
-			t.Log(cmdString, " Command result:\n", string(result))
-			break
-		}
-	}
-}
-
-func parseCommandMap(b []byte) (out map[string]commandSpec, err error) {
+func generateCmdSpec(b []byte) (out map[string]CommandSpec, err error) {
 	err = yaml.Unmarshal(b, &out)
+	return
+}
+
+func generateCmdString(cmdSpec CommandSpec) (cmdString []string) {
+	cmdSplit := strings.Fields(cmdSpec.Cmd)
+	optionsSplit := []string{}
+	for _, val := range cmdSpec.Options {
+		optionsSplit = append(optionsSplit, strings.Fields(val)...)
+	}
+	cmdString = append(cmdSplit, cmdSpec.Args...)
+	cmdString = append(cmdString, optionsSplit...)
+	return
+}
+
+func runCmd(cmdString []string) (result []byte, err error) {
+	cmd := exec.Command(cmdString[0], cmdString[1:]...)
+	result, err = cmd.CombinedOutput()
 	return
 }

--- a/cmd/amp/cli/test_samples/00-invalid-sample-01.yml
+++ b/cmd/amp/cli/test_samples/00-invalid-sample-01.yml
@@ -1,8 +1,8 @@
-create-service:
-  cmd: amp service create
+invalid-sample:
+  cmd: amp service creat
   args:
     - appcelerator/pinger
   options:
     - --name pinger
     - -p www:90:3000
-  expectation: ([a-z0-9]{25})
+  expectation:

--- a/cmd/amp/cli/test_samples/00-invalid-sample-02.yml
+++ b/cmd/amp/cli/test_samples/00-invalid-sample-02.yml
@@ -1,0 +1,6 @@
+invalid-sample:
+  cmd: curl
+  args:
+    - localhost:90/ping
+  options:
+  expectation:

--- a/cmd/amp/cli/test_samples/02-list-service.yml
+++ b/cmd/amp/cli/test_samples/02-list-service.yml
@@ -2,3 +2,4 @@ list-service:
   cmd: docker service ls
   args:
   options:
+  expectation: ((ID)(\s)+(NAME)(\s)+(REPLICAS)(\s)+(IMAGE)(\s)+(COMMAND)((.)|(\s))+(pinger)(.)+(appcelerator/pinger)(\s)+(.)*)

--- a/cmd/amp/cli/test_samples/03-curl-service.yml
+++ b/cmd/amp/cli/test_samples/03-curl-service.yml
@@ -3,3 +3,4 @@ curl-service:
   args:
     - localhost:90/ping
   options:
+  expectation: ((.)|(\s))*(pong)((.)|(\s))*

--- a/cmd/amp/cli/test_samples/04-remove-service.yml
+++ b/cmd/amp/cli/test_samples/04-remove-service.yml
@@ -3,7 +3,9 @@ remove-service:
   args:
     - pinger
   options:
+  expectation: (pinger)
 list-service:
   cmd: docker service ls
   args:
   options:
+  expectation: ((ID)(\s)+(NAME)(\s)+(REPLICAS)(\s)+(IMAGE)(\s)+(COMMAND)((.)|(\s))+)

--- a/cmd/amp/cli/test_samples/05-create-stack.yml
+++ b/cmd/amp/cli/test_samples/05-create-stack.yml
@@ -1,0 +1,7 @@
+create-stack:
+  cmd: amp stack up
+  args:
+  options:
+     - -f ../../../api/rpc/stack/test_samples/sample-04.yml
+     - stack1
+  expectation: ([a-z0-9]{64})

--- a/cmd/amp/cli/test_samples/06-list-stack.yml
+++ b/cmd/amp/cli/test_samples/06-list-stack.yml
@@ -1,0 +1,5 @@
+list-stack:
+  cmd: amp stack ls
+  args:
+  options:
+  expectation: ((NAME)(\s)+(ID)(\s)+(STATE)((.)|(\s))+(stack1)(\s)+([a-z0-9]{64})(\s)+(Running)((.)|(\s))(.)*)

--- a/cmd/amp/cli/test_samples/07-stop-stack.yml
+++ b/cmd/amp/cli/test_samples/07-stop-stack.yml
@@ -1,0 +1,11 @@
+stop-stack:
+  cmd: amp stack stop
+  args:
+    - stack1
+  options:
+  expectation: ([a-z0-9]{64})
+list-stack:
+  cmd: amp stack ls
+  args:
+  options:
+  expectation: "No stack is available"

--- a/cmd/amp/cli/test_samples/08-restart-stack.yml
+++ b/cmd/amp/cli/test_samples/08-restart-stack.yml
@@ -1,0 +1,11 @@
+restart-stack:
+  cmd: amp stack restart
+  args:
+    - stack1
+  options:
+  expectation: ([a-z0-9]{64})
+list-stack:
+  cmd: amp stack ls
+  args:
+  options:
+  expectation: ((NAME)(\s)+(ID)(\s)+(STATE)((.)|(\s))+(stack1)(\s)+([a-z0-9]{64})(\s)+(Running)((.)|(\s))(.)*)

--- a/cmd/amp/cli/test_samples/09-remove-stack.yml
+++ b/cmd/amp/cli/test_samples/09-remove-stack.yml
@@ -1,0 +1,17 @@
+stop-stack:
+  cmd: amp stack stop
+  args:
+    - stack1
+  options:
+  expectation: ([a-z0-9]{64})
+remove-stack:
+  cmd: amp stack rm
+  args:
+    - stack1
+  options:
+  expectation: ([a-z0-9]{64})
+list-stack:
+  cmd: amp stack ls
+  args:
+  options:
+  expectation: "No stack is available"

--- a/cmd/amp/cli/test_samples/10-cpu-stats.yml
+++ b/cmd/amp/cli/test_samples/10-cpu-stats.yml
@@ -1,0 +1,7 @@
+cpu-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --cpu
+  expectation: ((Service name)(\s)+(CPU %%)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/11-mem-stats.yml
+++ b/cmd/amp/cli/test_samples/11-mem-stats.yml
@@ -1,0 +1,7 @@
+mem-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --mem
+  expectation: ((Service name)(\s)+(Mem usage)(\s)+(Mem %%)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/12-io-stats.yml
+++ b/cmd/amp/cli/test_samples/12-io-stats.yml
@@ -1,0 +1,7 @@
+io-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --io
+  expectation: ((Service name)(\s)+(Disk IO read/write)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/13-task-stats.yml
+++ b/cmd/amp/cli/test_samples/13-task-stats.yml
@@ -1,0 +1,7 @@
+task-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --task
+  expectation: ((Service name)(\s)+(Task name)(\s)+(Node id)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/14-container-stats.yml
+++ b/cmd/amp/cli/test_samples/14-container-stats.yml
@@ -1,0 +1,7 @@
+container-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --container
+  expectation: ((Service name)(\s)+(Container name)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/15-net-stats.yml
+++ b/cmd/amp/cli/test_samples/15-net-stats.yml
@@ -1,0 +1,7 @@
+net-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --net
+  expectation: ((Service name)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/16-node-stats.yml
+++ b/cmd/amp/cli/test_samples/16-node-stats.yml
@@ -1,0 +1,7 @@
+node-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --node
+  expectation: ((Node id)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/17-service-stats.yml
+++ b/cmd/amp/cli/test_samples/17-service-stats.yml
@@ -1,0 +1,7 @@
+service-stats:
+  cmd: amp stats
+  args:
+    -
+  options:
+    - --service
+  expectation: ((Service name)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/18-stack-logs.yml
+++ b/cmd/amp/cli/test_samples/18-stack-logs.yml
@@ -1,0 +1,7 @@
+stack-logs:
+  cmd: amp logs
+  args:
+    -
+  options:
+    - --stack stack1
+  expectation:

--- a/cmd/amp/cli/test_samples/19-numbered-logs.yml
+++ b/cmd/amp/cli/test_samples/19-numbered-logs.yml
@@ -1,0 +1,7 @@
+numbered-logs:
+  cmd: amp logs
+  args:
+    -
+  options:
+    - -n 10
+  expectation:

--- a/cmd/amp/cli/test_samples/20-metadata-logs.yml
+++ b/cmd/amp/cli/test_samples/20-metadata-logs.yml
@@ -1,0 +1,7 @@
+metadata-logs:
+  cmd: amp logs
+  args:
+    -
+  options:
+    - -m
+  expectation:

--- a/cmd/amp/cli/test_samples/21-all-logs.yml
+++ b/cmd/amp/cli/test_samples/21-all-logs.yml
@@ -1,0 +1,5 @@
+all-logs:
+  cmd: amp logs
+  args:
+  options:
+  expectation:


### PR DESCRIPTION
Added more YAML files for the purpose of testing the CLI commands.
- Stack
- Stats
- Logs (No Regex yet)

`cli_test.go` file edited:
- Includes invalid sample test
- Includes expected output test using regex

YAML files include expectation for comparing output.

to test

```
go test -v ./cmd/amp/cli
```
