### PR TITLE
Cli tests - synchronous testing of platform commands

### DIFF
--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -25,18 +25,19 @@ type CommandSpec struct {
 	Args        []string `yaml:"args"`
 	Options     []string `yaml:"options"`
 	Expectation string   `yaml:"expectation"`
+	Skip        bool     `yaml:"skip"`
 	Retry       int      `yaml:"retry"`
 	Timeout     string   `yaml:"timeout"`
 	Delay       string   `yaml:"delay"`
 }
 
 var (
-	lookupDir    = "./lookup"
-	setupDir     = "./setup"
-	sampleDir    = "./samples"
-	tearDownDir  = "./tearDown"
-	wg           sync.WaitGroup
-	regexMap     map[string]string
+	lookupDir   = "./lookup"
+	setupDir    = "./setup"
+	sampleDir   = "./samples"
+	tearDownDir = "./tearDown"
+	wg          sync.WaitGroup
+	regexMap    map[string]string
 )
 
 // read, parse and execute test commands

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"os/exec"
 	"sync"
 
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -30,127 +31,212 @@ type CommandSpec struct {
 }
 
 var (
-	suiteTimeout string
 	lookupDir    = "./lookup"
+	setupDir     = "./setup"
 	sampleDir    = "./samples"
-	regexMap     map[string]string
+	tearDownDir  = "./tearDown"
 	wg           sync.WaitGroup
+	regexMap     map[string]string
 )
 
 // read, parse and execute test commands
