### PR TITLE
Cli tests fixes

### DIFF
--- a/api/server/server_utils.go
+++ b/api/server/server_utils.go
@@ -79,7 +79,7 @@ func StartTestServer() (Config, *grpc.ClientConn) {
 	go Start(config)
 
 	// Wait for swarm to be ready
-	log.Println("Waiting swarm to be ready")
+	log.Println("Waiting for swarm to be ready")
 	if err := initDependencies(config); err != nil {
 		log.Panicln("Dependencies are not ready", err)
 	}

--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -64,12 +65,17 @@ func loadTestSpecs() ([]*TestSpec, error) {
 		if err != nil {
 			return nil, err
 		}
-		tests = append(tests, test)
+		if test != nil {
+			tests = append(tests, test)
+		}
 	}
 	return tests, nil
 }
 
 func loadTestSpec(fileName string) (*TestSpec, error) {
+	if filepath.Ext(fileName) != ".yml" {
+		return nil, nil
+	}
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load test spec: %s. Error: %v", fileName, err)


### PR DESCRIPTION
cherry picks from #375 
- cosmetic fix on log message
- don't run test if test file is not a yaml file (for instance you editor of choice .swp files)
