### PR TITLE
Minor fix to cli_test.go

### DIFF
--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -125,7 +125,7 @@ func runTestSpec(t *testing.T, test *TestSpec) (err error) {
 				err = fmt.Errorf("Executing templating failed: %s", tmplErr)
 				t.Log(err)
 			}
-			tmplString := strings.Fields(tmplOutput)
+			tmplString = strings.Fields(tmplOutput)
 
 			t.Logf("Running: %s", strings.Join(tmplString, " "))
 			cmdOutput, cmdErr := exec.Command(tmplString[0], tmplString[1:]...).CombinedOutput()


### PR DESCRIPTION
Updated the assignment of tmplString variable.

To test -

`go test github.com/appcelerator/amp/cmd/amp/cli`