### PR TITLE
cli_test.go refactoring + #513 fix

### DIFF
--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -1,34 +1,24 @@
-package cli_test
+package cli
 
 import (
 	"fmt"
 	"os/exec"
 	"sync"
 
-	"bytes"
-	"context"
-	"io/ioutil"
-	"math/rand"
-	"path"
-	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
-
-	"gopkg.in/yaml.v2"
 )
 
-//TestSpec contains all the CommandSpec objects
+// TestSpec contains all the CommandSpec objects
 type TestSpec struct {
 	Name     string
 	Timeout  time.Duration
 	Commands []CommandSpec
 }
 
-//CommandSpec defines the commands with arguments and options
+// CommandSpec defines the commands with arguments and options
 type CommandSpec struct {
 	Cmd         string   `yaml:"cmd"`
 	Args        []string `yaml:"args"`
@@ -39,171 +29,120 @@ type CommandSpec struct {
 	Delay       string   `yaml:"delay"`
 }
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 var (
-	testDir      = "./samples"
-	lookupDir    = "./lookup"
-	regexMap     map[string]string
 	suiteTimeout string
+	lookupDir    = "./lookup"
+	sampleDir    = "./samples"
+	regexMap     map[string]string
 	wg           sync.WaitGroup
 )
 
-//read, parse and execute test commands
+// read, parse and execute test commands
 func TestCmds(t *testing.T) {
-	suiteTimeout = "1m"
+	// test suite timeout
+	suiteTimeout = "25s"
 	duration, err := time.ParseDuration(suiteTimeout)
 	if err != nil {
-		t.Errorf("Unable to generate suite timeout, reason: %v", err)
+		t.Errorf("Unable to create duration for timeout: Suite. Error: %v", err)
 		return
 	}
-	//test suite context
-	ctxSuite, cancelSuite := context.WithTimeout(context.Background(), duration)
+	// create test suite context
+	cancelSuite := createTimeout(t, duration, "Suite")
 	defer cancelSuite()
-	go checkTimeout(t, ctxSuite, "Suite")
-	err = loadRegexLookup()
+	// parse regexes
+	err = parseLookup(lookupDir)
 	if err != nil {
 		t.Errorf("Unable to load lookup specs, reason: %v", err)
 		return
 	}
-	tests, err := loadTestSpecs()
+	// parse test samples
+	tests, err := parseSpec(sampleDir, duration)
 	if err != nil {
 		t.Errorf("Unable to load test specs, reason: %v", err)
 		return
 	}
 	wg.Add(len(tests))
+	t.Logf("-----------------------------------------------------------------------------------------")
 	for _, test := range tests {
-		t.Logf("-----------------------------------------------------------------------------------------")
 		t.Logf("Running spec: %s", test.Name)
-		//test spec context
-		ctxSpec, cancelSpec := context.WithTimeout(context.Background(), test.Timeout)
-		defer cancelSpec()
-		go checkTimeout(t, ctxSpec, test.Name)
 		go runTestSpec(t, test)
 	}
 	wg.Wait()
+	t.Logf("-----------------------------------------------------------------------------------------")
 	t.Log("Finished!")
 }
 
-//read test_samples directory by parsing its contents
-func loadTestSpecs() ([]*TestSpec, error) {
-	files, err := ioutil.ReadDir(testDir)
-	if err != nil {
-		return nil, err
-	}
-	tests := []*TestSpec{}
-	for _, file := range files {
-		test, err := loadTestSpec(path.Join(testDir, file.Name()))
-		if err != nil {
-			return nil, err
-		}
-		if test != nil {
-			tests = append(tests, test)
-		}
-	}
-	return tests, nil
-}
-
-//parse test_samples directory and unmarshal its contents
-func loadTestSpec(fileName string) (*TestSpec, error) {
-	if filepath.Ext(fileName) != ".yml" {
-		return nil, nil
-	}
-	content, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to load test spec: %s. Error: %v", fileName, err)
-	}
-	duration, duraErr := time.ParseDuration("0ms")
-	if duraErr != nil {
-		return nil, fmt.Errorf("Unable to create duration for timeout: %s. Error: %v", fileName, err)
-	}
-	testSpec := &TestSpec{
-		Name:    fileName,
-		Timeout: duration,
-	}
-
-	var commandMap []CommandSpec
-	if err := yaml.Unmarshal(content, &commandMap); err != nil {
-		return nil, fmt.Errorf("Unable to parse test spec: %s. Error: %v", fileName, err)
-	}
-
-	for _, command := range commandMap {
-		if command.Timeout == "" {
-			command.Timeout = "5000ms"
-		}
-		testSpecTimeout := "1m"
-		duration, duraErr := time.ParseDuration(testSpecTimeout)
-		if duraErr != nil {
-			return nil, fmt.Errorf("Unable to create duration for timeout: %s. Error: %v", fileName, err)
-		}
-		testSpec.Timeout = duration
-		testSpec.Commands = append(testSpec.Commands, command)
-	}
-	return testSpec, nil
-}
-
-//execute commands and check for timeout, delay and retry
+// execute commands and check for timeout, delay and retry
 func runTestSpec(t *testing.T, test *TestSpec) {
 	defer wg.Done()
+	// test spec timeout
+	testSpecTimeout := "20s"
+	duration, duraErr := time.ParseDuration(testSpecTimeout)
+	if duraErr != nil {
+		t.Errorf("Unable to create duration for timeout: TestSpec. Error: %v", duraErr)
+		return
+	}
+	// create test spec context
+	cancelTestSpec := createTimeout(t, duration, test.Name)
+	defer cancelTestSpec()
 	var i int
 	var cache = map[string]string{}
 	var err error
-	//iterate through all the testSpec
+	// iterate through all the testSpec
 	for _, cmdSpec := range test.Commands {
 		var cmdTmplString []string
-		duration, duraErr := time.ParseDuration(cmdSpec.Timeout)
+		duration, duraErr = time.ParseDuration(cmdSpec.Timeout)
 		if duraErr != nil {
-			t.Log("Parsing duration failed: %v", err)
-			t.Fail()
+			t.Log("Unable to create duration for timeout: %s. Error: %v", cmdSpec.Cmd, duraErr)
+			t.Fatal()
 		}
-		//cmd Spec context
-		ctx, cancel := context.WithTimeout(context.Background(), duration)
-		go checkTimeout(t, ctx, cmdSpec.Cmd)
+		// cmd Spec context
+		cancelCmdSpec := createTimeout(t, duration, cmdSpec.Cmd)
 		for i = -1; i < cmdSpec.Retry; i++ {
-			//err is set to nil a the beginning of the loop to ensure that each time a
-			//command is retried or executed atleast once without the error assigned
-			//from the previous executions
+			// err is set to nil a the beginning of the loop to ensure that each time a
+			// command is retried or executed atleast once without the error assigned
+			// from the previous executions
 			err = nil
 
-			//generate command string from cmdSpec
+			// generate command string from cmdSpec
 			cmdString := generateCmdString(&cmdSpec)
 
-			//perform templating on cmdString
-			cmdTmplOutput, tmplErr := performTemplating(strings.Join(cmdString, " "), cache)
+			// perform templating on cmdString
+			cmdTmplOutput, tmplErr := templating(strings.Join(cmdString, " "), cache)
 			if tmplErr != nil {
-				t.Log("Executing templating failed: %s", tmplErr)
-				t.Fail()
+				t.Log("Executing templating failed: %s. Error: %v", cmdString, tmplErr)
+				t.Fatal()
 			}
 			cmdTmplString = strings.Fields(cmdTmplOutput)
 
-			//execute command
+			// execute command
 			cmdOutput, cmdErr := exec.Command(cmdTmplString[0], cmdTmplString[1:]...).CombinedOutput()
 			t.Logf("Running: %s", strings.Join(cmdTmplString, " "))
 
 			//perform templating on RegEx string
-			regexTmplOutput, tmplErr := performTemplating(cmdSpec.Expectation, cache)
+			regexTmplOutput, tmplErr := templating(regexMap[cmdSpec.Expectation], cache)
 			if tmplErr != nil {
-				t.Log("Executing templating failed: %s", tmplErr)
-				t.Fail()
+				t.Log("Executing templating failed: %s. Error: %v", cmdSpec.Expectation, tmplErr)
+				t.Fatal()
 			}
 
-			//check if the command output matches the RegEx
+			// check if the command output matches the RegEx
 			expectedOutput := regexp.MustCompile(regexTmplOutput)
 			if !expectedOutput.MatchString(string(cmdOutput)) {
 				err = fmt.Errorf("Mismatched expected output: %s : Error: %v", cmdOutput, cmdErr)
 				t.Log(err)
 			}
 
-			//if no error after retries, break the loop to continue command execution
+			// if no error after retries, break the loop to continue command execution
 			if err == nil {
 				break
 			}
-			//add delay (in Millisecond) to wait for command execution
+			// add delay (in Millisecond) to wait for command execution
 			if cmdSpec.Delay != "" {
 				del, delErr := time.ParseDuration(cmdSpec.Delay)
 				if delErr != nil {
 					t.Log("Invalid delay specified: %s : Error: %v", cmdSpec.Delay, delErr)
-					t.Fail()
+					t.Fatal()
 				}
 				time.Sleep(del)
 			}
@@ -213,14 +152,14 @@ func runTestSpec(t *testing.T, test *TestSpec) {
 		}
 		if err != nil {
 			t.Log(err)
-			t.Fail()
+			t.Fatal()
 		}
-		cancel()
+		cancelCmdSpec()
 	}
 }
 
-//create an array of strings representing the commands by concatenating
-//all the fields from the yml files in test_samples directory
+// create an array of strings representing the commands by concatenating
+// all the fields from the yml files in test_samples directory
 func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
 	cmdSplit := strings.Fields(cmdSpec.Cmd)
 	optionsSplit := []string{}
@@ -229,100 +168,5 @@ func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
 	}
 	cmdString = append(cmdSplit, cmdSpec.Args...)
 	cmdString = append(cmdString, optionsSplit...)
