### PR TITLE
Configuration file location in ~/.config/amp/

### DIFF
--- a/cmd/amp/cli/cli.go
+++ b/cmd/amp/cli/cli.go
@@ -36,9 +36,20 @@ func PrintErr(err error) {
 	os.Exit(1)
 }
 
-// SaveConfiguration saves the configuration to ~/.ampswarm.yaml
+// SaveConfiguration saves the configuration to ~/.config/amp/amp.yaml
 func SaveConfiguration(c interface{}) (err error) {
-	homedir, err := homedir.Dir()
+	var configdir string
+	xdgdir := os.Getenv("XDG_CONFIG_HOME")
+	if xdgdir != "" {
+		configdir = path.Join(xdgdir, "amp")
+	} else {
+		homedir, err := homedir.Dir()
+		if err != nil {
+			return err
+		}
+		configdir = path.Join(homedir, ".config/amp")
+	}
+	err = os.MkdirAll(configdir, 0755)
 	if err != nil {
 		return
 	}
@@ -46,7 +57,7 @@ func SaveConfiguration(c interface{}) (err error) {
 	if err != nil {
 		return
 	}
-	err = ioutil.WriteFile(path.Join(homedir, ".amp.yaml"), contents, os.ModePerm)
+	err = ioutil.WriteFile(path.Join(configdir, "amp.yaml"), contents, os.ModePerm)
 	if err != nil {
 		return
 	}

--- a/cmd/amp/config.go
+++ b/cmd/amp/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -15,13 +16,21 @@ func init() {
 	// configCmd represents the Config command
 	configCmd := &cobra.Command{
 		Use:   "config",
-		Short: "Display the current configuration",
-		Long:  `Display the current configuration.`,
+		Short: "Display or update configuration",
+		Long: `With no argument, display the current configuration.
+			With one argument, display the value for this key
+			With two arguments, set the value for the key (respectively 2nd and 1st arg)`,
 		Run: func(cmd *cobra.Command, args []string) {
 			switch len(args) {
 			case 0:
-				fmt.Println(Config)
+				// Display full configuration
+				j, err := json.MarshalIndent(structs.Map(Config), "", "  ")
+				if err != nil {
+					fmt.Println("error:", err)
+				}
+				fmt.Println(string(j))
 			case 1:
+				// Display one key
 				s := structs.New(Config)
 				f, ok := s.FieldOk(strings.Title(args[0]))
 				if !ok {
@@ -29,6 +38,7 @@ func init() {
 				}
 				fmt.Println(f.Value())
 			case 2:
+				// Change one key
 				s := structs.New(Config)
 				f, ok := s.FieldOk(strings.Title(args[0]))
 				if !ok {

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -85,7 +85,7 @@ func main() {
 	RootCmd.SetUsageTemplate(usageTemplate)
 	RootCmd.SetHelpTemplate(helpTemplate)
 
-	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.amp.yaml)")
+	RootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default is $HOME/.config/amp/amp.yaml)")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, `Verbose output`)
 	RootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "Server address")
 	RootCmd.Flags().BoolVarP(&listVersion, "version", "V", false, "Version number")


### PR DESCRIPTION
resolves #560 and #556 

- compliant with XDG base directory configuration specifications
- prettier output for amp config

How to test:
- make install
- touch ~/.amp.yaml && amp config # should complain
- rm ~/.amp.yaml
- amp config # displays default configuration in a pretty format
- amp config ServerAddress # displays the server address, something like 127.0.0.1:8080
- amp config ServerAddress amp.gov.us:8080 # displays the value
- amp config ServerAddress # displays the value set above
- cat ~/.config/amp/amp.yaml # contains the configuration, in particular the value set above