### PR TITLE
Updated cli_test.go to accept different values for timeout and delay

### DIFF
--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -21,7 +21,7 @@
   options:
   expectation: service-curl
   retry: 3
-  delay: 2500
+  delay: 2500ms
 
 - service-remove:
   cmd: amp service rm

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -5,8 +5,8 @@
   options:
      - -f ../../api/rpc/stack/test_samples/sample-04.yml
   expectation: stack-id
-  timeout: 2000
-  delay: 1000
+  timeout: 10ms
+  delay: 4000ms
 
 - stack-list:
   cmd: amp stack ls


### PR DESCRIPTION
Updated cli_test.go to accept different values for timeout and delay using ParseDuration function.
The timeout and duration fields now accept values with different suffix, like ms, ns, s, etc.

To test:
`go test github.com/appcelerator/amp/cmd/amp/cli`
