### PR TITLE
Use AMP images for TICK stack

### DIFF
--- a/swarm
+++ b/swarm
@@ -39,7 +39,7 @@ IMAGES=(
 MINIMAGES=(
   appcelerator/amp:${AMP_VERSION}
   appcelerator/elasticsearch-amp:${ELASTICSEARCH_VERSION}
-  appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
+  appcelerator/influxdb-amp:${INFLUXDATA_VERSION}
   appcelerator/telegraf:telegraf-${TELEGRAF_VERSION}
   registry:2.5.1
   appcelerator/etcd:${ETCD_VERSION}

--- a/swarm
+++ b/swarm
@@ -10,10 +10,10 @@
 set -euo pipefail
 AMP_VERSION=latest
 UI_VERSION=0.2.0
-INFLUXDATA_VERSION=1.0.2
-KAPACITOR_VERSION=1.0.2-1
+INFLUXDATA_VERSION=1.0.0
+KAPACITOR_VERSION=1.0.0
 TELEGRAF_VERSION=1.0.1
-GRAFANA_VERSION=3.1.1-1
+GRAFANA_VERSION=1.0.0
 ELASTICSEARCH_VERSION=2.3.3
 ETCD_VERSION=3.1.0-rc.0
 NATS_VERSION=0.3.0
@@ -25,10 +25,10 @@ IMAGES=(
   appcelerator/amp:${AMP_VERSION}
   appcelerator/amp-ui:${UI_VERSION}
   appcelerator/elasticsearch-amp:${ELASTICSEARCH_VERSION}
-  appcelerator/grafana:grafana-${GRAFANA_VERSION}
+  appcelerator/grafana-amp:${GRAFANA_VERSION}
   appcelerator/haproxy:${HAPROXY_VERSION}
-  appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
-  appcelerator/kapacitor:kapacitor-${KAPACITOR_VERSION}
+  appcelerator/influxdb-amp:${INFLUXDATA_VERSION}
+  appcelerator/kapacitor-amp:${KAPACITOR_VERSION}
   appcelerator/telegraf:telegraf-${TELEGRAF_VERSION}
   registry:2.5.1
   appcelerator/etcd:${ETCD_VERSION}
@@ -309,11 +309,7 @@ grafana() { # Owner: ndegory
   docker service create --with-registry-auth --network amp-infra --name grafana \
     --label io.amp.role="infrastructure" \
     -p 6001:3000 \
-    -e INFLUXDB_HOST=influxdb \
-    -e INFLUXDB_PASS=changeme \
-    -e FORCE_HOSTNAME=auto \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
-    appcelerator/grafana:grafana-${GRAFANA_VERSION}
+    appcelerator/grafana-amp:${GRAFANA_VERSION}
 }
 
 influxdb() { # Owner: ndegory
@@ -321,10 +317,7 @@ influxdb() { # Owner: ndegory
     --label io.amp.role="infrastructure" \
     -p 8086:8086 \
     -p 8083:8083 \
-    -e FORCE_HOSTNAME=auto \
-    -e PRE_CREATE_DB=telegraf \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
-    appcelerator/influxdb:influxdb-${INFLUXDATA_VERSION}
+    appcelerator/influxdb-amp:${INFLUXDATA_VERSION}
 }
 
 kapacitor() { # Owner: ndegory
@@ -341,12 +334,8 @@ kapacitor() { # Owner: ndegory
   fi
   docker service create --with-registry-auth --network amp-infra --name kapacitor \
     --label io.amp.role="infrastructure" \
-    -e INFLUXDB_URL=http://influxdb:8086 \
-    -e KAPACITOR_HOSTNAME=auto \
-    -e SUBSCRIPTION_PROTOCOL="udp" \
-    -e CONFIG_ARCHIVE_URL="https://github.com/appcelerator/amp-config/archive/${TICK_CONFIG_VERSION}.tar.gz" \
     $SLACK_OPTIONS \
-    appcelerator/kapacitor:kapacitor-${KAPACITOR_VERSION}
+    appcelerator/kapacitor-amp:${KAPACITOR_VERSION}
 }
 
 haproxy() { # Owner: freignat91


### PR DESCRIPTION
- Using AMP images instead of the generic ones for influxdb, kapacitor and grafana

How to test:
- swarm start
- check that the services are up and stable: docker service ps kapacitor, etc
- connect to grafana (http://localhost:6001), check that the dashboard are defined, and check that the dashboards contain data.
