### PR TITLE
Fix stats issue 402 (1)

### DIFF
--- a/api/rpc/stack/stack_test.go
+++ b/api/rpc/stack/stack_test.go
@@ -1,10 +1,10 @@
 package stack_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
-        "fmt"
 
 	"github.com/appcelerator/amp/api/rpc/stack"
 	"github.com/appcelerator/amp/api/runtime"

--- a/cmd/amp/stats.go
+++ b/cmd/amp/stats.go
@@ -123,6 +123,7 @@ func Stats(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	query.FilterContainerName = backQuoteDash(cmd.Flag("container-name").Value.String())
 	query.FilterContainerImage = backQuoteDash(cmd.Flag("image").Value.String())
 	query.FilterServiceId = cmd.Flag("service-id").Value.String()
+	query.FilterServiceName = cmd.Flag("service-name").Value.String()
 	query.FilterTaskId = cmd.Flag("task-id").Value.String()
 	query.FilterTaskName = backQuoteDash(cmd.Flag("task-name").Value.String())
 	query.FilterNodeId = cmd.Flag("node-id").Value.String()

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,16 @@
+Counter
+======
+
+Two replicated webapps connected to a redis counter
+
+Run in this directory:
+
+    $ amp stack up -f stack.yml counter
+
+The app will be running at [http://go.counter.localhost.tv](http://go.counter.localhost.tv) and [http://python.counter.localhost.tv](http://python.counter.localhost.tv)
+
+Test with
+
+    $ curl http://go.counter.localhost.tv
+
+Or open urls in browser

--- a/examples/counter/stack.yml
+++ b/examples/counter/stack.yml
@@ -1,0 +1,15 @@
+services:
+  python:
+    image: tutum/quickstart-python
+    public:
+    - name: python
+      internal_port: 80
+    replicas: 3
+  go:
+    image: htilford/go-redis-counter
+    public:
+    - name: go
+      internal_port: 80
+    replicas: 3
+  redis:
+    image: redis

--- a/examples/pinger/README.md
+++ b/examples/pinger/README.md
@@ -1,0 +1,14 @@
+Pinger
+======
+
+Basic go webapp [src](https://github.com/appcelerator/docker-pinger) that pongs at /ping
+
+Run in this directory:
+
+    $ amp stack up -f stack.yml pinger
+
+The app will be running at [http://www.pinger.localhost.tv](http://www.pinger.localhost.tv)
+
+Test with
+
+    $ curl http://www.pinger.localhost.tv/ping

--- a/examples/pinger/stack.yml
+++ b/examples/pinger/stack.yml
@@ -1,0 +1,6 @@
+services:
+  pinger:
+    image: appcelerator/pinger
+    public:
+      - name: www
+        internal_port: 3000

--- a/examples/voting-app/README.md
+++ b/examples/voting-app/README.md
@@ -1,16 +1,13 @@
 Instavote
 =========
 
-Getting started
----------------
-
-Download [Docker for Mac or Windows](https://www.docker.com).
+Cannonical docker swarm example
 
 Run in this directory:
 
     $ amp stack up -f stack.yml instavote
 
-The app will be running at [.](http://vote.instavote.localhost.tv), and the results will be at [http://results.instavote.localhost.tv](http://results.instavote.localhost.tv).
+The app will be running at [http://vote.instavote.localhost.tv](http://vote.instavote.localhost.tv), and the results will be at [http://results.instavote.localhost.tv](http://results.instavote.localhost.tv).
 
 Architecture
 -----


### PR DESCRIPTION
Fix issue 402 related to stats service-name filter

test: 
- start amp: ./swarm start
- start local amplifier
- execute: amp stats --service-name amp

should return only services starting by 'amp'

regression tests:
- make test
