### PR TITLE
updates amp version information instruction

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -61,7 +61,7 @@ Briefly describe the problem you are having in a few paragraphs.
 (paste your output here)
 ```
 
-**Output of `amp version`:**
+**Output of `amp info`:**
 
 ```
 (paste your output here)


### PR DESCRIPTION
see https://github.com/appcelerator/amp/issues/456

`amp version` is a built in from cobra that as of this writing does not return the version
`amp info` is our own command that works, and also provides more information

This PR fixes the issue template to ask for `amp info`