### PR TITLE
Templating for regexes

### DIFF
--- a/tests/cli/lookup/regex-lookup.yml
+++ b/tests/cli/lookup/regex-lookup.yml
@@ -2,11 +2,14 @@ logs-all: ([a-zA-Z0-9\.\-:\"\s\_\t\n$&?/\[\]%><,;()+='*{}\\]*)
 logs-metadata: (timestamp:"[A-Z0-9\.\-:\"]+\s+time_id:"[A-Z0-9\.\-:\"]+\s+service_id:"[a-z0-9$\"]+\s+service_name:"[a-z0-9\-$\"]+\s+message:"[a-zA-Z0-9\./\-:\s\_\"=\t\n\$\\&%?\[\]\%\>\<\,\;\+$\"]+\s+container_id:"[a-z0-9$\"]+\s+node_id:"[a-z0-9$\"]+\s+task_id:"[a-z0-9$\"]+\s+task_name:"[a-z0-9\.\-$\"]+)
 logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
 docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
+docker-service-list-valid-service: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}({{call .uniq `pinger`}})([a-zA-Z0-9\s\.\-:/]*){1,}
+docker-service-list-invalid-service: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}[^{{call .uniq `pinger`}}]([a-zA-Z0-9\s\.\-:/]*){1,}
 service-id: ([a-z0-9]){25}
 service-curl: ((.)|(\s))*(pong)((.)|(\s))*
-stack-list: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}
+service-remove: "{{call .uniq `pinger`}}"
+stack-list-running: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}({{call .uniq `stack1`}})([a-z0-9A-Z\s]*){1,}
+stack-list-unavailable: No stack is available
 stack-id: ([a-z0-9]){64}
-stack-unavailable: No stack is available
 stats-container: Service name\s+Container name\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\-\.%\s/]*){1,}
 stats-cpu: Service name\s+CPU %%\s*\n-+\s*\n([a-z\-0-9\.%\s]*){1,}
 stats-io: Service name\s+Disk IO\s+read/write\s*\n-+\s*\n([a-z0-9A-Z\-\./\s]*){1,}

--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -11,7 +11,7 @@
   cmd: docker service ls
   args:
   options:
-  expectation: docker-service-list
+  expectation: docker-service-list-valid-service
 
 # Should use API call as a form of blocking.
 - service-curl:
@@ -22,7 +22,7 @@
   expectation: service-curl
   retry: 3
   delay: 2500ms
-  timeout: 10000ms
+  timeout: 15000ms
 
 - service-remove:
   cmd: amp service rm
@@ -30,10 +30,11 @@
     - "{{call .uniq `pinger`}}"
   options:
     -
-  expectation: "pinger-[[:alpha:]]+"
+  expectation: service-remove
+    # "pinger-[[:alpha:]]+"
 
 - service-list:
   cmd: docker service ls
   args:
   options:
-  expectation: docker-service-list
+  expectation: docker-service-list-invalid-service

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -12,7 +12,7 @@
     -
   options:
     -
-  expectation: stack-list
+  expectation: stack-list-running
 
 - stack-stop:
   cmd: amp stack stop
@@ -28,7 +28,7 @@
     -
   options:
     -
-  expectation: stack-unavailable
+  expectation: stack-list-unavailable
 
 - stack-restart:
   cmd: amp stack start
@@ -44,7 +44,7 @@
     -
   options:
     -
-  expectation: stack-list
+  expectation: stack-list-running
 
 - stack-stop:
   cmd: amp stack stop
@@ -68,4 +68,4 @@
     -
   options:
     -
-  expectation: stack-unavailable
+  expectation: stack-list-unavailable


### PR DESCRIPTION
Templating for regexes. The regexes are passed the generated names created from templating the commands. Separate, more definitive regexes have been created for these instances:

- Docker-service-list-valid-service
- Docker-service-list-invalid-service
- Stack-list-running
- Stack-list-unavailable
- Service-remove

to test
`go test ./tests/cli`

You can also try inserting some different names into the respective `service.yml` , `stack.yml` and `looukp.yml`fields if you want to test further.
