### PR TITLE
Clean up stack code after Docker 1.12.3 release

### DIFF
--- a/api/rpc/stack/stack_test.go
+++ b/api/rpc/stack/stack_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 	"time"
+        "fmt"
 
 	"github.com/appcelerator/amp/api/rpc/stack"
 	"github.com/appcelerator/amp/api/runtime"
@@ -73,8 +74,7 @@ func TestMain(m *testing.M) {
 //Test two stacks life cycle in the same time
 func TestShouldManageStackLifeCycleSuccessfully(t *testing.T) {
 	//Start stack essai1
-	//name := fmt.Sprintf("test-%d", time.Now().Unix())
-	name := "stacktest"
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
 	//Start stack test
 	t.Log("start stack " + name)
 	rUp, errUp := client.Up(ctx, &stack.StackFileRequest{StackName: name, Stackfile: example1})
@@ -95,7 +95,6 @@ func TestShouldManageStackLifeCycleSuccessfully(t *testing.T) {
 		StackIdent: rUp.StackId,
 	}
 	//Stop stack test
-	time.Sleep(1 * time.Second)
 	t.Log("stop stack " + name)
 	rStop, errStop := client.Stop(ctx, &stackRequest)
 	if errStop != nil {
@@ -103,7 +102,6 @@ func TestShouldManageStackLifeCycleSuccessfully(t *testing.T) {
 	}
 	assert.NotEmpty(t, rStop.StackId, "Stack test StackId should not be empty")
 	//Restart stack test
-	time.Sleep(3 * time.Second)
 	t.Log("restart stack " + name)
 	rRestart, errRestart := client.Start(ctx, &stackRequest)
 	if errRestart != nil {


### PR DESCRIPTION
Hey! very good news today!!
Considering fixes in new Docker release 1.12.3 on linux and 1.12.3-rc1 on os/x:

Revert the stack updates done to lower docker 1.12.2 network issues, so:
- delete networks on stack rm.
- remove comments in code about docker 1.12.2 issue
- remove sleep and use random stack name in stack test

Test:
- start amp: ./swarm start
- execute several times: go test -v ./api/rpc/stack 

(test is faster, tested 100 times on ubuntu and os/x without docker hang)

Regression tests:
- make test

Docker 1.12.3 release note about Networking:

```
Networking

Update libnetwork #27559
Fix race in serializing sandbox to string docker/libnetwork#1495
Fix race during deletion docker/libnetwork#1503
Reset endpoint port info on connectivity revoke in bridge driver docker/libnetwork#1504
Fix a deadlock in networking code docker/libnetwork#1507
Fix a race in load balancer state docker/libnetwork#1512
```
