### PR TITLE
Fixes state machine initialization issue

### DIFF
--- a/api/rpc/stack/stack-state.go
+++ b/api/rpc/stack/stack-state.go
@@ -1,9 +1,6 @@
 package stack
 
-import (
-	"github.com/appcelerator/amp/api/runtime"
-	"github.com/appcelerator/amp/api/state"
-)
+import "github.com/appcelerator/amp/api/state"
 
 // StackRuleSet defines possible transitions for stack states
 var StackRuleSet = state.RuleSet{
@@ -32,5 +29,3 @@ var StackRuleSet = state.RuleSet{
 		StackState_Redeploying.String(): false,
 	},
 }
-
-var stackStateMachine = state.NewMachine(StackRuleSet, runtime.Store)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -8,6 +8,9 @@ import (
 
 	// "github.com/appcelerator/amp/api/rpc/build"
 	"fmt"
+	"math/rand"
+	"strconv"
+
 	"github.com/appcelerator/amp/api/rpc/logs"
 	"github.com/appcelerator/amp/api/rpc/oauth"
 	"github.com/appcelerator/amp/api/rpc/service"
@@ -21,8 +24,6 @@ import (
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/nats-io/nats"
 	"google.golang.org/grpc"
-	"math/rand"
-	"strconv"
 )
 
 const (
@@ -77,10 +78,10 @@ func Start(config Config) {
 	service.RegisterServiceServer(s, &service.Service{
 		Docker: runtime.Docker,
 	})
-	stack.RegisterStackServiceServer(s, &stack.Server{
-		Store:  runtime.Store,
-		Docker: runtime.Docker,
-	})
+	stack.RegisterStackServiceServer(s, stack.NewServer(
+		runtime.Store,
+		runtime.Docker,
+	))
 	topic.RegisterTopicServer(s, &topic.Server{
 		Store: runtime.Store,
 		Nats:  runtime.Nats,

--- a/api/state/machine.go
+++ b/api/state/machine.go
@@ -3,8 +3,9 @@ package state
 import (
 	"context"
 	"fmt"
-	"github.com/appcelerator/amp/data/storage"
 	"path"
+
+	"github.com/appcelerator/amp/data/storage"
 )
 
 const statesRootKey = "states"


### PR DESCRIPTION
Fixes panic in machine.go due to store being null due to timing during server initialization.

To test:

edit platform_infrastructure.go to use ampVersion local
run `amp pf stop && docker build -t appcelerator/amp:local . && make install && amp pf start && make test`