### PR TITLE
Fix make test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,0 @@
-# appclerator/protoc is based on alpine and includes latest go and protoc
-FROM appcelerator/protoc:0.3.0
-RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk --no-cache add make bash git docker@community
-WORKDIR /go/src/github.com/appcelerator/amp
-COPY . /go/src/github.com/appcelerator/amp
-ENTRYPOINT []
-CMD [ "make", "test-integration-host"]

--- a/tests/cli/parse.go
+++ b/tests/cli/parse.go
@@ -12,33 +12,30 @@ import (
 )
 
 // read lookup directory by parsing its contents
-func parseLookup(directory string) error {
-	files, err := ioutil.ReadDir(lookupDir)
+func parseLookup(directory string) (regexMap map[string]string, err error) {
+	files, err := ioutil.ReadDir(directory)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, file := range files {
-		err := generateRegexes(path.Join(lookupDir, file.Name()))
-		if err != nil {
-			return err
-		}
+		regexMap, err = generateRegexes(path.Join(directory, file.Name()))
 	}
-	return nil
+	return
 }
 
 // parse lookup directory and unmarshal its contents
-func generateRegexes(fileName string) error {
+func generateRegexes(fileName string) (regexMap map[string]string, err error) {
 	if filepath.Ext(fileName) != ".yml" {
-		return fmt.Errorf("Cannot parse non-yaml file: %s", fileName)
+		return nil, fmt.Errorf("Cannot parse non-yaml file: %s", fileName)
 	}
 	pairs, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return fmt.Errorf("Unable to read yaml regex lookup: %s. Error: %v", fileName, err)
+		return nil, fmt.Errorf("Unable to read yaml regex lookup: %s. Error: %v", fileName, err)
 	}
 	if err := yaml.Unmarshal(pairs, &regexMap); err != nil {
-		return fmt.Errorf("Unable to unmarshal yaml regex lookup: %s. Error: %v", fileName, err)
+		return nil, fmt.Errorf("Unable to unmarshal yaml lookup: %s. Error: %v", fileName, err)
 	}
-	return nil
+	return
 }
 
 // read specs from directory by parsing its contents
@@ -79,8 +76,8 @@ func generateTestSpecs(fileName string, timeout time.Duration) (*TestSpec, error
 	}
 	for _, command := range commandMap {
 		if command.Timeout == "" {
-			// command spec timeout
-			command.Timeout = "5s"
+			// default command spec timeout
+			command.Timeout = "30s"
 		}
 		testSpec.Commands = append(testSpec.Commands, command)
 	}

--- a/tests/cli/samples/service.yml
+++ b/tests/cli/samples/service.yml
@@ -12,9 +12,9 @@
   args:
   options:
   expectation: docker-service-list-valid-service
-  retry: 15
+  retry: 20
   delay: 1s
-  timeout: 15s
+  timeout: 20s
 
 - service-curl:
   cmd: curl
@@ -22,9 +22,9 @@
     - localhost:{{call .port `pinger1` 49152 65535}}/ping
   options:
   expectation: service-curl
-  retry: 15
+  retry: 20
   delay: 1s
-  timeout: 15s
+  timeout: 20s
 
 - service-remove:
   cmd: amp service rm

--- a/tests/cli/samples/stack.yml
+++ b/tests/cli/samples/stack.yml
@@ -5,7 +5,7 @@
   options:
      - -f ../../api/rpc/stack/test_samples/sample-01.yml
   expectation: stack-id
-  timeout: 10s
+  timeout: 20s
 
 - stack-list:
   cmd: amp stack ls
@@ -38,7 +38,7 @@
   options:
     -
   expectation: stack-id
-  timeout: 10s
+  timeout: 20s
 
 - stack-list:
   cmd: amp stack ls


### PR DESCRIPTION
Fix #524 

related: #525 , #524 

Integration tests failing on master, removed the `dockerfile.test` so integration tests use the same Dockerfile used to build image.

Edits to the CLI tests, makes the logs less chatty and makes timeouts more forgiving.

to test
```
amp pf stop
make install
./shrink.sh local
amp pf start --local
make test
```

However, this does not fix the issue of some travis builds failing due to transport closing (amplifier crashing). 

You can see evidence of this in the travis build of this PR. 
 - https://travis-ci.org/appcelerator/amp/builds/182110005
```
--- FAIL: TestCmds (11.62s)
	cli_test.go:144: Mismatched expected output: Error during: amp stats, reason: rpc error: code = 13 desc = transport is closing
		: Error: exit status 1
	cli_test.go:144: Mismatched expected output: Error during: amp start, reason: rpc error: code = 13 desc = transport is closing
		: Error: exit status 1
	cli_test.go:141: This command : [curl localhost:51383/ping] has re-run 7 times.
FAIL
FAIL	github.com/appcelerator/amp/tests/cli	11.627s
```

Discussion on the issue: #524 