### PR TITLE
build binaries for Linux, MacOS and Windows (#436)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 /amplifier
 /amp-agent
 /amp-log-worker
+/dist
+/*.exe
 coverage.out
 coverage-all.out

--- a/docs/installation/binaries.md
+++ b/docs/installation/binaries.md
@@ -12,35 +12,37 @@ packages for many distributions, and more keep showing up all the time!
 
 ## Check kernel dependencies
 
-
-> **Warning**:
-> Installing custom kernels and kernel packages is probably not
-> supported by your Linux distribution's vendor. Please make sure to
-> ask your vendor about Docker support first before attempting to
-> install custom kernels on your distribution.
-
-> **Warning**:
-> Installing a newer kernel might not be enough for some distributions
-> which provide packages which are too old or incompatible with
-> newer kernels.
+AMP kernel requirements are those of the Docker daemon. A 3.10 Linux kernel is the minimum version supported, it was released in June 2013 so it's a safe guess that any recent Linux distro should meet the requirement.
 
 Note that AMP also has a client mode, which can run on virtually any
-Linux kernel (it even builds on OS X!).
+Linux kernel (it even builds on MacOS and MS Windows!).
 
 ## Enable AppArmor and SELinux when possible
 
 
 ## Get the AMP binaries
 
+The links are available on the github release page.
+
+Substitute X.Y.Z in the links below with the latest available release.
+
 ### Get the Linux binaries
 
+[get.amp.appcelerator.io](https://get.amp.appcelerator.io/builds/Linux/x86_64/amp-vX.Y.Z.tgz)
+
 #### Install the Linux binaries
+
+    tar xzf amp-vX.Y.Z.tgz -C /usr/local/bin/
 
 #### Run AMP on Linux
 
 ### Get the Mac OS X binary
 
+[get.amp.appcelerator.io](https://get.amp.appcelerator.io/builds/Darwin/x86_64/amp-vX.Y.Z.tgz)
+
 ### Get the Windows binary
+
+[get.amp.appcelerator.io](https://get.amp.appcelerator.io/builds/Windows/x86_64/amp-vX.Y.Z.tgz)
 
 
 ## Giving non-root access

--- a/hack/build
+++ b/hack/build
@@ -5,14 +5,14 @@ set -euo pipefail
 APP=$1
 
 # build variables (injected into binaries by linker -ldflags below)
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 BUILD=$(git rev-parse HEAD | cut -c1-8)
 
 OWNER=appcelerator
 REPO=github.com/$OWNER/amp
 
-GOOS=$(uname | tr [:upper:] [:lower:])
-GOARCH=amd64
+GOOS=${GOOS:-$(uname | tr [:upper:] [:lower:])}
+GOARCH=${GOARCH:-amd64}
 
 DOCKER_RUN="docker run -t --rm"
 GOTOOLS=appcelerator/gotools2


### PR DESCRIPTION
Refs #436 

- version is now based on the content of the VERSION file
- targets for amp and amplifier binaries on Linux/Darwin/Windows
- targets for distribution archives


