### PR TITLE
add cmd color themes

### DIFF
--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -59,6 +59,7 @@ type Configuration struct {
 	Images        []string
 	Port          string
 	ServerAddress string
+	CmdTheme      string
 }
 
 // AMP holds the state for the current environment

--- a/cmd/amp/platform_manager.go
+++ b/cmd/amp/platform_manager.go
@@ -64,8 +64,9 @@ type ampService struct {
 	user            bool
 }
 
+var currentColorTheme = "default"
 var (
-	colMagenta = 0
+	colRegular = 0
 	colInfo    = 1
 	colWarn    = 2
 	colError   = 3
@@ -75,14 +76,9 @@ var (
 
 func (s *ampManager) init(firstMessage string) error {
 	s.ctx = context.Background()
-	s.printColor[0] = color.New(color.FgMagenta)
-	s.printColor[1] = color.New(color.FgHiBlack)
-	s.printColor[2] = color.New(color.FgYellow)
-	s.printColor[3] = color.New(color.FgRed)
-	s.printColor[4] = color.New(color.FgGreen)
-	s.printColor[5] = color.New(color.FgHiGreen)
+	s.setColors()
 	if firstMessage != "" {
-		s.printf(colMagenta, firstMessage+"\n")
+		s.printf(colRegular, firstMessage+"\n")
 	}
 	if s.force {
 		s.printf(colWarn, "Force mode: on\n")
@@ -283,7 +279,7 @@ func (s *ampManager) monitor(stack *ampStack) {
 			} else if serv.status == "partially running" {
 				s.printf(colWarn, "%s\n", s.displayService(serv, cols))
 			} else if serv.status == "starting" {
-				s.printf(colMagenta, "%s\n", s.displayService(serv, cols))
+				s.printf(colRegular, "%s\n", s.displayService(serv, cols))
 			} else {
 				s.printf(colInfo, "%s\n", s.displayService(serv, cols))
 			}
@@ -613,6 +609,27 @@ func (s *ampManager) printf(col int, format string, args ...interface{}) {
 
 func (s *ampManager) close() {
 	//s.docker.Close()
+}
+
+func (s *ampManager) setColors() {
+	//theme := s.getTheme()
+	theme := AMP.Configuration.CmdTheme
+	if theme == "dark" {
+		s.printColor[0] = color.New(color.FgHiWhite)
+		s.printColor[1] = color.New(color.FgHiBlack)
+		s.printColor[2] = color.New(color.FgYellow)
+		s.printColor[3] = color.New(color.FgRed)
+		s.printColor[4] = color.New(color.FgGreen)
+		s.printColor[5] = color.New(color.FgHiGreen)
+	} else {
+		s.printColor[0] = color.New(color.FgMagenta)
+		s.printColor[1] = color.New(color.FgHiBlack)
+		s.printColor[2] = color.New(color.FgYellow)
+		s.printColor[3] = color.New(color.FgRed)
+		s.printColor[4] = color.New(color.FgGreen)
+		s.printColor[5] = color.New(color.FgHiGreen)
+	}
+	//add theme as you want.
 }
 
 //ampStack & ampService

--- a/cmd/amp/platform_pull.go
+++ b/cmd/amp/platform_pull.go
@@ -45,6 +45,6 @@ func pullAMPImages(cmd *cobra.Command, args []string) error {
 		manager.printf(colError, "Pull error: %v\n", err)
 		os.Exit(1)
 	}
-	manager.printf(colMagenta, "AMP platform images pulled\n")
+	manager.printf(colRegular, "AMP platform images pulled\n")
 	return nil
 }

--- a/cmd/amp/platform_start.go
+++ b/cmd/amp/platform_start.go
@@ -49,7 +49,7 @@ func startAMP(cmd *cobra.Command, args []string) error {
 	manager.computeStatus(stack)
 	if manager.status == "running" {
 		if !manager.force {
-			manager.printf(colMagenta, "AMP platform already started (-f to force a re-start)\n")
+			manager.printf(colRegular, "AMP platform already started (-f to force a re-start)\n")
 			return nil
 		}
 		if err := manager.stop(stack); err != nil {
@@ -64,6 +64,6 @@ func startAMP(cmd *cobra.Command, args []string) error {
 		}
 		os.Exit(1)
 	}
-	manager.printf(colMagenta, "AMP platform started\n")
+	manager.printf(colRegular, "AMP platform started\n")
 	return nil
 }

--- a/cmd/amp/platform_status.go
+++ b/cmd/amp/platform_status.go
@@ -42,7 +42,7 @@ func getAMPStatus(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	manager.computeStatus(getAMPInfrastructureStack(manager))
-	manager.printf(colMagenta, "status: %s\n", manager.status)
+	manager.printf(colRegular, "status: %s\n", manager.status)
 	if manager.status != "running" {
 		os.Exit(1)
 	}

--- a/cmd/amp/platform_stop.go
+++ b/cmd/amp/platform_stop.go
@@ -44,13 +44,13 @@ func stopAMP(cmd *cobra.Command, args []string) error {
 	stack := getAMPInfrastructureStack(manager)
 	manager.computeStatus(stack)
 	if manager.status == "stopped" {
-		manager.printf(colMagenta, "AMP platform already stopped\n")
+		manager.printf(colRegular, "AMP platform already stopped\n")
 		return nil
 	}
 	if err := manager.stop(stack); err != nil {
 		manager.printf(colError, "Stop error: %v\n", err)
 		os.Exit(1)
 	}
-	manager.printf(colMagenta, "AMP platform stopped\n")
+	manager.printf(colRegular, "AMP platform stopped\n")
 	return nil
 }


### PR DESCRIPTION
Related to #477 

Have amp commands color themes to adapt colors to different terminals L&F.
Default is the "magenta" theme created by Neha, but it doesn't look good on Ubuntu  default terminal which are magenta dark by default.
Added one named "dark" to be back to the original colors (white in place of magenta)

to change it, update $HOME/.amp.yaml file adding this line for instance:
cmdTheme: dark

For now only 2 themes (default or dark) 

Test:
- make install
- start/stop amp: see the regular lines are magenta
- update .amp.yml as explained
- start/stop amp: see the regular lines are white

It's possible to add new theme updating cmd/amp/platform_manager.go
