### PR TITLE
Quicker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ Dockerfile
 Dockerfile.*
 docker-compose.*.yml
 shrink.sh
+.git
+dist
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-# appclerator/protoc is based on alpine and includes latest go and protoc
+# appcelerator/protoc is based on alpine and includes latest go and protoc
 FROM appcelerator/protoc:0.3.0
 RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add bash alpine-sdk
 WORKDIR /go/src/github.com/appcelerator/amp
 COPY . /go/src/github.com/appcelerator/amp
-RUN make install
+ARG BUILD=unknown
+RUN make BUILD=$BUILD install
 EXPOSE 50101
 ENTRYPOINT []
 CMD [ "/go/bin/amplifier"]

--- a/Dockerfile.shrink
+++ b/Dockerfile.shrink
@@ -1,4 +1,4 @@
-FROM appcelerator/alpine:20160726
+FROM appcelerator/alpine:20160928
 COPY ./amp /usr/local/bin/amp
 COPY ./amplifier /usr/local/bin/amplifier
 COPY ./amp-agent /usr/local/bin/amp-agent

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BASEDIR := $(shell echo $${PWD})
 VERSION_FILE=VERSION
 # build variables (provided to binaries by linker LDFLAGS below)
 VERSION := $(shell cat $(VERSION_FILE))
-BUILD := $(shell git rev-parse HEAD | cut -c1-8)
+BUILD ?= $(shell git rev-parse HEAD | cut -c1-8)
 
 LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
 
@@ -115,7 +115,7 @@ build:
 	@hack/build $(GATEWAY)
 
 build-server-image:
-	@docker build -t appcelerator/$(SERVER):$(TAG) .
+	@docker build --build-arg BUILD=$(BUILD) -t appcelerator/$(SERVER):$(TAG) .
 
 build-cli-linux:
 	@rm -f $(CLI)
@@ -168,7 +168,7 @@ check:
 	@go tool vet ${CHECKSRC}
 
 build-image:
-	@docker build -t $(IMAGE) .
+	@docker build --build-arg BUILD=$(BUILD) -t $(IMAGE) .
 
 run: build-image
 	@CID=$(shell docker run --net=host -d --name $(SERVER) $(IMAGE)) && echo $${CID}
@@ -185,8 +185,8 @@ test-unit:
 
 test-integration:
 	@docker service rm amp-integration-test > /dev/null 2>&1 || true
-	@docker build -f Dockerfile.test -t appcelerator/amp-integration-test .
-	@docker service create --network amp-infra --name amp-integration-test --restart-condition none appcelerator/amp-integration-test
+	@docker build --build-arg BUILD=$(BUILD) -t appcelerator/amp-integration-test .
+	@docker service create --network amp-infra --name amp-integration-test --restart-condition none appcelerator/amp-integration-test make BUILD=$(BUILD) test-integration-host
 	@containerid=""; \
 	while [[ $${containerid} == "" ]] ; do \
 		containerid=`docker ps -qf 'name=amp-integration'`; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: all clean install fmt simplify check version build-image run
+.PHONY: all clean proto-clean install fmt simplify check version build-image run proto proto-host
 .PHONY: build build-cli-linux build-cli-darwin build-cli-windows build-server build-server-linux build-server-darwin build-server-windows
 .PHONY: dist dist-linux dist-darwin dist-windows
 .PHONY: test test-unit test-cli test-integration test-integration-host
@@ -91,8 +91,10 @@ proto: $(PROTOFILES)
 proto-host: $(PROTOFILES)
 	@go run hack/proto.go -protoc
 
-clean:
+proto-clean:
 	@rm -rf $(GENERATED)
+
+clean:
 	@rm -f $$(which $(CLI)) ./$(CLI)
 	@rm -f $$(which $(SERVER)) ./$(SERVER)
 	@rm -f coverage.out coverage-all.out

--- a/hack/build
+++ b/hack/build
@@ -6,7 +6,9 @@ APP=$1
 
 # build variables (injected into binaries by linker -ldflags below)
 VERSION="${VERSION:-1.0.0}"
-BUILD=$(git rev-parse HEAD | cut -c1-8)
+if [[ -z "$BUILD" ]]; then
+  BUILD=$(git rev-parse HEAD | cut -c1-8)
+fi
 
 OWNER=appcelerator
 REPO=github.com/$OWNER/amp

--- a/shrink.sh
+++ b/shrink.sh
@@ -57,12 +57,16 @@ fi
 echo "OK"
 
 echo "building shrunk image... "
+cp -p .dockerignore .dockerignore.bak
+echo "vendor" >> .dockerignore
 $DOCKER build -f $SHRINK_DOCKER_FILE -t appcelerator/amp:$TAG . >&2
 if [ $? -ne 0 ]; then
+  mv .dockerignore.bak .dockerignore
   echo "failed"
   exit 1
 fi
 echo "OK"
+mv .dockerignore.bak .dockerignore
 
 echo "cleanup... "
 rm -f amp amplifier amp-agent amp-log-worker amplifier-gateway


### PR DESCRIPTION
Quicker builds and quicker tests

- reduce the size of the image (and the build time) by ignoring the .git folder

how to test:
- make clean install
- amp version # should display an abbrev (git rev-parse HEAD | cut -c1-8) as build number
- ./shrink.sh local
- amp pf start --local
- make test-integration