### PR TITLE
Default amp client to platform amplifier

### DIFF
--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	//DefaultServerAddress amplifier address + port default
-	DefaultServerAddress = "localhost:50101"
+	DefaultServerAddress = "localhost:8080"
 )
 
 var (

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/appcelerator/amp/api/server"
 	flag "github.com/spf13/pflag"
-	"strings"
 )
 
 const (

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,10 @@
 # Example Applications
 
 The `examples/` directory contains example applications running from stackfiles for demo and quick start purposes.
+
+To run them:
+  - start docker
+  - run `./swarm pull`
+  - run `./swarm start`
+  - run `./swarm monitor` until things are up
+  - follow the instructions in the README.md in the example directory

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -7,10 +7,6 @@ Run in this directory:
 
     $ amp stack up -f stack.yml counter
 
-Depending on your configuration, you may need to explicitly specify the server address as shown below:
-
-    $ amp stack up -f stack.yml counter --server localhost:8080
-
 The app will be running at [http://go.counter.local.atomiq.io](http://go.counter.local.atomiq.io) and [http://python.counter.local.atomiq.io](http://python.counter.local.atomiq.io)
 
 Test with

--- a/examples/micro/deploy.sh
+++ b/examples/micro/deploy.sh
@@ -2,5 +2,5 @@
 amp stack rm -f micro || true
 docker build -t examples/micro .
 amp registry push examples/micro
-amp stack up -f stack.yml micro --server localhost:8080
+amp stack up -f stack.yml micro
 

--- a/examples/pinger/README.md
+++ b/examples/pinger/README.md
@@ -7,10 +7,6 @@ Run in this directory:
 
     $ amp stack up -f stack.yml pinger
 
-Depending on your configuration, you may need to explicitly specify the server address as shown below:
-
-    $ amp stack up -f stack.yml pinger --server localhost:8080
-
 The app will be available at [http://www.pinger.local.atomiq.io](http://www.pinger.local.atomiq.io)
 
 Test with

--- a/examples/voting-app/README.md
+++ b/examples/voting-app/README.md
@@ -7,10 +7,6 @@ Run in this directory:
 
     $ amp stack up -f stack.yml instavote
 
-Depending on your configuration, you may need to explicitly specify the server address as shown below:
-
-    $ amp stack up -f stack.yml instavote --server localhost:8080
-
 The voting app will be available at [http://vote.instavote.local.atomiq.io](http://vote.instavote.local.atomiq.io).
 
 The results app will be available at [http://results.instavote.local.atomiq.io](http://results.instavote.local.atomiq.io).

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -16,11 +16,11 @@ Test using
 
 You can then check the logs with
 
-    $ amp logs websocket --server localhost:8080
+    $ amp logs websocket
 
 And stats with
 
-    $ amp stats websocket --server localhost:8080
+    $ amp stats websocket
 
 For extra fun try the following from within a bash session
 

--- a/examples/websocket/deploy.sh
+++ b/examples/websocket/deploy.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
-AMPOPTS="--server localhost:8080"
-amp $AMPOPTS stack rm -f websocket || true
+amp stack rm -f websocket || true
 docker build -t examples/ws-bash-server server
-amp $AMPOPTS registry push examples/ws-bash-server
+amp registry push examples/ws-bash-server
 docker build -t examples/ws-bash-web web
-amp $AMPOPTS registry push examples/ws-bash-web
-amp $AMPOPTS stack up -f stack.yml websocket
+amp registry push examples/ws-bash-web
+amp stack up -f stack.yml websocket


### PR DESCRIPTION
closes https://github.com/appcelerator/amp/issues/406

Sets the default amplifier server address to localhost:8080 to make things easier for new users.

For dev just run `amp config serverAddress localhost:50101`