### PR TITLE
amp version option

### DIFF
--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -24,11 +24,18 @@ var (
 	configFile string
 	verbose    bool
 	serverAddr string
+	listVersion = true
 
 	// RootCmd is the base command for the CLI.
 	RootCmd = &cobra.Command{
 		Use:   `amp [OPTIONS] COMMAND [arg...]`,
 		Short: "Appcelerator Microservice Platform.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if listVersion {
+				fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
+			}
+			fmt.Println(cmd.UsageString())
+		},
 	}
 )
 
@@ -54,6 +61,17 @@ func main() {
 		})
 	})
 
+	// versionCmd represents the amp version
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display the version number of amp",
+		Long:  `Display the version number of amp`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
+		},
+	}
+	RootCmd.AddCommand(versionCmd)
+
 	// infoCmd represents the amp information
 	infoCmd := &cobra.Command{
 		Use:   "info",
@@ -70,6 +88,7 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.amp.yaml)")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `Verbose output`)
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "Server address")
+	RootCmd.Flags().BoolVarP(&listVersion, "version", "V", false, "Version number")
 	RootCmd.AddCommand(infoCmd)
 	cmd, _, err := RootCmd.Find(os.Args[1:])
 	if err != nil {


### PR DESCRIPTION
Ref #458 

Added command to display amp version. The following commands display the version of amp.

`amp version`
`amp -V`
`amp --version`

Output:

```
amp (cli version: v0.4.0-dev, build: 55bfccb1)
Usage:	amp COMMAND

Appcelerator Microservice Platform.

Options:
      --config string   Config file (default is $HOME/.amp.yaml)
  -h, --help            help for amp
      --server string   Server address
  -v, --verbose         Verbose output
  -V, --version         Version number

Commands:
  config      Display the current configuration
  info        Display amp version and server information
  login       Login via github
  logs        Fetch log entries matching provided criteria. If provided, SERVICE can be a partial or full service id or service name.
  registry    Registry operations
  service     Manage services
  stack       Stack operations
  stats       Display resource usage statistics
  topic       topic operations
  version     Display the version number of amp

Run 'amp COMMAND --help' for more information on a command.
```