### PR TITLE
Add grpc-gateway and swagger support to proto build

### DIFF
--- a/api/rpc/build/build.swagger.json
+++ b/api/rpc/build/build.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/build/build.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/logs/logs.swagger.json
+++ b/api/rpc/logs/logs.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/logs/logs.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/oauth/oauth.swagger.json
+++ b/api/rpc/oauth/oauth.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/oauth/oauth.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/project/project.swagger.json
+++ b/api/rpc/project/project.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/project/project.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/service/service.swagger.json
+++ b/api/rpc/service/service.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/service/service.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/stack/stack.swagger.json
+++ b/api/rpc/stack/stack.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/stack/stack.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/stats/stats.swagger.json
+++ b/api/rpc/stats/stats.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/stats/stats.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/rpc/topic/topic.swagger.json
+++ b/api/rpc/topic/topic.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/rpc/topic/topic.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/api/state/state.swagger.json
+++ b/api/state/state.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/api/state/state.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/data/storage/etcd/store_test.swagger.json
+++ b/data/storage/etcd/store_test.swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "github.com/appcelerator/amp/data/storage/etcd/store_test.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {}
+}

--- a/hack/proto.go
+++ b/hack/proto.go
@@ -51,9 +51,13 @@ func main() {
 		"appcelerator/protoc",
 	}
 	protocArgs := []string{
-		"--go_out=plugins=grpc:/go/src/",
+		"--go_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:/go/src/",
+		"--grpc-gateway_out=logtostderr=true:/go/src",
+		"--swagger_out=logtostderr=true:/go/src/",
 		"-I",
 		"/go/src/",
+		"-I",
+		"/go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis",
 	}
 	if protoc {
 		for _, path := range paths {


### PR DESCRIPTION
progress on https://github.com/appcelerator/amp/issues/425

The swagger files are stubs for now, they will fill in as we specify the routes.
Once routes are added the <pkg>.gw.go files will be generated.

Relies on https://github.com/appcelerator/docker-protoc/pull/2

To test:
  clone https://github.com/appcelerator/docker-protoc
  checkout grpc-support
  docker build -t appcelerator/protoc <docker-protoc-dir>
  cd <ampdir>
  make proto