### PR TITLE
Templating for generating random ports (part 2)

### DIFF
--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -21,7 +21,8 @@
   options:
   expectation: service-curl
   retry: 3
-  delay: 2500ms
+  delay: 1500ms
+  timeout: 10000ms
 
 - service-remove:
   cmd: amp service rm

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -5,8 +5,7 @@
   options:
      - -f ../../api/rpc/stack/test_samples/sample-04.yml
   expectation: stack-id
-  timeout: 10ms
-  delay: 4000ms
+  timeout: 3000ms
 
 - stack-list:
   cmd: amp stack ls
@@ -39,6 +38,7 @@
   options:
     -
   expectation: stack-id
+  timeout: 3000ms
 
 - stack-list:
   cmd: amp stack ls


### PR DESCRIPTION
PR #441  merged before necessary changes made.

Changes:
- `time.Since()` function used
- templating errors returns
- return statement edited

to test
`go test -v ./cmd/amp/cli`

for testing timing changes, modify `stack.yml` first command `amp stack up` to a failing case, as it can test the retry and timeout fields, then run.
`go test -v ./cmd/amp/cli`