### PR TITLE
registry command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-AMP: A... Microservices Platform ![WIP](./static_files/amp--docs-WIP-yellow.svg)
+AMP: A... Microservices Platform ![WIP](static_files/amp--docs-WIP-yellow.svg)
 ============================
 
 AMP is currently under development and this section is here to help you get started based on latest stable tagged version of the project. If you're here, then you **ARE** pioneering with us and we encourage you to [get in touch](./contributing.md) !
@@ -207,3 +207,10 @@ A few useful examples:
 ```
   $ amp stats --task --cpu --mem
 ```
+
+### Managing Docker images
+
+    amp registry ls
+    amp registry push
+
+More details in the [userguide](userguide/registry.md)

--- a/docs/userguide/registry.md
+++ b/docs/userguide/registry.md
@@ -1,0 +1,56 @@
+AMP registry
+============
+
+# Usage
+
+AMP comes with an internal registry available through the AMP cli and providing images to the Swarm cluster. It is meant to host the Docker images used by the application services (defined in a stack).
+
+## CLI
+
+### localhost (development)
+
+#### Push an image
+
+```amp registry push appcelerator/pinger:latest```
+
+### remote cluster
+
+the cluster should have a FQDN with sub level aliases. Let's say the domain is amp.example.com, the registry is available on registry.amp.example.com.
+
+If there's no legit certificate for this registry with this name (default use case), this url should be declared as insecure registry in your Docker configuration.
+
+#### Configuration on Linux
+
+```systemctl edit docker.service```
+
+add the block (or adapt the existing file if you already have a customization)
+
+```
+[Service]
+Environment="INSECURE_REGISTRY=registry.amp.example.com"
+ExecStart=-
+ExecStart=/usr/bin/dockerd $OPTIONS \
+          $INSECURE_REGISTRY
+```
+
+#### Configuration on Mac OS
+
+Go in Preferences, advanced tab, add an insecure registry.
+
+#### Push an image
+
+```amp registry push --domain amp.example.com  appcelerator/pinger:latest```
+
+#### Check the registry catalog
+
+```amp registry ls --domain amp.example.com```
+
+## Stack definition
+
+The internal registry images are available with the local alias local.appcelerator.io.
+In the stack definition, use this alias in the hostname part of the image:
+
+```
+myservice1:
+    image: local.appcelerator.io/pinger:latest
+```


### PR DESCRIPTION
fixes #535 

- ```domain``` option applies to all registry commands
- leverage the Docker API for push options
- updated documentation with usage help

how to test:
- make clean install
- create a cluster with multiple nodes (you can use appcelerator/amp-swarm-deploy for that)
- create an alias on route53 to point to an instance of the cluster (domain.com), with * subdomain CNAME
- amp registry --domain domain.com ls # should return an empty array
- amp registry --domain domain.com push an_image # should tag and push to the cluster registry
- amp registry --domain domain.com ls # should return an array with the image just pushed