### PR TITLE
firstMessage color change

### DIFF
--- a/cmd/amp/platform_manager.go
+++ b/cmd/amp/platform_manager.go
@@ -63,7 +63,7 @@ type ampService struct {
 }
 
 var (
-	colWhite   = 0
+	colMagenta = 0
 	colInfo    = 1
 	colWarn    = 2
 	colError   = 3
@@ -73,14 +73,14 @@ var (
 
 func (s *ampManager) init(firstMessage string) error {
 	s.ctx = context.Background()
-	s.printColor[0] = color.New(color.FgHiWhite)
+	s.printColor[0] = color.New(color.FgMagenta)
 	s.printColor[1] = color.New(color.FgHiBlack)
 	s.printColor[2] = color.New(color.FgYellow)
 	s.printColor[3] = color.New(color.FgRed)
 	s.printColor[4] = color.New(color.FgGreen)
 	s.printColor[5] = color.New(color.FgHiGreen)
 	if firstMessage != "" {
-		s.printf(colWhite, firstMessage+"\n")
+		s.printf(colMagenta, firstMessage+"\n")
 	}
 	if s.force {
 		s.printf(colWarn, "Force mode: on\n")
@@ -278,7 +278,7 @@ func (s *ampManager) monitor(stack *ampStack) {
 			} else if serv.status == "partially running" {
 				s.printf(colWarn, "%s\n", s.displayService(serv, cols))
 			} else if serv.status == "starting" {
-				s.printf(colWhite, "%s\n", s.displayService(serv, cols))
+				s.printf(colMagenta, "%s\n", s.displayService(serv, cols))
 			} else {
 				s.printf(colInfo, "%s\n", s.displayService(serv, cols))
 			}

--- a/cmd/amp/platform_pull.go
+++ b/cmd/amp/platform_pull.go
@@ -40,6 +40,6 @@ func pullAMPImages(cmd *cobra.Command, args []string) error {
 		manager.printf(colError, "Pull error: %v\n", err)
 		os.Exit(1)
 	}
-	manager.printf(colWhite, "AMP platform images pulled\n")
+	manager.printf(colMagenta, "AMP platform images pulled\n")
 	return nil
 }

--- a/cmd/amp/platform_start.go
+++ b/cmd/amp/platform_start.go
@@ -44,7 +44,7 @@ func startAMP(cmd *cobra.Command, args []string) error {
 	manager.computeStatus(stack)
 	if manager.status == "running" {
 		if !manager.force {
-			manager.printf(colWhite, "AMP platform already started (-f to force a re-start)\n")
+			manager.printf(colMagenta, "AMP platform already started (-f to force a re-start)\n")
 			return nil
 		}
 		if err := manager.stop(stack); err != nil {
@@ -59,6 +59,6 @@ func startAMP(cmd *cobra.Command, args []string) error {
 		}
 		os.Exit(1)
 	}
-	manager.printf(colWhite, "AMP platform started\n")
+	manager.printf(colMagenta, "AMP platform started\n")
 	return nil
 }

--- a/cmd/amp/platform_status.go
+++ b/cmd/amp/platform_status.go
@@ -37,7 +37,7 @@ func getAMPStatus(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	manager.computeStatus(getAMPInfrastructureStack(manager))
-	manager.printf(colWhite, "status: %s\n", manager.status)
+	manager.printf(colMagenta, "status: %s\n", manager.status)
 	if manager.status != "running" {
 		os.Exit(1)
 	}

--- a/cmd/amp/platform_stop.go
+++ b/cmd/amp/platform_stop.go
@@ -39,13 +39,13 @@ func stopAMP(cmd *cobra.Command, args []string) error {
 	stack := getAMPInfrastructureStack(manager)
 	manager.computeStatus(stack)
 	if manager.status == "stopped" {
-		manager.printf(colWhite, "AMP platform already stopped\n")
+		manager.printf(colMagenta, "AMP platform already stopped\n")
 		return nil
 	}
 	if err := manager.stop(stack); err != nil {
 		manager.printf(colError, "Stop error: %v\n", err)
 		os.Exit(1)
 	}
-	manager.printf(colWhite, "AMP platform stopped\n")
+	manager.printf(colMagenta, "AMP platform stopped\n")
 	return nil
 }


### PR DESCRIPTION
Ref Issue #477 

The firstMessage was printed in `white` color, which was not clearly visible on light-solarized theme. It is now changed to `magenta`.
Tested the colored output on both light and dark solarized themes. It seems like the color `black` (info logs - `Pulling ...` ) appears consistent across both the themes. The above mentioned change is the only what I felt could be modified.
<img width="638" alt="screen shot 2016-11-18 at 3 11 47 pm" src="https://cloud.githubusercontent.com/assets/12013126/20450724/7b8c149c-ada7-11e6-93a7-35057dc3ce54.png">
<img width="640" alt="screen shot 2016-11-18 at 3 13 01 pm" src="https://cloud.githubusercontent.com/assets/12013126/20450725/7b8cf89e-ada7-11e6-95e9-ed7837c0e594.png">