### PR TITLE
fix SVG link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-AMP: A... Microservices Platform ![WIP](static_files/amp--docs-WIP-yellow.svg)
+AMP: A... Microservices Platform ![WIP](https://cdn.rawgit.com/appcelerator/amp/master/docs/static_files/amp--docs-WIP-yellow.svg)
 ============================
 
 AMP is currently under development and this section is here to help you get started based on latest stable tagged version of the project. If you're here, then you **ARE** pioneering with us and we encourage you to [get in touch](./contributing.md) !


### PR DESCRIPTION
Updated the Work In Progress SVG graphic. GitHub blocks SVG images due to XSS issues so I used rawgit.com as a workaround.