### PR TITLE
Disable refresh on index

### DIFF
--- a/data/elasticsearch/elasticsearch.go
+++ b/data/elasticsearch/elasticsearch.go
@@ -67,7 +67,6 @@ func (es *Elasticsearch) Index(esIndex string, esType string, body interface{}) 
 		Index(esIndex).
 		Type(esType).
 		BodyJson(body).
-		Refresh(true).
 		Do()
 	if err != nil {
 		return err


### PR DESCRIPTION
Disable forced refresh on index for elasticsearch to reduce CPU load

## Verification
    $ amp pf stop
    $ make install
    $ ./shrink.sh local
    $ amp pf start --local
    $ make test
