### PR TITLE
Shorten default connection timeout for AMP stack

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultTimeOut = 5 * time.Minute
+	defaultTimeOut = 30 * time.Second
 	natsClusterID  = "test-cluster"
 	natsClientID   = "amplifier"
 )


### PR DESCRIPTION
Sometimes the AMP stack is broken and connection to infra services such as etcd or elasticsearch timeouts. The default timeout is 5 min, for which we don't see a reason to be so high.
Reduce the timeout to 30 sec.

How to test:
- stop the services (swarm stop)
- run the cli tests (go test -v ./cmd/amp/cli)
The timeout should happen in 30 sec.
- start the services
- run the cli tests, should succeed