### PR TITLE
Templating for generating random Ports

### DIFF
--- a/cmd/amp/cli/cli_test.go
+++ b/cmd/amp/cli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"strconv"
 	"testing"
 	"text/template"
 	"time"
@@ -119,13 +120,15 @@ func runTestSpec(t *testing.T, test *TestSpec) (err error) {
 		startTime := time.Now().UnixNano() / 1000000
 
 		for i = -1; i < cmdSpec.Retry; i++ {
+			err = nil
+
 			cmdString := generateCmdString(&cmdSpec)
 			tmplOutput, tmplErr := performTemplating(strings.Join(cmdString, " "), cache)
 			if tmplErr != nil {
 				err = fmt.Errorf("Executing templating failed: %s", tmplErr)
 				t.Log(err)
 			}
-			tmplString := strings.Fields(tmplOutput)
+			tmplString = strings.Fields(tmplOutput)
 
 			t.Logf("Running: %s", strings.Join(tmplString, " "))
 			cmdOutput, cmdErr := exec.Command(tmplString[0], tmplString[1:]...).CombinedOutput()
@@ -148,7 +151,7 @@ func runTestSpec(t *testing.T, test *TestSpec) (err error) {
 			t.Log("This command :", tmplString, "has re-run", i, "times.")
 		}
 	}
-	return
+	return err
 }
 
 func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
@@ -208,9 +211,18 @@ func performTemplating(s string, cache map[string]string) (output string, err er
 		cache[in] = out
 		return out
 	}
+	p := func(in string, min, max int) string {
+		if val, ok := cache[in]; ok {
+			return val
+		}
+		out := strconv.Itoa(rand.Intn(max - min) + min)
+		cache[in] = out
+		return out
+	}
 	var doc bytes.Buffer
 	var fm = template.FuncMap{
 		"uniq": func(in string) string { return f(in) },
+		"port": func(in string, min, max int) string { return p(in, min, max) },
 	}
 	err = t.Execute(&doc, fm)
 	if err != nil {

--- a/cmd/amp/cli/lookup/regex-lookup.yml
+++ b/cmd/amp/cli/lookup/regex-lookup.yml
@@ -3,6 +3,7 @@ logs-metadata: (timestamp:"[A-Z0-9\.\-:\"]+\s+time_id:"[A-Z0-9\.\-:\"]+\s+servic
 logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
 docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
 service-id: ([a-z0-9]){25}
+service-curl: ((.)|(\s))*(pong)((.)|(\s))*
 stack-list: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}
 stack-id: ([a-z0-9]){64}
 stack-unavailable: No stack is available

--- a/cmd/amp/cli/test_samples/service.yml
+++ b/cmd/amp/cli/test_samples/service.yml
@@ -4,7 +4,7 @@
     - appcelerator/pinger
   options:
     - "--name {{call .uniq `pinger`}}"
-    - "-p www:90:3000"
+    - "-p www:{{call .port `pinger1` 1100 1200}}:3000"
   expectation: service-id
 
 - service-list:
@@ -13,13 +13,15 @@
   options:
   expectation: docker-service-list
 
-# Commented out until Delay and APIcall (Blocking) implemented.
-# - service-curl:
-#   cmd: curl
-#   args:
-#     - localhost:90/ping
-#   options:
-#   expectation: ((.)|(\s))*(pong)((.)|(\s))*
+# Should use API call as a form of blocking.
+- service-curl:
+  cmd: curl
+  args:
+    - localhost:{{call .port `pinger1` 1100 1200}}/ping
+  options:
+  expectation: service-curl
+  retry: 3
+  delay: 2500
 
 - service-remove:
   cmd: amp service rm


### PR DESCRIPTION
creates random port numbers for templating. Similar to random name generation. A range of ports can be supplied to the template.

Added curl method (uncommented) in `service.yml` as retry, timeout and delay fields implemented. Regex moved into `lookup.yml`

to test
`go test github.com/appcelerator/amp/cmd/amp/cli`