### PR TITLE
bump influxdb and telegraf versions (1.1 stable)

### DIFF
--- a/cmd/amp/platform_infrastructure.go
+++ b/cmd/amp/platform_infrastructure.go
@@ -13,9 +13,9 @@ const (
 const (
 	ampVersion           = "latest"
 	uiVersion            = "0.2.0"
-	influxDBVersion      = "1.1.0"
+	influxDBVersion      = "1.1.2"
 	kapacitorVersion     = "1.1.0"
-	telegrafVersion      = "1.1.0-rc1"
+	telegrafVersion      = "1.1.1"
 	grafanaVersion       = "1.0.1"
 	elasticsearchVersion = "2.3.3"
 	etcdVersion          = "3.1.0-rc.0-2"


### PR DESCRIPTION
Use latest versions of the images:
- influxdb-amp:1.1.2
- telegraf-1.1.1

how to test:
- make install
- amp pf pull
- amp pf start
- amp pf monitor, the services should stabilize, no failed tasks
- check the Grafana dashboards (http://localhost:6001/), we should have metrics in the realtime dashboard
