### PR TITLE
Travis builds should not push to Docker hub on Pull Request builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - make test
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - if [ "$TRAVIS_BRANCH" == "master" and "$TRAVIS_PULL_REQUEST" != "false" ]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
       timeout 120 ./shrink.sh latest &&
       timeout 30 docker push appcelerator/amp:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.7.1
+  - 1.7.3
 
 install:
   - go get -u github.com/golang/lint/golint
@@ -21,7 +21,7 @@ script:
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      ./shrink.sh latest;
-      docker push appcelerator/amp:latest;
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
+      timeout 120 ./shrink.sh latest &&
+      timeout 30 docker push appcelerator/amp:latest
     fi


### PR DESCRIPTION
Ref #419 

- Travis builds are not reliable, add timeouts and don't execute next steps if an error occurs
- Upgrade go from 1.7.1 to 1.7.3
- Don't push images on PR builds