### PR TITLE
RegEx Lookup and Improved RegEx 

### DIFF
--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 
 
 func TestCmds(t *testing.T) {
-	_, err := loadRegexLookup()
+	err := loadRegexLookup()
 	if err != nil {
 		t.Errorf("Unable to load lookup specs, reason: %v", err)
 		return
@@ -142,42 +142,37 @@ func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
 	return
 }
 
-func loadRegexLookup() ([]*LookupSpec, error) {
+func loadRegexLookup() error {
 
 	files, err := ioutil.ReadDir(lookupDir)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	lookupFiles := []*LookupSpec{}
 	for _, file := range files {
-		lookupFile, err := parseLookup(path.Join(lookupDir, file.Name()))
+		err := parseLookup(path.Join(lookupDir, file.Name()))
 		if err != nil {
-			return nil, err
-		}
-		if lookupFile != nil {
-			lookupFiles = append(lookupFiles, lookupFile)
+			return err
 		}
 	}
 
-	return lookupFiles, nil
+	return nil
 }
 
-//Parse regex-lookup.yml using a map
-func parseLookup(file string) (*LookupSpec, error) {
+func parseLookup(file string) error {
 
 	if filepath.Ext(file) != ".yml" {
-		return nil, nil
+		return nil
 	}
 	pairs, err := ioutil.ReadFile(file)
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to load regex lookup: %s. Error: %v", file, err)
+		return fmt.Errorf("Unable to load regex lookup: %s. Error: %v", file, err)
 	}
 
 	if err := yaml.Unmarshal(pairs, &regexMap); err != nil {
-		return nil, fmt.Errorf("Unable to parse regex lookup: %s. Error: %v", file, err)
+		return fmt.Errorf("Unable to parse regex lookup: %s. Error: %v", file, err)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/cmd/amp/cli/lookup/regex-lookup.yml
+++ b/cmd/amp/cli/lookup/regex-lookup.yml
@@ -1,0 +1,18 @@
+logs-all: ([a-zA-Z0-9\.\-:\"\s\_\t\n$&?/\[\]%><,;()+='*{}\\]*)
+logs-metadata: (timestamp:"[A-Z0-9\.\-:\"]+\s+time_id:"[A-Z0-9\.\-:\"]+\s+service_id:"[a-z0-9$\"]+\s+service_name:"[a-z0-9\-$\"]+\s+message:"[a-zA-Z0-9\./\-:\s\_\"=\t\n\$\\&%?\[\]\%\>\<\,\;\+$\"]+\s+container_id:"[a-z0-9$\"]+\s+node_id:"[a-z0-9$\"]+\s+task_id:"[a-z0-9$\"]+\s+task_name:"[a-z0-9\.\-$\"]+)
+logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
+docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
+service-create: ([a-z0-9]){25}
+service-remove: ([a-z]+)
+stack-create: ([a-z0-9]){64}
+stack-list: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}
+stack-stop: ([a-z0-9]){64}
+stack-restart: ([a-z0-9]){64}
+stack-unavailable: No stack is available
+stats-container: Service name\s+Container name\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\-\.%\s/]*){1,}
+stats-cpu: Service name\s+CPU %%\s*\n-+\s*\n([a-z\-0-9\.%\s]*){1,}
+stats-io: Service name\s+Disk IO\s+read/write\s*\n-+\s*\n([a-z0-9A-Z\-\./\s]*){1,}
+stats-net: Service name\s+Net Rx/Tx\s*\n-+\s*\n([a-z0-9\-\.A-Z\s/]*){1,}
+stats-node: Node id\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO read/write\s+Net Rx/Tx\s*\n-+\s*\n([0-9a-zA-Z\.\s/%]*){1,}
+stats-service: Service name\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\.\s/%]*){1,}
+stats-task: Service name\s+Task name\s+Node id\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\-\.\s%]*){1,}

--- a/cmd/amp/cli/lookup/regex-lookup.yml
+++ b/cmd/amp/cli/lookup/regex-lookup.yml
@@ -2,12 +2,9 @@ logs-all: ([a-zA-Z0-9\.\-:\"\s\_\t\n$&?/\[\]%><,;()+='*{}\\]*)
 logs-metadata: (timestamp:"[A-Z0-9\.\-:\"]+\s+time_id:"[A-Z0-9\.\-:\"]+\s+service_id:"[a-z0-9$\"]+\s+service_name:"[a-z0-9\-$\"]+\s+message:"[a-zA-Z0-9\./\-:\s\_\"=\t\n\$\\&%?\[\]\%\>\<\,\;\+$\"]+\s+container_id:"[a-z0-9$\"]+\s+node_id:"[a-z0-9$\"]+\s+task_id:"[a-z0-9$\"]+\s+task_name:"[a-z0-9\.\-$\"]+)
 logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
 docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
-service-create: ([a-z0-9]){25}
-service-remove: ([a-z]+)
-stack-create: ([a-z0-9]){64}
+service-id: ([a-z0-9]){25}
 stack-list: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}
-stack-stop: ([a-z0-9]){64}
-stack-restart: ([a-z0-9]){64}
+stack-id: ([a-z0-9]){64}
 stack-unavailable: No stack is available
 stats-container: Service name\s+Container name\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\-\.%\s/]*){1,}
 stats-cpu: Service name\s+CPU %%\s*\n-+\s*\n([a-z\-0-9\.%\s]*){1,}

--- a/cmd/amp/cli/test_samples/logs.yml
+++ b/cmd/amp/cli/test_samples/logs.yml
@@ -1,16 +1,21 @@
 - logs-all:
   cmd: amp logs
   args:
+    -
   options:
-  expectation: ([a-z0-9A-Z\.\-:\"\s\_\t\n$&%?/\[\]\%\>\<\,\;]((.)|(\s)){1,})
+    -
+  expectation: logs-all
+  #retry: 5
+  #timeout:
 
 - logs-metadata:
   cmd: amp logs
   args:
-    -
+    -  -m
   options:
-    - -m
-  expectation:  ((timestamp:"[0-9A-Z\.\-:\"]{1,})(\s)(time_id:"[0-9A-Z\.\-:\"]{1,})(\s)(service_id:"[a-z0-9$\"]{1,})(\s)(service_name:"[a-z0-9\-$\"]{1,})(\s)(message:"[a-zA-Z\./\-0-9:\s\_\"=\t\n\$\\&%?\[\]\%\>\<\,\;\+$\"]{1,})(\s)(container_id:"[a-z0-9$\"]{1,})(\s)(node_id:"[a-z0-9$\"]{1,})(\s)(task_id:"[a-z0-9$\"]{1,})(\s)(task_name:"[a-z\.0-9\-$\"]{1,})((.)|(\s)){1,}(.)*)
+    -
+  expectation: logs-metadata
+  #retry: 5
 
 - logs-numbered:
   cmd: amp logs
@@ -18,7 +23,8 @@
     -
   options:
     - -n 10
-  expectation: ([a-z0-9A-Z\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]((.)|(\s)){10})
+  expectation: logs-numbered
+  #retry: 5
 
 - logs-stack:
   cmd: amp logs
@@ -27,3 +33,4 @@
   options:
     - --stack stack1
   expectation:
+  #retry: 5

--- a/cmd/amp/cli/test_samples/logs.yml
+++ b/cmd/amp/cli/test_samples/logs.yml
@@ -5,8 +5,6 @@
   options:
     -
   expectation: logs-all
-  #retry: 5
-  #timeout:
 
 - logs-metadata:
   cmd: amp logs
@@ -15,7 +13,6 @@
   options:
     -
   expectation: logs-metadata
-  #retry: 5
 
 - logs-numbered:
   cmd: amp logs
@@ -24,7 +21,6 @@
   options:
     - -n 10
   expectation: logs-numbered
-  #retry: 5
 
 - logs-stack:
   cmd: amp logs
@@ -33,4 +29,3 @@
   options:
     - --stack stack1
   expectation:
-  #retry: 5

--- a/cmd/amp/cli/test_samples/service.yml
+++ b/cmd/amp/cli/test_samples/service.yml
@@ -5,13 +5,15 @@
   options:
     - --name pinger
     - -p www:90:3000
-  expectation: ([a-z0-9]{25})
+  expectation: service-create
+  #retry: 5
 
 - service-list:
   cmd: docker service ls
   args:
   options:
-  expectation: (?ms)ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND.+\n[a-z0-9]{12}\s+.+appcelerator/pinger
+  expectation: docker-service-list
+  #retry: 5
 
 # Commented out until Delay and APIcall (Blocking) implemented.
 # - service-curl:
@@ -26,10 +28,13 @@
   args:
     - pinger
   options:
-  expectation: (pinger)
+    -
+  expectation: service-remove
+  #retry: 5
 
 - service-list:
   cmd: docker service ls
   args:
   options:
-  expectation: ((ID)(\s)+(NAME)(\s)+(REPLICAS)(\s)+(IMAGE)(\s)+(COMMAND)((.)|(\s))+)
+  expectation: docker-service-list
+  #retry: 5

--- a/cmd/amp/cli/test_samples/service.yml
+++ b/cmd/amp/cli/test_samples/service.yml
@@ -5,15 +5,13 @@
   options:
     - --name pinger
     - -p www:90:3000
-  expectation: service-create
-  #retry: 5
+  expectation: service-id
 
 - service-list:
   cmd: docker service ls
   args:
   options:
   expectation: docker-service-list
-  #retry: 5
 
 # Commented out until Delay and APIcall (Blocking) implemented.
 # - service-curl:
@@ -29,12 +27,10 @@
     - pinger
   options:
     -
-  expectation: service-remove
-  #retry: 5
+  expectation: service-id
 
 - service-list:
   cmd: docker service ls
   args:
   options:
   expectation: docker-service-list
-  #retry: 5

--- a/cmd/amp/cli/test_samples/stack.yml
+++ b/cmd/amp/cli/test_samples/stack.yml
@@ -4,7 +4,7 @@
      - stack1
   options:
      - -f ../../../api/rpc/stack/test_samples/sample-04.yml
-  expectation: stack-create
+  expectation: stack-id
 
 - stack-list:
   cmd: amp stack ls
@@ -20,7 +20,7 @@
     - stack1
   options:
     -
-  expectation: stack-stop
+  expectation: stack-id
 
 - stack-list:
   cmd: amp stack ls
@@ -36,7 +36,7 @@
     - stack1
   options:
     -
-  expectation: stack-restart
+  expectation: stack-id
 
 - stack-list:
   cmd: amp stack ls
@@ -52,7 +52,7 @@
     - stack1
   options:
     -
-  expectation: stack-stop
+  expectation: stack-id
 
 - stack-remove:
   cmd: amp stack rm
@@ -60,7 +60,7 @@
     - stack1
   options:
     -
-  expectation: stack-remove
+  expectation: stack-id
 
 - stack-list:
   cmd: amp stack ls

--- a/cmd/amp/cli/test_samples/stack.yml
+++ b/cmd/amp/cli/test_samples/stack.yml
@@ -1,59 +1,71 @@
 - stack-create:
   cmd: amp stack up
   args:
+     - stack1
   options:
      - -f ../../../api/rpc/stack/test_samples/sample-04.yml
-     - stack1
-  expectation: ([a-z0-9]{64})
+  expectation: stack-create
 
 - stack-list:
   cmd: amp stack ls
   args:
+    -
   options:
-  expectation: ((NAME)(\s)+(ID)(\s)+(STATE)((.)|(\s))+(stack1)(\s)+([a-z0-9]{64})(\s)+(Running)((.)|(\s))(.)*)
+    -
+  expectation: stack-list
 
 - stack-stop:
   cmd: amp stack stop
   args:
     - stack1
   options:
-  expectation: ([a-z0-9]{64})
+    -
+  expectation: stack-stop
 
 - stack-list:
   cmd: amp stack ls
   args:
+    -
   options:
-  expectation: "No stack is available"
+    -
+  expectation: stack-unavailable
 
 - stack-restart:
   cmd: amp stack start
   args:
     - stack1
   options:
-  expectation: ([a-z0-9]{64})
+    -
+  expectation: stack-restart
 
 - stack-list:
   cmd: amp stack ls
   args:
+    -
   options:
-  expectation: ((NAME)(\s)+(ID)(\s)+(STATE)((.)|(\s))+(stack1)(\s)+([a-z0-9]{64})(\s)+(Running)((.)|(\s))(.)*)
+    -
+  expectation: stack-list
 
 - stack-stop:
   cmd: amp stack stop
   args:
     - stack1
   options:
-  expectation: ([a-z0-9]{64})
+    -
+  expectation: stack-stop
 
 - stack-remove:
   cmd: amp stack rm
   args:
     - stack1
   options:
-  expectation: ([a-z0-9]{64})
+    -
+  expectation: stack-remove
 
 - stack-list:
   cmd: amp stack ls
   args:
+    -
   options:
-  expectation: "No stack is available"
+    -
+  expectation: stack-unavailable

--- a/cmd/amp/cli/test_samples/stats.yml
+++ b/cmd/amp/cli/test_samples/stats.yml
@@ -1,55 +1,62 @@
 - stats-container:
   cmd: amp stats
   args:
-    -
+    -  --container
   options:
-    - --container
-  expectation: ((Service name)(\s)+(Container name)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)
+    -
+  expectation: stats-container
+  #retry: 5
 
 - stats-cpu:
   cmd: amp stats
   args:
-    -
-  options:
     - --cpu
-  expectation: (?m)Service name\s+CPU %%\s*\n-+\s*\n[a-z]+\s+[0-9\.]+%
+  options:
+    -
+  expectation: stats-cpu
+  #retry: 5
 
 - stats-io:
   cmd: amp stats
   args:
-    -
-  options:
     - --io
-  expectation: (?m)Service name\s+Disk IO\s+read/write\s*\n-+\s*\n[a-z]+\s+[0-9]+.* / [0-9]+
+  options:
+    -
+  expectation: stats-io
+  #retry: 5
 
 - stats-net:
   cmd: amp stats
   args:
-    -
-  options:
     - --net
-  expectation: ((Service name)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  options:
+    -
+  expectation: stats-net
+  #retry: 5
 
 - stats-node:
   cmd: amp stats
   args:
-    -
-  options:
     - --node
-  expectation: (?m)Node id\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO read/write\s+Net Rx/Tx\s*\n(-|\s)+\n[a-z0-9]{25}\s+
+  options:
+    -
+  expectation: stats-node
+  #retry: 5
 
 - stats-service:
   cmd: amp stats
   args:
-    -
-  options:
     - --service
-  expectation: ((Service name)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  options:
+    -
+  expectation: stats-service
+  #retry: 5
 
 - stats-task:
   cmd: amp stats
   args:
-    -
-  options:
     - --task
-  expectation: ((Service name)(\s)+(Task name)(\s)+(Node id)(\s)+(CPU %%)(\s)+(Mem usage)(\s)+(Mem %%)(\s)+(Disk IO read/write)(\s)+(Net Rx/Tx)((.)|(\s))+((.)|(\s)){1,}(.)*)
+  options:
+    -
+  expectation: stats-task
+  #retry: 5

--- a/cmd/amp/cli/test_samples/stats.yml
+++ b/cmd/amp/cli/test_samples/stats.yml
@@ -5,7 +5,6 @@
   options:
     -
   expectation: stats-container
-  #retry: 5
 
 - stats-cpu:
   cmd: amp stats
@@ -14,7 +13,6 @@
   options:
     -
   expectation: stats-cpu
-  #retry: 5
 
 - stats-io:
   cmd: amp stats
@@ -23,7 +21,6 @@
   options:
     -
   expectation: stats-io
-  #retry: 5
 
 - stats-net:
   cmd: amp stats
@@ -32,7 +29,6 @@
   options:
     -
   expectation: stats-net
-  #retry: 5
 
 - stats-node:
   cmd: amp stats
@@ -41,7 +37,6 @@
   options:
     -
   expectation: stats-node
-  #retry: 5
 
 - stats-service:
   cmd: amp stats
@@ -50,7 +45,6 @@
   options:
     -
   expectation: stats-service
-  #retry: 5
 
 - stats-task:
   cmd: amp stats
@@ -59,4 +53,3 @@
   options:
     -
   expectation: stats-task
-  #retry: 5


### PR DESCRIPTION
Ref #387 

Added `regex-lookup.yml` containing a dictionary of regular expressions used in the test runner. Also updated the regular expressions for better pattern matching.

The earlier version of regular expressions was limited to matching the pattern of the first row of the output. The updated regex matches the pattern of the entire output that is returned. 

To test:

`go test github.com/appcelerator/amp/cmd/amp/cli` 