### PR TITLE
Added timeout, retry and delay in CLI tests

### DIFF
--- a/cmd/amp/cli/test_samples/stack.yml
+++ b/cmd/amp/cli/test_samples/stack.yml
@@ -5,6 +5,8 @@
   options:
      - -f ../../../api/rpc/stack/test_samples/sample-04.yml
   expectation: stack-id
+  timeout: 2000
+  delay: 1000
 
 - stack-list:
   cmd: amp stack ls


### PR DESCRIPTION
Added timeout, delay and retry fields in the yaml files. No values added as expected timeouts are not know. 
The tests pass as the expectation field for remove service command has no regex (Ref: #413) 

To test -
`go test github.com/appcelerator/amp/cmd/amp/cli`