### PR TITLE
Updated regex for metadata logs

### DIFF
--- a/cmd/amp/cli/test_samples/logs-metadata.yml
+++ b/cmd/amp/cli/test_samples/logs-metadata.yml
@@ -4,4 +4,4 @@ logs-metadata:
     -
   options:
     - -m
-  expectation:  ((timestamp:"[0-9A-Z\.\-:\"]{1,})(\s)(time_id:"[0-9A-Z\.\-:$\"]{1,})(\s)(service_id:"[a-z0-9$\"]{1,})(\s)(service_name:"[a-z0-9$\"]{1,})(\s)(message:"[a-zA-Z\./\-0-9:\s\_\t\n\$&%?/\[\]\%\>\<\,\;$\"]{1,})(\s)(container_id:"[a-z0-9$\"]{1,})(\s)(node_id:"[a-z0-9$\"]{1,})(\s)(task_id:"[a-z0-9$\"]{1,})(\s)(task_name:"[a-z\.0-9$\"]{1,})((.)|(\s)){1,}(.)*)
+  expectation:  ((timestamp:"[0-9A-Z\.\-:\"]{1,})(\s)(time_id:"[0-9A-Z\.\-:\"]{1,})(\s)(service_id:"[a-z0-9$\"]{1,})(\s)(service_name:"[a-z0-9\-$\"]{1,})(\s)(message:"[a-zA-Z\./\-0-9:\s\_\"=\t\n\$\\&%?\[\]\%\>\<\,\;\+$\"]{1,})(\s)(container_id:"[a-z0-9$\"]{1,})(\s)(node_id:"[a-z0-9$\"]{1,})(\s)(task_id:"[a-z0-9$\"]{1,})(\s)(task_name:"[a-z\.0-9\-$\"]{1,})((.)|(\s)){1,}(.)*)


### PR DESCRIPTION
Minor update to regex in metadata logs since it failed. The cli test is however expected to fail since the blocking functionality for service-curl has not been implemented.

To test:
`go test github.com/appcelerator/amp/cmd/amp/cli`