### PR TITLE
Add amplifier-gateway to platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ install:
   - sudo apt-get install docker-engine
   - docker swarm init --advertise-addr 127.0.0.1
   - make install
-  - amp platform pull
-  - amp platform start
+  - ./shrink.sh local
+  - amp platform pull --local
+  - amp platform start --local
 
 script:
   - make test

--- a/cmd/amp/platform_infrastructure.go
+++ b/cmd/amp/platform_infrastructure.go
@@ -20,7 +20,7 @@ const (
 	elasticsearchVersion = "2.3.5"
 	etcdVersion          = "3.1.0-rc.1"
 	natsVersion          = "0.3.0"
-	haproxyVersion       = "1.0.1"
+	haproxyVersion       = "1.0.2"
 	registryVersion      = "2.5.1"
 	tickConfigVersion    = "0.4.0"
 )
@@ -31,7 +31,11 @@ func getAMPInfrastructureStack(m *ampManager) *ampStack {
 	stack.init()
 
 	//add images
-	stack.addImage("amp", "appcelerator/amp:"+ampVersion)
+	if m.local {
+		stack.addImage("amp", "appcelerator/amp:local")
+	} else {
+		stack.addImage("amp", "appcelerator/amp:"+ampVersion)
+	}
 	stack.addImage("amp-ui", "appcelerator/amp-ui:"+uiVersion)
 	stack.addImage("elasticsearch", "appcelerator/elasticsearch-amp:"+elasticsearchVersion)
 	stack.addImage("grafana", "appcelerator/grafana-amp:"+grafanaVersion)
@@ -564,6 +568,37 @@ func getAMPInfrastructureStack(m *ampManager) *ampStack {
 			},
 		},
 		"etcd", "nats", "elasticsearch", "influxdb")
+
+	//add amplifier-gateway
+	stack.addService(m, "amplifier-gateway", "amp", 1,
+		&swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Labels: map[string]string{
+					"io.amp.role": "infrastructure",
+				},
+			},
+			TaskTemplate: swarm.TaskSpec{
+				ContainerSpec: swarm.ContainerSpec{
+					Args: []string{
+						"amplifier-gateway",
+						"--amplifier_endpoint",
+						"amplifier:50101",
+					},
+					Env: nil,
+					Labels: map[string]string{
+						"io.amp.role": "infrastructure",
+					},
+				},
+			},
+			EndpointSpec: nil,
+			Networks: []swarm.NetworkAttachmentConfig{
+				{
+					Target:  infraPublicNetwork,
+					Aliases: []string{"amplifier-gateway"},
+				},
+			},
+		},
+		"amplifier")
 
 	//return stack
 	return &stack

--- a/cmd/amp/platform_manager.go
+++ b/cmd/amp/platform_manager.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -9,8 +12,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/fatih/color"
 	"golang.org/x/net/context"
