### PR TITLE
Fixing integration tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,0 @@
-# appclerator/protoc is based on alpine and includes latest go and protoc
-FROM appcelerator/protoc:0.3.0
-RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk --no-cache add make bash git docker@community
-WORKDIR /go/src/github.com/appcelerator/amp
-COPY . /go/src/github.com/appcelerator/amp
-ENTRYPOINT []
-CMD [ "make", "test-integration-host"]

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ run: build-image
 
 test-cli:
 	@for pkg in $(CLI_TEST_PACKAGES) ; do \
-		go test $$pkg ; \
+		go test -v $$pkg ; \
 	done
 
 test-unit:
@@ -185,8 +185,8 @@ test-unit:
 
 test-integration:
 	@docker service rm amp-integration-test > /dev/null 2>&1 || true
-	@docker build -f Dockerfile.test -t appcelerator/amp-integration-test .
-	@docker service create --network amp-infra --name amp-integration-test --restart-condition none appcelerator/amp-integration-test
+	@docker build -t appcelerator/amp-integration-test .
+	@docker service create --network amp-infra --name amp-integration-test --restart-condition none appcelerator/amp-integration-test make test-integration-host
 	@containerid=""; \
 	while [[ $${containerid} == "" ]] ; do \
 		containerid=`docker ps -qf 'name=amp-integration'`; \

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -40,7 +40,7 @@ var (
 // read, parse and execute test commands
 func TestCmds(t *testing.T) {
 	// test suite timeout
-	suiteTimeout = "25s"
+	suiteTimeout = "120s"
 	duration, err := time.ParseDuration(suiteTimeout)
 	if err != nil {
 		t.Errorf("Unable to create duration for timeout: Suite. Error: %v", err)
@@ -76,7 +76,7 @@ func TestCmds(t *testing.T) {
 func runTestSpec(t *testing.T, test *TestSpec) {
 	defer wg.Done()
 	// test spec timeout
-	testSpecTimeout := "20s"
+	testSpecTimeout := "60s"
 	duration, duraErr := time.ParseDuration(testSpecTimeout)
 	if duraErr != nil {
 		t.Errorf("Unable to create duration for timeout: TestSpec. Error: %v", duraErr)

--- a/tests/cli/parse.go
+++ b/tests/cli/parse.go
@@ -80,7 +80,7 @@ func generateTestSpecs(fileName string, timeout time.Duration) (*TestSpec, error
 	for _, command := range commandMap {
 		if command.Timeout == "" {
 			// command spec timeout
-			command.Timeout = "5s"
+			command.Timeout = "30s"
 		}
 		testSpec.Commands = append(testSpec.Commands, command)
 	}

--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -4,7 +4,7 @@
     - appcelerator/pinger
   options:
     - "--name {{call .uniq `pinger`}}"
-    - "-p www:{{call .port `pinger1` 49152 65535}}:3000"
+    - "-p www:{{call .port `pinger1` 30000 32767}}:3000"
   expectation: service-id
 
 - service-list:
@@ -12,19 +12,19 @@
   args:
   options:
   expectation: docker-service-list-valid-service
-  retry: 15
+  retry: 30
   delay: 1s
-  timeout: 15s
+  timeout: 30s
 
 - service-curl:
-  cmd: curl
+  cmd: curl -s
   args:
-    - localhost:{{call .port `pinger1` 49152 65535}}/ping
+    - 127.0.0.1:{{call .port `pinger1` 30000 32767}}/ping
   options:
   expectation: service-curl
-  retry: 15
+  retry: 30
   delay: 1s
-  timeout: 15s
+  timeout: 30s
 
 - service-remove:
   cmd: amp service rm


### PR DESCRIPTION
Fix #524

This fix removes the `Dockerfile.test` file. Now, integration tests use the same `Dockerfile` as the one use to build the image to ensure consistency.

## Verification
    $ amp pf stop
    $ make install
    $ ./shrink.sh local
    $ amp pf start --local
    $ make test