-	if regexMap[cmdSpec.Expectation] != "" {
-		cmdSpec.Expectation = regexMap[cmdSpec.Expectation]
-	}
 	return
-}
-
-//read lookup directory by parsing its contents
-func loadRegexLookup() error {
-	files, err := ioutil.ReadDir(lookupDir)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		err := parseLookup(path.Join(lookupDir, file.Name()))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-//parse lookup directory and unmarshal its contents
-func parseLookup(file string) error {
-	if filepath.Ext(file) != ".yml" {
-		return nil
-	}
-	pairs, err := ioutil.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("Unable to load regex lookup: %s. Error: %v", file, err)
-	}
-	if err := yaml.Unmarshal(pairs, &regexMap); err != nil {
-		return fmt.Errorf("Unable to parse regex lookup: %s. Error: %v", file, err)
-	}
-	return nil
-}
-
-//create, parse and execute a template to generate unique values
-func performTemplating(s string, cache map[string]string) (output string, err error) {
-	var t *template.Template
-	t, err = template.New("Command").Parse(s)
-	if err != nil {
-		return
-	}
-	//custom function to create a unique name with a randomly generated string
-	name := func(in string) string {
-		if val, ok := cache[in]; ok {
-			return val
-		}
-		out := in + randString(10)
-		cache[in] = out
-		return out
-	}
-	//custom function to randomly generate a port number
-	port := func(in string, min, max int) string {
-		if val, ok := cache[in]; ok {
-			return val
-		}
-		out := strconv.Itoa(rand.Intn(max-min) + min)
-		cache[in] = out
-		return out
-	}
-	var doc bytes.Buffer
-	//add the custom functions to template for execution
-	var fMap = template.FuncMap{
-		"uniq": func(in string) string { return name(in) },
-		"port": func(in string, min, max int) string { return port(in, min, max) },
-	}
-	//execute the parsed template
-	err = t.Execute(&doc, fMap)
-	if err != nil {
-		return
-	}
-	output = doc.String()
-	return
-}
-
-//generate a random string consisting of uppercase and lowercase characters
-func randString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
-	}
-	return string(b)
-}
-
-//repeatedly call the done() method for the context, fail if the deadline exceeds
-func checkTimeout(t *testing.T, ctx context.Context, name string) {
-	for {
-		select {
-		case <-ctx.Done():
-			if ctx.Err() == context.DeadlineExceeded {
-				t.Fatal("Deadline exceeded:", name)
-			}
-			return
-		}
-	}
 }