-	"sort"
-	"time"
 )
 
 const (
@@ -31,6 +32,7 @@ type ampManager struct {
 	silence    bool
 	verbose    bool
 	force      bool
+	local      bool
 	status     string
 	printColor [6]*color.Color
 }
@@ -153,6 +155,9 @@ func (s *ampManager) stop(stack *ampStack) error {
 
 func (s *ampManager) pull(stack *ampStack) error {
 	for _, image := range stack.imageMap {
+		if s.local && image == "appcelerator/amp:local" {
+			continue
+		}
 		s.printf(colInfo, "Pulling image %s\n", image)
 		options := types.ImagePullOptions{}
 		if RegistryToken != "" {

--- a/cmd/amp/platform_pull.go
+++ b/cmd/amp/platform_pull.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // PlatformPull is the main command for attaching platform subcommands.
@@ -17,6 +18,7 @@ var PlatformPull = &cobra.Command{
 
 func init() {
 	PlatformPull.Flags().BoolP("silence", "s", false, "no console output at all")
+	PlatformPull.Flags().BoolP("local", "l", false, "use local amp image")
 	PlatformCmd.AddCommand(PlatformPull)
 }
 
@@ -27,6 +29,9 @@ func pullAMPImages(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flag("verbose").Value.String() == "true" {
 		manager.verbose = true
+	}
+	if cmd.Flag("local").Value.String() == "true" {
+		manager.local = true
 	}
 	if err := manager.init("Pulling AMP images"); err != nil {
 		manager.printf(colError, "Pull error: %v\n", err)

--- a/cmd/amp/platform_start.go
+++ b/cmd/amp/platform_start.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // PlatformStart is the main command for attaching platform subcommands.
@@ -18,6 +19,7 @@ var PlatformStart = &cobra.Command{
 func init() {
 	PlatformStart.Flags().BoolP("force", "f", false, "Start all possible services, do not stop on error")
 	PlatformStart.Flags().BoolP("silence", "s", false, "no console output at all")
+	PlatformStart.Flags().BoolP("local", "l", false, "use local amp image")
 	PlatformCmd.AddCommand(PlatformStart)
 }
 
@@ -31,6 +33,9 @@ func startAMP(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flag("verbose").Value.String() == "true" {
 		manager.verbose = true
+	}
+	if cmd.Flag("local").Value.String() == "true" {
+		manager.local = true
 	}
 	if err := manager.init("Starting AMP platform"); err != nil {
 		manager.printf(colError, "Start error: %v\n", err)

--- a/cmd/amp/platform_status.go
+++ b/cmd/amp/platform_status.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // PlatformStatus is the main command for attaching platform subcommands.
@@ -17,6 +18,7 @@ var PlatformStatus = &cobra.Command{
 
 func init() {
 	PlatformStatus.Flags().BoolP("silence", "s", false, "no console output at all")
+	PlatformStatus.Flags().BoolP("local", "l", false, "use local amp image")
 	PlatformCmd.AddCommand(PlatformStatus)
 }
 
@@ -27,6 +29,9 @@ func getAMPStatus(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flag("verbose").Value.String() == "true" {
 		manager.verbose = true
+	}
+	if cmd.Flag("local").Value.String() == "true" {
+		manager.local = true
 	}
 	if err := manager.init(""); err != nil {
 		manager.printf(colError, "Compute status error: %v\n", err)

--- a/cmd/amp/platform_stop.go
+++ b/cmd/amp/platform_stop.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // PlatformStop is the main command for attaching platform subcommands.
@@ -17,6 +18,7 @@ var PlatformStop = &cobra.Command{
 
 func init() {
 	PlatformStop.Flags().BoolP("silence", "s", false, "no console output at all")
+	PlatformStop.Flags().BoolP("local", "l", false, "use local amp image")
 	PlatformCmd.AddCommand(PlatformStop)
 }
 
@@ -27,6 +29,9 @@ func stopAMP(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flag("verbose").Value.String() == "true" {
 		manager.verbose = true
+	}
+	if cmd.Flag("local").Value.String() == "true" {
+		manager.local = true
 	}
 	if err := manager.init("Stopping AMP platform"); err != nil {
 		manager.printf(colError, "Start error: %v\n", err)

--- a/shrink.sh
+++ b/shrink.sh
@@ -50,6 +50,12 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 echo "OK"
+$DOCKER cp amp-builder:/go/bin/amplifier-gateway ./amplifier-gateway >&2
+if [ $? -ne 0 ]; then
+  echo "failed"
+  exit 1
+fi
+echo "OK"
 
 echo -n "building shrinked image... "
 $DOCKER build -f $SHRINKED_DOCKER_FILE -t appcelerator/amp:$TAG . >&2


### PR DESCRIPTION
Adds amplifier-gateway to `amp platform`

To test:
`make install`
`amp platform pull`
`amp platform start`
`curl amplifier-api.local.atomiq.io/v1/log`