### PR TITLE
Regex for Logs

### DIFF
--- a/cmd/amp/cli/test_samples/08-restart-stack.yml
+++ b/cmd/amp/cli/test_samples/08-restart-stack.yml
@@ -1,5 +1,5 @@
 restart-stack:
-  cmd: amp stack restart
+  cmd: amp stack start
   args:
     - stack1
   options:

--- a/cmd/amp/cli/test_samples/19-numbered-logs.yml
+++ b/cmd/amp/cli/test_samples/19-numbered-logs.yml
@@ -4,4 +4,4 @@ numbered-logs:
     -
   options:
     - -n 10
-  expectation:
+  expectation: ([a-z0-9A-Z\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]((.)|(\s)){10})

--- a/cmd/amp/cli/test_samples/20-metadata-logs.yml
+++ b/cmd/amp/cli/test_samples/20-metadata-logs.yml
@@ -4,4 +4,4 @@ metadata-logs:
     -
   options:
     - -m
-  expectation:
+  expectation:  ((timestamp:"[0-9A-Z\.\-:\"]{1,})(\s)(time_id:"[0-9A-Z\.\-:$\"]{1,})(\s)(service_id:"[a-z0-9$\"]{1,})(\s)(service_name:"[a-z0-9$\"]{1,})(\s)(message:"[a-zA-Z\./\-0-9:\s\_\t\n\$&%?/\[\]\%\>\<\,\;$\"]{1,})(\s)(container_id:"[a-z0-9$\"]{1,})(\s)(node_id:"[a-z0-9$\"]{1,})(\s)(task_id:"[a-z0-9$\"]{1,})(\s)(task_name:"[a-z\.0-9$\"]{1,})((.)|(\s)){1,}(.)*)

--- a/cmd/amp/cli/test_samples/21-all-logs.yml
+++ b/cmd/amp/cli/test_samples/21-all-logs.yml
@@ -2,4 +2,4 @@ all-logs:
   cmd: amp logs
   args:
   options:
-  expectation:
+  expectation: ([a-z0-9A-Z\.\-:\"\s\_\t\n$&%?/\[\]\%\>\<\,\;]((.)|(\s)){1,})


### PR DESCRIPTION
Added regex for _logs_ CLI commands and updated the restart-stack.yml to use the correct command. The test however fails at times because of the order in which the commands are called. See #375 for further details.

To test
`go test ./cmd/amp/cli`
