### PR TITLE
make clean should not error if no coverage files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 	@rm -rf $(GENERATED)
 	@rm -f $$(which $(CLI)) ./$(CLI)
 	@rm -f $$(which $(SERVER)) ./$(SERVER)
-	@rm coverage.out coverage-all.out
+	@rm -f coverage.out coverage-all.out
 
 install-deps:
 	@$(GLIDE_INSTALL)


### PR DESCRIPTION
Update Makefile to ensure `make clean` doesn't fail when there are no coverage files to remove.

## Verification

    $ rm -f coverage*.out
    $ make clean

Should not report an error.