--- a/tests/cli/context.go
+++ b/tests/cli/context.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// create the timeout goroutine and return the cancelFunc
+func createTimeout(t *testing.T, duration time.Duration, name string) (cancel func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	go checkTimeout(t, ctx, name)
+	return cancel
+}
+
+// repeatedly call the done() method for the context, fail if the deadline exceeds
+func checkTimeout(t *testing.T, ctx context.Context, name string) {
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatal("Deadline exceeded:", name)
+			}
+			return
+		}
+	}
+}

--- a/tests/cli/parse.go
+++ b/tests/cli/parse.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// read lookup directory by parsing its contents
+func parseLookup(directory string) error {
+	files, err := ioutil.ReadDir(lookupDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		err := generateRegexes(path.Join(lookupDir, file.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parse lookup directory and unmarshal its contents
+func generateRegexes(fileName string) error {
+	if filepath.Ext(fileName) != ".yml" {
+		return fmt.Errorf("Cannot parse non-yaml file: %s", fileName)
+	}
+	pairs, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return fmt.Errorf("Unable to read yaml regex lookup: %s. Error: %v", fileName, err)
+	}
+	if err := yaml.Unmarshal(pairs, &regexMap); err != nil {
+		return fmt.Errorf("Unable to unmarshal yaml regex lookup: %s. Error: %v", fileName, err)
+	}
+	return nil
+}
+
+// read specs from directory by parsing its contents
+func parseSpec(directory string, timeout time.Duration) ([]*TestSpec, error) {
+	files, err := ioutil.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	tests := []*TestSpec{}
+	for _, file := range files {
+		test, err := generateTestSpecs(path.Join(directory, file.Name()), timeout)
+		if err != nil {
+			return nil, err
+		}
+		if test != nil {
+			tests = append(tests, test)
+		}
+	}
+	return tests, nil
+}
+
+// parse samples directory and unmarshal its contents
+func generateTestSpecs(fileName string, timeout time.Duration) (*TestSpec, error) {
+	if filepath.Ext(fileName) != ".yml" {
+		return nil, fmt.Errorf("Cannot parse non-yaml file: %s", fileName)
+	}
+	contents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read yaml test spec: %s. Error: %v", fileName, err)
+	}
+	testSpec := &TestSpec{
+		Name:    fileName,
+		Timeout: timeout,
+	}
+	var commandMap []CommandSpec
+	if err = yaml.Unmarshal(contents, &commandMap); err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal yaml test spec: %s. Error: %v", fileName, err)
+	}
+	for _, command := range commandMap {
+		if command.Timeout == "" {
+			// command spec timeout
+			command.Timeout = "5s"
+		}
+		testSpec.Commands = append(testSpec.Commands, command)
+	}
+	return testSpec, nil
+}

--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -13,10 +13,9 @@
   options:
   expectation: docker-service-list-valid-service
   retry: 15
-  delay: 1000ms
-  timeout: 15000ms
+  delay: 1s
+  timeout: 15s
 
-# Should use API call as a form of blocking.
 - service-curl:
   cmd: curl
   args:
@@ -24,8 +23,8 @@
   options:
   expectation: service-curl
   retry: 15
-  delay: 1000ms
-  timeout: 15000ms
+  delay: 1s
+  timeout: 15s
 
 - service-remove:
   cmd: amp service rm
@@ -34,7 +33,6 @@
   options:
     -
   expectation: service-remove
-    # "pinger-[[:alpha:]]+"
 
 - service-list:
   cmd: docker service ls

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -3,8 +3,9 @@
   args:
      - "{{call .uniq `stack1`}}"
   options:
-     - -f ../../api/rpc/stack/test_samples/sample-04.yml
+     - -f ../../api/rpc/stack/test_samples/sample-01.yml
   expectation: stack-id
+  timeout: 10s
 
 - stack-list:
   cmd: amp stack ls
@@ -37,6 +38,7 @@
   options:
     -
   expectation: stack-id
+  timeout: 10s
 
 - stack-list:
   cmd: amp stack ls

--- a/tests/cli/template.go
+++ b/tests/cli/template.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"math/rand"
+	"strconv"
+	"text/template"
+	"time"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+// create, parse and execute a template to generate unique values
+func templating(input string, cache map[string]string) (output string, err error) {
+	var tmpl *template.Template
+	tmpl, err = template.New("Command").Parse(input)
+	if err != nil {
+		return
+	}
+	// custom function to create a unique name with a randomly generated string
+	name := func(in string) string {
+		if val, ok := cache[in]; ok {
+			return val
+		}
+		out := in + randUniq(10)
+		cache[in] = out
+		return out
+	}
+	// custom function to randomly generate a port number
+	port := func(in string, min, max int) string {
+		if val, ok := cache[in]; ok {
+			return val
+		}
+		out := randPort(min, max)
+		cache[in] = out
+		return out
+	}
+	var doc bytes.Buffer
+	// add the custom functions to template for execution
+	var fMap = template.FuncMap{
+		"uniq": func(in string) string { return name(in) },
+		"port": func(in string, min, max int) string { return port(in, min, max) },
+	}
+	// execute the parsed template
+	err = tmpl.Execute(&doc, fMap)
+	if err != nil {
+		return
+	}
+	output = doc.String()
+	return
+}
+
+// generate a random string consisting of uppercase and lowercase characters
+func randUniq(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+// generate a random number between the minimum and maximum values
+func randPort(min int, max int) string {
+	return strconv.Itoa(rand.Intn(max-min) + min)
+}


### PR DESCRIPTION
Refactoring and cleaning up the `cli_test.go` file. The file was getting quite large.

Moved the parsing and templating methods in to separate files, along with a new method for creating contexts (`createTimeout`) and the `checkTimeout` method in another separate file. 

Some additional comments added.

to test either
`go test ./tests/cli`
or 
`make test`