### PR TITLE
Fix service rm expectation in CLI tests

### DIFF
--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -23,11 +23,11 @@ type TestSpec struct {
 }
 
 type CommandSpec struct {
-	Cmd                string   `yaml:"cmd"`
-	Args               []string `yaml:"args"`
-	Options            []string `yaml:"options"`
-	Expectation        string   `yaml:"expectation"`
-	ExpectErrorStatus  bool     `yaml:"expectErrorStatus"`
+	Cmd               string   `yaml:"cmd"`
+	Args              []string `yaml:"args"`
+	Options           []string `yaml:"options"`
+	Expectation       string   `yaml:"expectation"`
+	ExpectErrorStatus bool     `yaml:"expectErrorStatus"`
 }
 
 type LookupSpec struct {
@@ -37,16 +37,15 @@ type LookupSpec struct {
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 var (
-	testDir = "./test_samples"
+	testDir   = "./test_samples"
 	lookupDir = "./lookup"
-	regexMap map[string]string
+	regexMap  map[string]string
 )
 
 func TestMain(m *testing.M) {
 	server.StartTestServer()
 	os.Exit(m.Run())
 }
-
 
 func TestCmds(t *testing.T) {
 	err := loadRegexLookup()
@@ -128,7 +127,7 @@ func runTestSpec(t *testing.T, test *TestSpec) error {
 		actualOutput, cmdErr := exec.Command(tmplString[0], tmplString[1:]...).CombinedOutput()
 		expectedOutput := regexp.MustCompile(cmdSpec.Expectation)
 		if !expectedOutput.MatchString(string(actualOutput)) {
-			return fmt.Errorf("miss matched expected output: %s", actualOutput)
+			return fmt.Errorf("miss matched expected output: %s, expectation was: %s\n", actualOutput, cmdSpec.Expectation)
 		}
 		if cmdErr != nil && !cmdSpec.ExpectErrorStatus {
 			return fmt.Errorf("Command was expected to exit with zero status but got: %v", cmdErr)
@@ -148,7 +147,9 @@ func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
 	}
 	cmdString = append(cmdSplit, cmdSpec.Args...)
 	cmdString = append(cmdString, optionsSplit...)
-	cmdSpec.Expectation = regexMap[cmdSpec.Expectation]
+	if regexMap[cmdSpec.Expectation] != "" {
+		cmdSpec.Expectation = regexMap[cmdSpec.Expectation]
+	}
 	return
 }
 

--- a/cmd/amp/cli/test_samples/service.yml
+++ b/cmd/amp/cli/test_samples/service.yml
@@ -27,7 +27,7 @@
     - "{{call .uniq `pinger`}}"
   options:
     -
-  expectation: service-id
+  expectation: "pinger-[[:alpha:]]+"
 
 - service-list:
   cmd: docker service ls


### PR DESCRIPTION
CLI tests are failing due to a wrong expectation on service rm output.

- allow to specify an hardcoded expectation (instead of a lookup)
- updated expectation for the service rm test

how to test:
- swarm start
- go test cmd/amp/cli