### PR TITLE
issue 573-576: grpc codes error for stacks and stats

### DIFF
--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/appcelerator/amp/data/influx"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // Stats structure to implement StatsServer interface
@@ -181,7 +183,7 @@ func (s *Stats) statQueryMetric(req *StatsRequest, metric string) (*StatsReply, 
 	fmt.Println("Influx query: " + query)
 	res, err := s.Influx.Query(query)
 	if err != nil {
-		return nil, err
+		return nil, grpc.Errorf(codes.Internal, "InfluxDB Query error: %v", err)
 	}
 	if len(res.Results[0].Series) == 0 {
 		ret := &StatsReply{


### PR DESCRIPTION
related to #573 and #576 (also #591)
add grpc errors for stack and stats

test:
- make install
- ../shrink.sh local
- amp pf start -v --local
- make test

rules applies for all grpc error issues to be consistent:
- if docker error: code.Internal
- If ETCD creation/update/delete error: code.Internal
- if state machine creation failed: code.Internal
- if state machine inconstancy: code.FailedPrecondition
- if stack file error or arg error: code.InvalidArgument
- if internal timeout: code.DeadlineExceeded
- if resource not found: code.NotFound
- if resource creation already exist: code.AlreadyExists