-func TestCmds(t *testing.T) {
+func TestCliCmds(t *testing.T) {
+
 	// test suite timeout
-	suiteTimeout = "10m"
+	suiteTimeout := "10m"
 	duration, err := time.ParseDuration(suiteTimeout)
 	if err != nil {
-		t.Errorf("Unable to create duration for timeout: Suite. Error: %v", err)
+		t.Errorf("Unable to create duration for timeout: Suite. Error:", err)
 		return
 	}
 	// create test suite context
-	cancelSuite := createTimeout(t, duration, "Suite")
-	defer cancelSuite()
+	cancel := createTimeout(t, duration, "Suite")
+	defer cancel()
+
 	// parse regexes
 	regexMap, err = parseLookup(lookupDir)
 	if err != nil {
-		t.Errorf("Unable to load lookup specs, reason: %v", err)
+		t.Errorf("Unable to load lookup specs, reason:", err)
 		return
 	}
-	// parse test samples
-	tests, err := parseSpec(sampleDir, duration)
+
+	// create setup timeout and parse setup specs
+	setupTimeout := "8m"
+	setup, err := createTestSpecs(setupDir, setupTimeout)
 	if err != nil {
-		t.Errorf("Unable to load test specs, reason: %v", err)
+		t.Errorf("Unable to create setup specs, reason:", err)
 		return
 	}
-	wg.Add(len(tests))
-	for _, test := range tests {
-		go runTestSpec(t, test)
+
+	// create samples timeout and parse sample specs
+	sampleTimeout := "30s"
+	samples, err := createTestSpecs(sampleDir, sampleTimeout)
+	if err != nil {
+		t.Errorf("Unable to create sample specs, reason:", err)
+		return
 	}
+
+	// create teardown timeout and parse tearDown specs
+	tearDownTimeout := "1.5m"
+	tearDown, err := createTestSpecs(tearDownDir, tearDownTimeout)
+	if err != nil {
+		t.Errorf("Unable to create tearDown specs, reason:", err)
+		return
+	}
+
+	noOfSpecs := len(samples)
+
+	runFramework(t, setup)
+	wg.Add(noOfSpecs)
+	runTests(t, samples)
 	wg.Wait()
+	runFramework(t, tearDown)
 }
 
-// execute commands and check for timeout, delay and retry
-func runTestSpec(t *testing.T, test *TestSpec) {
-	defer wg.Done()
+func createTestSpecs(directory string, timeout string) ([]*TestSpec, error) {
 	// test spec timeout
-	testSpecTimeout := "2m"
-	duration, duraErr := time.ParseDuration(testSpecTimeout)
-	if duraErr != nil {
-		t.Fatal("Unable to create duration for timeout: TestSpec. Error: %v", duraErr)
+	duration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create duration for timeout: %s. Error: %v", directory, err)
 	}
-	// create test spec context
-	cancelTestSpec := createTimeout(t, duration, test.Name)
-	defer cancelTestSpec()
-	var i int
+	// parse tests
+	testSpecs, err := parseSpec(directory, duration)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load test specs: %s. reason: %v", directory, err)
+	}
+	return testSpecs, nil
+}
+
+// runs a framework (setup/tearDown)
+func runFramework(t *testing.T, commands []*TestSpec) {
+	for _, command := range commands {
+		runFrameworkSpec(t, command)
+	}
+}
+
+// runs test commands
+func runTests(t *testing.T, samples []*TestSpec) {
+	for _, sample := range samples {
+		go runSampleSpec(t, sample)
+	}
+}
+
+// execute framework commands and check for timeout, delay and retry
+func runFrameworkSpec(t *testing.T, test *TestSpec) {
+
 	var cache = map[string]string{}
-	var err error
+
+	// create test spec context
+	cancel := createTimeout(t, test.Timeout, test.Name)
+	defer cancel()
+
 	// iterate through all the testSpec
-	for _, cmdSpec := range test.Commands {
-		var cmdTmplString []string
-		duration, duraErr = time.ParseDuration(cmdSpec.Timeout)
-		if duraErr != nil {
-			t.Fatal("Unable to create duration for timeout: %s. Error: %v", cmdSpec.Cmd, duraErr)
+	for _, command := range test.Commands {
+		runCmdSpec(t, command, cache)
+	}
+}
+
+// execute sample commands and decrement waitgroup counter
+func runSampleSpec(t *testing.T, test *TestSpec) {
+
+	var cache = map[string]string{}
+
+	// decrements wg counter
+	defer wg.Done()
+
+	// create test spec context
+	cancel := createTimeout(t, test.Timeout, test.Name)
+	defer cancel()
+
+	// iterate through all the testSpec
+	for _, command := range test.Commands {
+		runCmdSpec(t, command, cache)
+	}
+}
+
+//
+func runCmdSpec(t *testing.T, cmd CommandSpec, cache map[string]string) {
+
+	var i int
+	var err error
+
+	// command Spec timeout
+	duration, duraErr := time.ParseDuration(cmd.Timeout)
+	if duraErr != nil {
+		t.Fatal("Unable to create duration for timeout:", cmd.Cmd, "Error:", duraErr)
+	}
+	// command Spec context
+	cancel := createTimeout(t, duration, cmd.Cmd)
+	defer cancel()
+
+	// generate command slice from cmdSpec
+	cmdSlice := generateCmdString(cmd)
+	cmdString := strings.Join(cmdSlice, " ")
+
+	// perform templating on command
+	cmdTmplOutput, tmplErr := templating(cmdString, cache)
+	if tmplErr != nil {
+		t.Fatal("Executing templating failed:", cmdString, "Error:", tmplErr)
+	}
+	cmdTmplString := strings.Fields(cmdTmplOutput)
+
+	// checks if the expectation has a corresponding regex
+	if cmd.Expectation != "" && regexMap[cmd.Expectation] == "" {
+		t.Fatal("Unable to fetch regex for command:", cmdTmplString, "reason: no regex for given expectation:", cmd.Expectation)
+	}
+
+	// perform templating on RegEx string
+	regexTmplOutput, tmplErr := templating(regexMap[cmd.Expectation], cache)
+	if tmplErr != nil {
+		t.Fatal("Executing templating failed:", cmd.Expectation, "Error:", tmplErr)
+	}
+
+	for i = 0; i <= cmd.Retry; i++ {
+		// err is set to nil a the beginning of the loop to ensure that each time a
+		// command is retried or executed atleast once without the error assigned
+		// from the previous executions
+		err = nil
+
+		// execute command
+		cmdOutput, _ := exec.Command(cmdTmplString[0], cmdTmplString[1:]...).CombinedOutput()
+
+		// check if the command output matches the RegEx
+		expectedOutput := regexp.MustCompile(regexTmplOutput)
+		if !expectedOutput.MatchString(string(cmdOutput)) {
+			errString := "Mismatched expected output: " + string(cmdOutput)
+			err = errors.New(errString)
 		}
-		// cmd Spec context
-		cancelCmdSpec := createTimeout(t, duration, cmdSpec.Cmd)
-		for i = -1; i < cmdSpec.Retry; i++ {
-			// err is set to nil a the beginning of the loop to ensure that each time a
-			// command is retried or executed atleast once without the error assigned
-			// from the previous executions
-			err = nil
 
-			// generate command string from cmdSpec
-			cmdString := generateCmdString(&cmdSpec)
-
-			// perform templating on cmdString
-			cmdTmplOutput, tmplErr := templating(strings.Join(cmdString, " "), cache)
-			if tmplErr != nil {
-				t.Fatal("Executing templating failed: %s. Error: %v", cmdString, tmplErr)
+		// add delay to wait after command execution
+		if cmd.Delay != "" {
+			del, delErr := time.ParseDuration(cmd.Delay)
+			if delErr != nil {
+				t.Fatal("Invalid delay specified: ", cmd.Delay, "Error:", delErr)
 			}
-			cmdTmplString = strings.Fields(cmdTmplOutput)
-
-			// execute command
-			cmdOutput, _ := exec.Command(cmdTmplString[0], cmdTmplString[1:]...).CombinedOutput()
-
-			//perform templating on RegEx string
-			regexTmplOutput, tmplErr := templating(regexMap[cmdSpec.Expectation], cache)
-			if tmplErr != nil {
-				t.Fatal("Executing templating failed: %s. Error: %v", cmdSpec.Expectation, tmplErr)
-			}
-
-			// check if the command output matches the RegEx
-			expectedOutput := regexp.MustCompile(regexTmplOutput)
-			if !expectedOutput.MatchString(string(cmdOutput)) {
-				err = fmt.Errorf("Mismatched expected output: %s", string(cmdOutput))
-			}
-
-			// if no error after retries, break the loop to continue command execution
-			if err == nil {
-				break
-			}
-			// add delay (in Millisecond) to wait for command execution
-			if cmdSpec.Delay != "" {
-				del, delErr := time.ParseDuration(cmdSpec.Delay)
-				if delErr != nil {
-					t.Fatal("Invalid delay specified: %s : Error: %v", cmdSpec.Delay, delErr)
-				}
-				time.Sleep(del)
-			}
+			time.Sleep(del)
 		}
-		if i > 0 {
-			t.Log("This command :", cmdTmplString, "has re-run", i, "times.")
+
+		// If there is no error, break the retry loop as there is no need to continue
+		// If there is an error after all the retries have been used, fail the test
+		if err == nil {
+			break
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		cancelCmdSpec()
+	}
+	// If the command did retry, log the no. of times it did
+	if i > 1 {
+		t.Log("The command :", cmdTmplString, "has re-run", i, "times.")
+	}
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
 // create an array of strings representing the commands by concatenating
 // all the fields from the yml files in test_samples directory
-func generateCmdString(cmdSpec *CommandSpec) (cmdString []string) {
+func generateCmdString(cmdSpec CommandSpec) (cmdString []string) {
 	cmdSplit := strings.Fields(cmdSpec.Cmd)
 	optionsSplit := []string{}
+	// Possible to have multiple options
 	for _, val := range cmdSpec.Options {
 		optionsSplit = append(optionsSplit, strings.Fields(val)...)
 	}

--- a/tests/cli/lookup/regex-lookup.yml
+++ b/tests/cli/lookup/regex-lookup.yml
@@ -4,13 +4,7 @@ logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
 docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
 docker-service-list-valid-service:   .*({{call .uniq `pinger`}}).*
 docker-service-list-invalid-service: .*[^{{call .uniq `pinger`}}].*
-docker-swarm-initialize: Swarm initialized(:) current node \(([a-z0-9A-Z]{25})\) is now a manager.\n+To add a worker to this swarm, run the following command:\n+\s+docker swarm join\s+\\\n\s+--token\s+SWMTKN-1-([a-z0-9A-Z]{50})-([a-z0-9A-Z]{25})\s+\\\n\s+192.168.65.2(:)2377\n+To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions
-docker-swarm-leave: "Node left the swarm."
-platform-pull: Pulling AMP images\n(image (appcelerator/(haproxy:|pinger:|amp-nats-streaming:|amp:|amp-ui:|elasticsearch-amp:|grafana-amp:|influxdb-amp:|kapacitor-amp:|telegraf:|etcd:)|registry:)([a-zA-Z0-9\s\.\-:]*) pulled\n)*AMP platform images pulled
-platform-start: "Starting AMP platform\n((Service|Warning: Service) (nats|registry|amp-ui|influxdb|etcd|elasticsearch|telegraf-agent|kapacitor|amp-agent|amp-log-worker|amplifier|haproxy|amplifier-gateway|grafana|telegraf-haproxy) (is ready|is failing)\n)+AMP platform started"
 platform-status-running: "status: running"
-platform-status-stopped: "status: stopped"
-platform-stop: Stopping AMP platform\n(Service (nats|registry|amp-ui|influxdb|etcd|elasticsearch|telegraf-agent|kapacitor|amp-agent|amp-log-worker|amplifier|haproxy|amplifier-gateway|grafana|telegraf-haproxy) removed\n){15}AMP platform stopped
 service-id: ([a-z0-9]){25}
 service-curl: ((.)|(\s))*(pong)((.)|(\s))*
 service-remove: "{{call .uniq `pinger`}}"

--- a/tests/cli/lookup/regex-lookup.yml
+++ b/tests/cli/lookup/regex-lookup.yml
@@ -4,10 +4,17 @@ logs-numbered: ([a-zA-Z0-9\.\-:\"\s\_\t\n\$&%?/\[\]\%\>\<\,\;]*){10}
 docker-service-list: ID\s+NAME\s+REPLICAS\s+IMAGE\s+COMMAND\s*\n([a-zA-Z0-9\s\.\-:/]*){1,}
 docker-service-list-valid-service:   .*({{call .uniq `pinger`}}).*
 docker-service-list-invalid-service: .*[^{{call .uniq `pinger`}}].*
+docker-swarm-initialize: Swarm initialized(:) current node \(([a-z0-9A-Z]{25})\) is now a manager.\n+To add a worker to this swarm, run the following command:\n+\s+docker swarm join\s+\\\n\s+--token\s+SWMTKN-1-([a-z0-9A-Z]{50})-([a-z0-9A-Z]{25})\s+\\\n\s+192.168.65.2(:)2377\n+To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions
+docker-swarm-leave: "Node left the swarm."
+platform-pull: Pulling AMP images\n(image (appcelerator/(haproxy:|pinger:|amp-nats-streaming:|amp:|amp-ui:|elasticsearch-amp:|grafana-amp:|influxdb-amp:|kapacitor-amp:|telegraf:|etcd:)|registry:)([a-zA-Z0-9\s\.\-:]*) pulled\n)*AMP platform images pulled
+platform-start: "Starting AMP platform\n((Service|Warning: Service) (nats|registry|amp-ui|influxdb|etcd|elasticsearch|telegraf-agent|kapacitor|amp-agent|amp-log-worker|amplifier|haproxy|amplifier-gateway|grafana|telegraf-haproxy) (is ready|is failing)\n)+AMP platform started"
+platform-status-running: "status: running"
+platform-status-stopped: "status: stopped"
+platform-stop: Stopping AMP platform\n(Service (nats|registry|amp-ui|influxdb|etcd|elasticsearch|telegraf-agent|kapacitor|amp-agent|amp-log-worker|amplifier|haproxy|amplifier-gateway|grafana|telegraf-haproxy) removed\n){15}AMP platform stopped
 service-id: ([a-z0-9]){25}
 service-curl: ((.)|(\s))*(pong)((.)|(\s))*
 service-remove: "{{call .uniq `pinger`}}"
-stack-list-running: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}({{call .uniq `stack1`}})([a-z0-9A-Z\s]*){1,}
+stack-list-running: NAME\s+ID\s+STATE\s*-+\s*\n+([a-z0-9A-Z\s]*){1,}({{call .uniq `stack`}})([a-z0-9A-Z\s]*){1,}
 stack-list-unavailable: No stack is available
 stack-id: ([a-z0-9]){64}
 stats-container: Service name\s+Container name\s+CPU %%\s+Mem usage\s+Mem %%\s+Disk IO\s+read/write\s+Net Rx/Tx\s*\n-+\s*\n([a-zA-Z0-9\-\.%\s/]*){1,}

--- a/tests/cli/parse.go
+++ b/tests/cli/parse.go
@@ -87,7 +87,9 @@ func generateTestSpecs(fileName string, timeout time.Duration) (*TestSpec, error
 			// default command spec timeout
 			command.Timeout = "30s"
 		}
-		testSpec.Commands = append(testSpec.Commands, command)
+		if command.Skip != true {
+			testSpec.Commands = append(testSpec.Commands, command)
+		}
 	}
 	return testSpec, nil
 }

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -1,7 +1,7 @@
 - stack-create:
   cmd: amp stack up
   args:
-     - "{{call .uniq `stack1`}}"
+     - "{{call .uniq `stack`}}"
   options:
      - -f ../../api/rpc/stack/test_samples/sample-01.yml
   expectation: stack-id
@@ -18,7 +18,7 @@
 - stack-stop:
   cmd: amp stack stop
   args:
-    - "{{call .uniq `stack1`}}"
+    - "{{call .uniq `stack`}}"
   options:
     -
   expectation: stack-id
@@ -34,7 +34,7 @@
 - stack-restart:
   cmd: amp stack start
   args:
-    - "{{call .uniq `stack1`}}"
+    - "{{call .uniq `stack`}}"
   options:
     -
   expectation: stack-id
@@ -51,7 +51,7 @@
 - stack-stop:
   cmd: amp stack stop
   args:
-    - "{{call .uniq `stack1`}}"
+    - "{{call .uniq `stack`}}"
   options:
     -
   expectation: stack-id
@@ -59,7 +59,7 @@
 - stack-remove:
   cmd: amp stack rm
   args:
-    - "{{call .uniq `stack1`}}"
+    - "{{call .uniq `stack`}}"
   options:
     -
   expectation: stack-id

--- a/tests/cli/setup/platform.yml
+++ b/tests/cli/setup/platform.yml
@@ -1,0 +1,46 @@
+- docker-swarm-initialize:
+  cmd: docker swarm init
+  args:
+  options:
+  expectation: docker-swarm-initialize
+  timeout: 20s
+
+- platform-pull:
+  cmd: amp platform pull
+  args:
+  options:
+  expectation: platform-pull
+  timeout: 5m
+
+- platform-start:
+  cmd: amp platform start
+  args:
+  options:
+  expectation: platform-start
+  timeout: 2m
+
+- platform-status:
+  cmd: amp platform status
+  args:
+  options:
+  expectation: platform-status-running
+
+- platform-stop:
+  cmd: amp platform stop
+  args:
+  options:
+  expectation: platform-stop
+  timeout: 1m
+
+- platform-status:
+  cmd: amp platform status
+  args:
+  options:
+  expectation: platform-status-stopped
+
+- platform-start:
+  cmd: amp platform start
+  args:
+  options:
+  expectation: platform-start
+  timeout: 2m

--- a/tests/cli/setup/platform.yml
+++ b/tests/cli/setup/platform.yml
@@ -1,46 +1,5 @@
-- docker-swarm-initialize:
-  cmd: docker swarm init
-  args:
-  options:
-  expectation: docker-swarm-initialize
-  timeout: 20s
-
-- platform-pull:
-  cmd: amp platform pull
-  args:
-  options:
-  expectation: platform-pull
-  timeout: 5m
-
-- platform-start:
-  cmd: amp platform start
-  args:
-  options:
-  expectation: platform-start
-  timeout: 2m
-
 - platform-status:
   cmd: amp platform status
   args:
   options:
   expectation: platform-status-running
-
-- platform-stop:
-  cmd: amp platform stop
-  args:
-  options:
-  expectation: platform-stop
-  timeout: 1m
-
-- platform-status:
-  cmd: amp platform status
-  args:
-  options:
-  expectation: platform-status-stopped
-
-- platform-start:
-  cmd: amp platform start
-  args:
-  options:
-  expectation: platform-start
-  timeout: 2m

--- a/tests/cli/tearDown/platform.yml
+++ b/tests/cli/tearDown/platform.yml
@@ -1,0 +1,26 @@
+- platform-status:
+  cmd: amp platform status
+  args:
+  options:
+  expectation: platform-status-running
+
+- platform-stop:
+  cmd: amp platform stop
+  args:
+  options:
+  expectation: platform-stop
+  timeout: 1m
+
+- platform-status:
+  cmd: amp platform status
+  args:
+  options:
+  expectation: platform-status-stopped
+
+- docker-swarm-leave:
+  cmd: docker swarm leave
+  args:
+  options:
+    - --force
+  expectation: docker-swarm-leave
+  timeout: 1m

--- a/tests/cli/tearDown/platform.yml
+++ b/tests/cli/tearDown/platform.yml
@@ -3,24 +3,3 @@
   args:
   options:
   expectation: platform-status-running
-
-- platform-stop:
-  cmd: amp platform stop
-  args:
-  options:
-  expectation: platform-stop
-  timeout: 1m
-
-- platform-status:
-  cmd: amp platform status
-  args:
-  options:
-  expectation: platform-status-stopped
-
-- docker-swarm-leave:
-  cmd: docker swarm leave
-  args:
-  options:
-    - --force
-  expectation: docker-swarm-leave
-  timeout: 1m


### PR DESCRIPTION
Adds tests for the amp platform commands:
- pull
- start
- stop
- status
(Monitor can't be tested as it does not return to the cli)

Tests are implemented in the setup and tearDown directory `platform.yml` files. The setup and tearDown YAML test specs are run synchronously to the samples, with setup being before and tearDown being after. In addition, the docker swarm is initialized in the setup and left in the tearDown. 

New field added to the YAML file - run. Boolean which says if a command should or should not be run. By default, the commands in setup and tearDown are not run because they can take upwards of 5 minutes to run. 

To test, change the run fields to true in the `platform.yml` in both setup and tearDown directories. Ensure your platform is stopped and run `docker swarm leave --force` (Or you can reset the docker client), then run:

`go test ./tests/cli`