### PR TITLE
Asynchronous execution of test specs

### DIFF
--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -4,7 +4,7 @@
     - appcelerator/pinger
   options:
     - "--name {{call .uniq `pinger`}}"
-    - "-p www:{{call .port `pinger1` 1100 1200}}:3000"
+    - "-p www:{{call .port `pinger1` 49152 65535}}:3000"
   expectation: service-id
 
 - service-list:
@@ -17,11 +17,11 @@
 - service-curl:
   cmd: curl
   args:
-    - localhost:{{call .port `pinger1` 1100 1200}}/ping
+    - localhost:{{call .port `pinger1` 49152 65535}}/ping
   options:
   expectation: service-curl
   retry: 3
-  delay: 1500ms
+  delay: 2500ms
   timeout: 10000ms
 
 - service-remove:

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -5,7 +5,6 @@
   options:
      - -f ../../api/rpc/stack/test_samples/sample-04.yml
   expectation: stack-id
-  timeout: 3000ms
 
 - stack-list:
   cmd: amp stack ls
@@ -38,7 +37,6 @@
   options:
     -
   expectation: stack-id
-  timeout: 3000ms
 
 - stack-list:
   cmd: amp stack ls


### PR DESCRIPTION
TestSpecs run in parallel. Uses a waitgroup to do so.

Minor change to service port range.

to test -
`go test ./tests/cli`