### PR TITLE
Fixing integration tests error reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,12 +195,13 @@ test-integration:
 		sleep 1 ; \
 	done; \
 	docker logs -f $$containerid; \
-	docker service rm amp-integration-test > /dev/null 2>&1 || true \
-	exit `docker inspect --format='{{.State.ExitCode}}' $$containerid`
+	rc=`docker inspect --format='{{.State.ExitCode}}' $$containerid` ; \
+	docker service rm amp-integration-test > /dev/null 2>&1 || true ; \
+	exit $$rc
 
 test-integration-host:
 	@for pkg in $(INTEGRATION_TEST_PACKAGES) ; do \
-		go test $$pkg ; \
+		go test $$pkg || exit 1 ; \
 	done
 
 test: test-unit test-integration test-cli

--- a/tests/integration/data/storage/etcd/store_test.go
+++ b/tests/integration/data/storage/etcd/store_test.go
@@ -240,8 +240,7 @@ func TestList(t *testing.T) {
 }
 
 func TestCompareAndSet(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), defTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	key := "state"
 	expect := &state.State{Value: "hello"}
@@ -262,8 +261,7 @@ func TestCompareAndSet(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), defTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	key := "watch"
 	expect := &state.State{Value: "hello"}
@@ -290,7 +288,7 @@ WatchLoop:
 		select {
 		case event := <-watch.ResultChan():
 			events = append(events, event)
-		case <-time.After(time.Second):
+		case <-time.After(5 * time.Second):
 			break WatchLoop
 		}
 	}

--- a/tests/integration/rpc/logs_test.go
+++ b/tests/integration/rpc/logs_test.go
@@ -312,7 +312,7 @@ func produceLogEntries(howMany int) error {
 func listenToLogEntries(stream Logs_GetStreamClient, howMany int) (chan *LogEntry, error) {
 	entries := make(chan *LogEntry, howMany)
 	entryCount := 0
-	timeout := time.After(5 * time.Second)
+	timeout := time.After(30 * time.Second)
 
 	defer func() {
 		close(entries)


### PR DESCRIPTION
Fix #537 

## Verification
Purposely make a compilation error in integration tests and then:

    $ amp pf stop
    $ amp pf start
    $ make test

`make test` should report an error, not a success.