### PR TITLE
Fix stats issue 402 (2)

### DIFF
--- a/cmd/amp/stats.go
+++ b/cmd/amp/stats.go
@@ -123,6 +123,7 @@ func Stats(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	query.FilterContainerName = backQuoteDash(cmd.Flag("container-name").Value.String())
 	query.FilterContainerImage = backQuoteDash(cmd.Flag("image").Value.String())
 	query.FilterServiceId = cmd.Flag("service-id").Value.String()
+	query.FilterServiceName = cmd.Flag("service-name").Value.String()
 	query.FilterTaskId = cmd.Flag("task-id").Value.String()
 	query.FilterTaskName = backQuoteDash(cmd.Flag("task-name").Value.String())
 	query.FilterNodeId = cmd.Flag("node-id").Value.String()


### PR DESCRIPTION
Related to #402 
Fix stats issue, `service-name` filter regression

test:
- start amp: ./swarm start
- start local amplifier
- execute: amp stats --service-name amp

Display only the services starting by 'amp'

regression tests:
- make test
