### PR TITLE
tag for image appcelerator/protoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # appclerator/protoc is based on alpine and includes latest go and protoc
-FROM appcelerator/protoc
+FROM appcelerator/protoc:0.2.0
 RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add make bash git docker@community
 WORKDIR /go/src/github.com/appcelerator/amp

--- a/hack/proto.go
+++ b/hack/proto.go
@@ -48,7 +48,7 @@ func main() {
 		wd + ":/go/src/github.com/appcelerator/amp",
 		"-v",
 		"/var/run/docker.sock:/var/run/docker.sock",
-		"appcelerator/protoc",
+		"appcelerator/protoc:0.2.0",
 	}
 	protocArgs := []string{
 		"--go_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:/go/src/",


### PR DESCRIPTION
Ref. #468

image appcelerator/protoc used in amp build was not tagged.
This PR makes sure we use a tagged image.