### PR TITLE
Etcd 3.1.0 rc.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /amp
 /amplifier
+/amplifier-gateway
 /amp-agent
 /amp-log-worker
 /dist

--- a/cmd/amp/platform_infrastructure.go
+++ b/cmd/amp/platform_infrastructure.go
@@ -18,7 +18,7 @@ const (
 	telegrafVersion      = "1.1.1"
 	grafanaVersion       = "1.0.1"
 	elasticsearchVersion = "2.3.5"
-	etcdVersion          = "3.1.0-rc.0-2"
+	etcdVersion          = "3.1.0-rc.1"
 	natsVersion          = "0.3.0"
 	haproxyVersion       = "1.0.1"
 	registryVersion      = "2.5.1"


### PR DESCRIPTION
- etcd 3.1.0-rc.1 has been released
- update .gitignore for recent PR additions

how to test:
- make install
- amp pf pull
- amp pf start
- amp pf monitor