### PR TITLE
issue-574: grpc codes error for service

### DIFF
--- a/api/rpc/service/service.go
+++ b/api/rpc/service/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 var (
@@ -134,7 +136,7 @@ func (s *Service) Create(ctx context.Context, req *ServiceCreateRequest) (*Servi
 
 	r, err := s.Docker.ServiceCreate(ctx, service, options)
 	if err != nil {
-		return nil, err
+		return nil, grpc.Errorf(codes.Internal, "%v", err)
 	}
 
 	resp := &ServiceCreateResponse{
@@ -189,7 +191,7 @@ func (s *Service) processMounts(service *swarm.ServiceSpec, mounts []string) {
 func (s *Service) Remove(ctx context.Context, req *RemoveRequest) (*RemoveResponse, error) {
 	err := s.Docker.ServiceRemove(ctx, req.Ident)
 	if err != nil {
-		return nil, err
+		return nil, grpc.Errorf(codes.Internal, "%v", err)
 	}
 	fmt.Printf("Service removed %s\n", req.Ident)
 	response := &RemoveResponse{


### PR DESCRIPTION
related to #574
add grpc errors for service

test:

make install
../shrink.sh local
amp pf start -v --local
make test

rules applies for all grpc error issues to be consistent:
- if docker error: code.Internal
- If ETCD creation/update/delete error: code.Internal
- if state machine creation failed: code.Internal
- if state machine inconstancy: code.FailedPrecondition
- if stack file error or arg error: code.InvalidArgument
- if internal timeout: code.DeadlineExceeded
- if resource not found: code.NotFound
- if resource creation already exist: code.AlreadyExists

