### PR TITLE
Templates for generating random names

### DIFF
--- a/cmd/amp/cli/test_samples/service.yml
+++ b/cmd/amp/cli/test_samples/service.yml
@@ -3,8 +3,8 @@
   args:
     - appcelerator/pinger
   options:
-    - --name pinger
-    - -p www:90:3000
+    - "--name {{call .uniq `pinger`}}"
+    - "-p www:90:3000"
   expectation: service-id
 
 - service-list:
@@ -24,7 +24,7 @@
 - service-remove:
   cmd: amp service rm
   args:
-    - pinger
+    - "{{call .uniq `pinger`}}"
   options:
     -
   expectation: service-id

--- a/cmd/amp/cli/test_samples/stack.yml
+++ b/cmd/amp/cli/test_samples/stack.yml
@@ -1,7 +1,7 @@
 - stack-create:
   cmd: amp stack up
   args:
-     - stack1
+     - "{{call .uniq `stack1`}}"
   options:
      - -f ../../../api/rpc/stack/test_samples/sample-04.yml
   expectation: stack-id
@@ -17,7 +17,7 @@
 - stack-stop:
   cmd: amp stack stop
   args:
-    - stack1
+    - "{{call .uniq `stack1`}}"
   options:
     -
   expectation: stack-id
@@ -33,7 +33,7 @@
 - stack-restart:
   cmd: amp stack start
   args:
-    - stack1
+    - "{{call .uniq `stack1`}}"
   options:
     -
   expectation: stack-id
@@ -49,7 +49,7 @@
 - stack-stop:
   cmd: amp stack stop
   args:
-    - stack1
+    - "{{call .uniq `stack1`}}"
   options:
     -
   expectation: stack-id
@@ -57,7 +57,7 @@
 - stack-remove:
   cmd: amp stack rm
   args:
-    - stack1
+    - "{{call .uniq `stack1`}}"
   options:
     -
   expectation: stack-id


### PR DESCRIPTION
Templates implemented to generate random names for the commands passed in the yaml files.
e.g. 
`amp service create appcelerator/pinger --name pinger -p www:90:3000`

Appends a random set of characters to the end of the name. Generic and for better parallelism.

Currently tests fail, should pass when #413 is resolved.
test
`go test github.com/appcelerator/amp/cmd/amp/cli`