### PR TITLE
amp flags --version, -V function correctly

### DIFF
--- a/cmd/amp/config.go
+++ b/cmd/amp/config.go
@@ -62,7 +62,7 @@ func init() {
 				}
 				fmt.Println(f.Value())
 			default:
-				log.Fatal("too many arguments")
+				log.Fatal("Too many arguments")
 			}
 		},
 	}

--- a/cmd/amp/config.go
+++ b/cmd/amp/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -16,21 +15,13 @@ func init() {
 	// configCmd represents the Config command
 	configCmd := &cobra.Command{
 		Use:   "config",
-		Short: "Display or update configuration",
-		Long: `With no argument, display the current configuration.
-			With one argument, display the value for this key
-			With two arguments, set the value for the key (respectively 2nd and 1st arg)`,
+		Short: "Display the current configuration",
+		Long:  `Display the current configuration.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			switch len(args) {
 			case 0:
-				// Display full configuration
-				j, err := json.MarshalIndent(structs.Map(Config), "", "  ")
-				if err != nil {
-					fmt.Println("error:", err)
-				}
-				fmt.Println(string(j))
+				fmt.Println(Config)
 			case 1:
-				// Display one key
 				s := structs.New(Config)
 				f, ok := s.FieldOk(strings.Title(args[0]))
 				if !ok {
@@ -38,7 +29,6 @@ func init() {
 				}
 				fmt.Println(f.Value())
 			case 2:
-				// Change one key
 				s := structs.New(Config)
 				f, ok := s.FieldOk(strings.Title(args[0]))
 				if !ok {
@@ -54,7 +44,7 @@ func init() {
 				case "string":
 					f.Set(args[1])
 				default:
-					log.Fatal("unsupported field type")
+					log.Fatal("Unsupported field type")
 				}
 				err := cli.SaveConfiguration(Config)
 				if err != nil {

--- a/cmd/amp/login.go
+++ b/cmd/amp/login.go
@@ -13,8 +13,8 @@ import (
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Login via github",
-	Long:  `Create a github access token and store it in your Config file to authenticate further commands`,
+	Short: "Login via GitHub",
+	Long:  `Create a github access token and store it in your Config file to authenticate further commands.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := AMP.Connect()
 		if err != nil {

--- a/cmd/amp/logs.go
+++ b/cmd/amp/logs.go
@@ -13,7 +13,8 @@ import (
 
 var logsCmd = &cobra.Command{
 	Use:   "logs [OPTIONS] [SERVICE]",
-	Short: "Fetch log entries matching provided criteria. If provided, SERVICE can be a partial or full service id or service name.",
+	Short: "Fetch log entries matching provided criteria",
+	Long:  `Fetch log entries matching provided criteria. If provided, SERVICE can be a partial or full service id or service name.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := AMP.Connect()
 		if err != nil {

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -33,6 +33,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			if listVersion {
 				fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
+				cli.Exit(0)
 			}
 			fmt.Println(cmd.UsageString())
 		},
@@ -64,8 +65,8 @@ func main() {
 	// versionCmd represents the amp version
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "Display the version number of amp",
-		Long:  `Display the version number of amp`,
+		Short: "Display amp version",
+		Long:  `Display amp version.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
 		},
@@ -82,14 +83,17 @@ func main() {
 			fmt.Printf("Server: %s\n", Config.ServerAddress)
 		},
 	}
+	RootCmd.AddCommand(infoCmd)
+
 	RootCmd.SetUsageTemplate(usageTemplate)
 	RootCmd.SetHelpTemplate(helpTemplate)
 
-	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.config/amp/amp.yaml)")
-	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `Verbose output`)
+	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.amp.yaml)")
+	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "Server address")
-	RootCmd.Flags().BoolVarP(&listVersion, "version", "V", false, "Version number")
-	RootCmd.AddCommand(infoCmd)
+	RootCmd.PersistentFlags().BoolVarP(&listVersion, "version", "V", false, "Version number")
+	RootCmd.PersistentFlags().BoolP("help", "h", false, "Display help")
+
 	cmd, _, err := RootCmd.Find(os.Args[1:])
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/amp/platform.go
+++ b/cmd/amp/platform.go
@@ -6,8 +6,8 @@ import (
 
 // PlatformCmd is the main command for attaching topic subcommands.
 var PlatformCmd = &cobra.Command{
-	Use:     "platform operations",
-	Short:   "platform operations (alias: pf)",
+	Use:     "platform",
+	Short:   "Platform operations (alias: pf)",
 	Long:    `Manage platform-related operations.`,
 	Aliases: []string{"pf"},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/amp/platform_manager.go
+++ b/cmd/amp/platform_manager.go
@@ -87,7 +87,7 @@ func (s *ampManager) init(firstMessage string) error {
 	defaultHeaders := map[string]string{"User-Agent": "amplifier"}
 	cli, err := client.NewClient(DockerURL, DockerVersion, nil, defaultHeaders)
 	if err != nil {
-		return fmt.Errorf("Impossible to connect to Docker on: %s\n%v", DockerURL, err)
+		return fmt.Errorf("impossible to connect to Docker on: %s\n%v", DockerURL, err)
 	}
 	s.docker = cli
 	return nil
@@ -384,7 +384,7 @@ func (s *ampManager) updateServiceStates(service *ampService) error {
 						s.forceService(service)
 						return nil
 					}
-					return fmt.Errorf("Service %s startup timeout", service.name)
+					return fmt.Errorf("service %s startup timeout", service.name)
 				}
 			}
 			service.ready = false
@@ -466,7 +466,7 @@ func (s *ampManager) createService(service *ampService) error {
 			s.forceService(service)
 			return nil
 		}
-		return fmt.Errorf("Service %s image %s doesn't exist", service.name, service.image)
+		return fmt.Errorf("service %s image %s doesn't exist", service.name, service.image)
 	}
 	r, err := s.docker.ServiceCreate(s.ctx, *service.spec, options)
 	if err != nil {
@@ -598,7 +598,7 @@ func (s *ampManager) cleanVolume(name string) error {
 			return nil
 		}
 		if time.Now().Sub(started) > 30*time.Second {
-			return fmt.Errorf("Timeout waiting for all services removed")
+			return fmt.Errorf("timeout waiting for all services removed")
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/cmd/amp/platform_manager.go
+++ b/cmd/amp/platform_manager.go
@@ -87,7 +87,7 @@ func (s *ampManager) init(firstMessage string) error {
 	defaultHeaders := map[string]string{"User-Agent": "amplifier"}
 	cli, err := client.NewClient(DockerURL, DockerVersion, nil, defaultHeaders)
 	if err != nil {
-		return fmt.Errorf("impossible to connect to Docker on: %s\n%v", DockerURL, err)
+		return fmt.Errorf("Impossible to connect to Docker on: %s\n%v", DockerURL, err)
 	}
 	s.docker = cli
 	return nil
@@ -182,7 +182,7 @@ func (s *ampManager) pull(stack *ampStack) error {
 			s.printf(colInfo, "+")
 		}
 		s.printf(colInfo, "\n")
-		s.printf(colSuccess, "image %s pulled\n", image)
+		s.printf(colSuccess, "Image %s pulled\n", image)
 
 	}
 	return nil

--- a/cmd/amp/platform_monitor.go
+++ b/cmd/amp/platform_monitor.go
@@ -9,7 +9,7 @@ import (
 var PlatformMonitor = &cobra.Command{
 	Use:   "monitor",
 	Short: "Display AMP platform services",
-	Long:  `Display AMP platform services information and states`,
+	Long:  `Display AMP platform services information and states.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		displayAMPServiceStatus(cmd, args)
 	},

--- a/cmd/amp/platform_pull.go
+++ b/cmd/amp/platform_pull.go
@@ -10,15 +10,15 @@ import (
 var PlatformPull = &cobra.Command{
 	Use:   "pull",
 	Short: "Pull platform images",
-	Long:  `Pull all AMP platform images`,
+	Long:  `Pull all AMP platform images.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		pullAMPImages(cmd, args)
 	},
 }
 
 func init() {
-	PlatformPull.Flags().BoolP("silence", "s", false, "no console output at all")
-	PlatformPull.Flags().BoolP("local", "l", false, "use local amp image")
+	PlatformPull.Flags().BoolP("silence", "s", false, "No console output at all")
+	PlatformPull.Flags().BoolP("local", "l", false, "Use local amp image")
 	PlatformCmd.AddCommand(PlatformPull)
 }
 

--- a/cmd/amp/platform_start.go
+++ b/cmd/amp/platform_start.go
@@ -18,8 +18,8 @@ var PlatformStart = &cobra.Command{
 
 func init() {
 	PlatformStart.Flags().BoolP("force", "f", false, "Start all possible services, do not stop on error")
-	PlatformStart.Flags().BoolP("silence", "s", false, "no console output at all")
-	PlatformStart.Flags().BoolP("local", "l", false, "use local amp image")
+	PlatformStart.Flags().BoolP("silence", "s", false, "No console output at all")
+	PlatformStart.Flags().BoolP("local", "l", false, "Use local amp image")
 	PlatformCmd.AddCommand(PlatformStart)
 }
 

--- a/cmd/amp/platform_status.go
+++ b/cmd/amp/platform_status.go
@@ -10,15 +10,15 @@ import (
 var PlatformStatus = &cobra.Command{
 	Use:   "status",
 	Short: "Get AMP platform status",
-	Long:  `Get AMP platform global status (stopped, partially running, running command return 1 if status is not running`,
+	Long:  `Get AMP platform global status (stopped, partially running, running command return 1 if status is not running.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		getAMPStatus(cmd, args)
 	},
 }
 
 func init() {
-	PlatformStatus.Flags().BoolP("silence", "s", false, "no console output at all")
-	PlatformStatus.Flags().BoolP("local", "l", false, "use local amp image")
+	PlatformStatus.Flags().BoolP("silence", "s", false, "No console output at all")
+	PlatformStatus.Flags().BoolP("local", "l", false, "Use local amp image")
 	PlatformCmd.AddCommand(PlatformStatus)
 }
 

--- a/cmd/amp/platform_stop.go
+++ b/cmd/amp/platform_stop.go
@@ -17,8 +17,8 @@ var PlatformStop = &cobra.Command{
 }
 
 func init() {
-	PlatformStop.Flags().BoolP("silence", "s", false, "no console output at all")
-	PlatformStop.Flags().BoolP("local", "l", false, "use local amp image")
+	PlatformStop.Flags().BoolP("silence", "s", false, "No console output at all")
+	PlatformStop.Flags().BoolP("local", "l", false, "Use local amp image")
 	PlatformCmd.AddCommand(PlatformStop)
 }
 

--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -19,7 +19,7 @@ import (
 
 // RegCmd is the main command for attaching registry subcommands.
 var RegCmd = &cobra.Command{
-	Use:   "registry operations",
+	Use:   "registry",
 	Short: "Registry operations",
 	Long:  `Manage registry-related operations.`,
 }
@@ -31,7 +31,7 @@ var (
 	pushCmd  = &cobra.Command{
 		Use:   "push [image]",
 		Short: "Push an image to the amp registry",
-		Long:  `Push an image to the amp registry`,
+		Long:  `Push an image to the amp registry.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RegistryPush(AMP, cmd, args)
 		},
@@ -39,7 +39,7 @@ var (
 	reglsCmd = &cobra.Command{
 		Use:   "ls",
 		Short: "List the amp registry images",
-		Long:  `List the amp registry images`,
+		Long:  `List the amp registry images.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RegistryLs(AMP, cmd, args)
 		},
@@ -94,7 +94,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", image)
 	}
 	if _, isCanonical := distributionRef.(distreference.Canonical); isCanonical {
-		return errors.New("refusing to create a tag with a digest reference")
+		return errors.New("Refusing to create a tag with a digest reference")
 	}
 	tag := reference.GetTagFromNamedRef(distributionRef)
 	hostname, name := distreference.SplitHostname(distributionRef)
@@ -112,7 +112,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	fmt.Printf("push image %s\n", taggedImage)
+	fmt.Printf("Push image %s\n", taggedImage)
 	resp, err := dclient.ImagePush(ctx, taggedImage, imagePushOptions)
 	if err != nil {
 		return err

--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -81,7 +81,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	ac := types.AuthConfig{Username: "none"}
 	jsonString, err := json.Marshal(ac)
 	if err != nil {
-		return errors.New("Failed to marshal authconfig")
+		return errors.New("failed to marshal authconfig")
 	}
 	dst := make([]byte, base64.URLEncoding.EncodedLen(len(jsonString)))
 	base64.URLEncoding.Encode(dst, jsonString)
@@ -91,10 +91,10 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	image := args[0]
 	distributionRef, err := distreference.ParseNamed(image)
 	if err != nil {
-		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", image)
+		return fmt.Errorf("error parsing reference: %q is not a valid repository/tag", image)
 	}
 	if _, isCanonical := distributionRef.(distreference.Canonical); isCanonical {
-		return errors.New("Refusing to create a tag with a digest reference")
+		return errors.New("refusing to create a tag with a digest reference")
 	}
 	tag := reference.GetTagFromNamedRef(distributionRef)
 	hostname, name := distreference.SplitHostname(distributionRef)
@@ -124,7 +124,7 @@ func RegistryPush(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	re := regexp.MustCompile(`: digest: sha256:`)
 	if !re.Match(body) {
 		fmt.Print(string(body))
-		return errors.New("Push failed")
+		return errors.New("push failed")
 	}
 	return nil
 }

--- a/cmd/amp/service-create.go
+++ b/cmd/amp/service-create.go
@@ -18,7 +18,7 @@ var (
 	serviceCreateCmd = &cobra.Command{
 		Use:   "create [OPTIONS] IMAGE [CMD] [ARG...]",
 		Short: "Create a new service",
-		Long:  `Create a new service`,
+		Long:  `Create a new service.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return serviceCreate(AMP, cmd, args)
 		},
@@ -102,13 +102,13 @@ func serviceCreate(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	case "global":
 		if replicas != 0 {
 			// global mode can't specify replicas (only allowed 1 per node)
-			log.Fatal("replicas can only be used with replicated mode")
+			log.Fatal("Replicas can only be used with replicated mode")
 		}
 		swarmMode = &service.ServiceSpec_Global{
 			Global: &service.GlobalService{},
 		}
 	default:
-		log.Fatalf("invalid option for mode: %s", mode)
+		log.Fatalf("Invalid option for mode: %s", mode)
 	}
 
 	spec := &service.ServiceSpec{

--- a/cmd/amp/service-rm.go
+++ b/cmd/amp/service-rm.go
@@ -16,7 +16,7 @@ var (
 	serviceRmCmd = &cobra.Command{
 		Use:   "rm [OPTIONS] SERVICE [SERVICE...]",
 		Short: "Remove one or more services",
-		Long:  `Remove one or more services`,
+		Long:  `Remove one or more services.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return serviceRm(AMP, cmd, args)
 		},

--- a/cmd/amp/stack.go
+++ b/cmd/amp/stack.go
@@ -16,7 +16,7 @@ import (
 
 // StackCmd is the main command for attaching stack subcommands.
 var StackCmd = &cobra.Command{
-	Use:   "stack operations",
+	Use:   "stack",
 	Short: "Stack operations",
 	Long:  `Manage stack-related operations.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -46,7 +46,7 @@ var (
 	stackStartCmd = &cobra.Command{
 		Use:   "start [stack name or id]",
 		Short: "Start a stopped stack",
-		Long:  `Start a stopped stack`,
+		Long:  `Start a stopped stack.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackStart(AMP, cmd, args)
 		},

--- a/cmd/amp/topic-create.go
+++ b/cmd/amp/topic-create.go
@@ -27,11 +27,11 @@ func init() {
 
 func createTopic(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("Must specify topic name")
+		return errors.New("must specify topic name")
 	}
 	name := args[0]
 	if name == "" {
-		return errors.New("Must specify topic name")
+		return errors.New("must specify topic name")
 	}
 
 	request := &topic.CreateRequest{Topic: &topic.TopicEntry{

--- a/cmd/amp/topic-create.go
+++ b/cmd/amp/topic-create.go
@@ -27,11 +27,11 @@ func init() {
 
 func createTopic(amp *client.AMP, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("must specify topic name")
+		return errors.New("Must specify topic name")
 	}
 	name := args[0]
 	if name == "" {
-		return errors.New("must specify topic name")
+		return errors.New("Must specify topic name")
 	}
 
 	request := &topic.CreateRequest{Topic: &topic.TopicEntry{

--- a/cmd/amp/topic.go
+++ b/cmd/amp/topic.go
@@ -6,8 +6,8 @@ import (
 
 // TopicCmd is the main command for attaching topic subcommands.
 var TopicCmd = &cobra.Command{
-	Use:   "topic operations",
-	Short: "topic operations",
+	Use:   "topic",
+	Short: "Topic operations",
 	Long:  `Manage topic-related operations.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return AMP.Connect()

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -42,17 +42,16 @@ var (
 func parseFlags() {
 	var displayVersion bool
 
-	//
 	// set up flags
-	flag.StringVarP(&port, "port", "p", defaultPort, "server port (default '"+defaultPort+"')")
-	flag.StringVarP(&etcdEndpoints, "endpoints", "e", amp.EtcdDefaultEndpoint, "etcd comma-separated endpoints")
-	flag.StringVarP(&elasticsearchURL, "elasticsearchURL", "s", amp.ElasticsearchDefaultURL, "elasticsearch URL (default '"+amp.ElasticsearchDefaultURL+"')")
-	flag.StringVarP(&clientID, "clientid", "i", defaultClientID, "github app clientid (default '"+defaultClientID+"')")
-	flag.StringVarP(&clientSecret, "clientsecret", "c", defaultClientSecret, "github app clientsecret (default '"+defaultClientSecret+"')")
-	flag.StringVarP(&natsURL, "natsURL", "", amp.NatsDefaultURL, "Nats URL (default '"+amp.NatsDefaultURL+"')")
-	flag.StringVarP(&influxURL, "influxURL", "", amp.InfluxDefaultURL, "InfluxDB URL (default '"+amp.InfluxDefaultURL+"')")
-	flag.StringVar(&dockerURL, "dockerURL", amp.DockerDefaultURL, "Docker URL (default '"+amp.DockerDefaultURL+"')")
-	flag.BoolVarP(&displayVersion, "version", "V", false, "Print version information and quit")
+	flag.StringVarP(&port, "port", "p", defaultPort, "Server port (default '"+defaultPort+"')")
+	flag.StringVarP(&etcdEndpoints, "endpoints", "e", amp.EtcdDefaultEndpoint, "Etcd comma-separated endpoints")
+	flag.StringVarP(&elasticsearchURL, "elasticsearch-url", "s", amp.ElasticsearchDefaultURL, "Elasticsearch URL (default '"+amp.ElasticsearchDefaultURL+"')")
+	flag.StringVarP(&clientID, "clientid", "i", defaultClientID, "GitHub app clientid (default '"+defaultClientID+"')")
+	flag.StringVarP(&clientSecret, "clientsecret", "c", defaultClientSecret, "GitHub app clientsecret (default '"+defaultClientSecret+"')")
+	flag.StringVarP(&natsURL, "nats-url", "", amp.NatsDefaultURL, "Nats URL (default '"+amp.NatsDefaultURL+"')")
+	flag.StringVarP(&influxURL, "influx-url", "", amp.InfluxDefaultURL, "InfluxDB URL (default '"+amp.InfluxDefaultURL+"')")
+	flag.StringVar(&dockerURL, "docker-url", amp.DockerDefaultURL, "Docker URL (default '"+amp.DockerDefaultURL+"')")
+	flag.BoolVarP(&displayVersion, "version", "v", false, "Print version information and quit")
 
 	// parse command line flags
 	flag.Parse()


### PR DESCRIPTION
Fix for issues #547 #561 #565 

* Fixed `amp --version`, `amp -V` to only display amp version
* Formatted help descriptions
* Formatted amplifier flags to lowercase

To test #547 
```
$ make install
$ amp --version
amp (cli version: v0.4.0-dev, build: bdc1a369)
$ amp -V
amp (cli version: v0.4.0-dev, build: bdc1a369)
```