### PR TITLE
Better regular expressions for CLI tests

### DIFF
--- a/cmd/amp/cli/test_samples/service-list.yml
+++ b/cmd/amp/cli/test_samples/service-list.yml
@@ -2,4 +2,4 @@ service-list:
   cmd: docker service ls
   args:
   options:
-  expectation: ((ID)(\s)+(NAME)(\s)+(REPLICAS)(\s)+(IMAGE)(\s)+(COMMAND)((.)|(\s))+(pinger)(.)+(appcelerator/pinger)(\s)+(.)*)
+  expectation: (?ms)ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND.+\n[a-z0-9]{12}\s+.+appcelerator/pinger

--- a/cmd/amp/cli/test_samples/stats-cpu.yml
+++ b/cmd/amp/cli/test_samples/stats-cpu.yml
@@ -4,4 +4,4 @@ stats-cpu:
     -
   options:
     - --cpu
-  expectation: ((Service name)(\s)+(CPU %%)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  expectation: (?m)Service name\s+CPU %%\s*\n-+\s*\n[a-z]+\s+[0-9\.]+%

--- a/cmd/amp/cli/test_samples/stats-io.yml
+++ b/cmd/amp/cli/test_samples/stats-io.yml
@@ -4,4 +4,4 @@ stats-io:
     -
   options:
     - --io
-  expectation: ((Service name)(\s)+(Disk IO read/write)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  expectation: (?m)Service name\s+Disk IO\s+read/write\s*\n-+\s*\n[a-z]+\s+[0-9]+.* / [0-9]+

--- a/cmd/amp/cli/test_samples/stats-mem.yml
+++ b/cmd/amp/cli/test_samples/stats-mem.yml
@@ -4,4 +4,4 @@ stats-mem:
     -
   options:
     - --mem
-  expectation: ((Service name)(\s)+(Mem usage)(\s)+(Mem %%)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  expectation: (?m)Service name\s+Mem usage\s+Mem %%\s*\n-+\s*\n[a-z]+\s+.+[1-9\.]+%

--- a/cmd/amp/cli/test_samples/stats-node.yml
+++ b/cmd/amp/cli/test_samples/stats-node.yml
@@ -4,4 +4,4 @@ stats-node:
     -
   options:
     - --node
-  expectation: ((Node id)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  expectation: (?m)Node id\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO read/write\s+Net Rx/Tx\s*\n(-|\s)+\n[a-z0-9]{25}\s+


### PR DESCRIPTION
Refs #370 

Rewrite of regexp to be more accurate

How to check:

```
swarm start
go test ./cmd/amp/cli
```

has to be rebased after #386 has been merged.
