### PR TITLE
Optimize development workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - sudo apt-get install docker-engine
   - docker swarm init --advertise-addr 127.0.0.1
   - make install
-  - ./shrink.sh local
+  - make TAG=local build-image
   - amp platform pull --local
   - amp platform start --local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# golang:alpine provides an up to date go build environment
-FROM golang:alpine
+# appcelerator/protoc is based on alpine and includes latest go and protoc
+FROM appcelerator/protoc:0.3.0
 RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add bash alpine-sdk
 WORKDIR /go/src/github.com/appcelerator/amp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add bash alpine-sdk
 WORKDIR /go/src/github.com/appcelerator/amp
 COPY . /go/src/github.com/appcelerator/amp
 ARG BUILD=unknown
-RUN make BUILD=$BUILD install
+RUN make BUILD=$BUILD install-host
 EXPOSE 50101
 ENTRYPOINT []
 CMD [ "/go/bin/amplifier"]

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ AGENT := amp-agent
 LOGWORKER := amp-log-worker
 GATEWAY := amplifier-gateway
 
-TAG := latest
+TAG ?= latest
 IMAGE := $(OWNER)/amp:$(TAG)
 
 # tools
@@ -174,7 +174,7 @@ check:
 	@go tool vet ${CHECKSRC}
 
 build-image:
-	@docker build --build-arg BUILD=$(BUILD) -t $(IMAGE) .
+	@BUILD=$(BUILD) $(PWD)/build-amp-image.sh $(TAG)
 
 run: build-image
 	@CID=$(shell docker run --net=host -d --name $(SERVER) $(IMAGE)) && echo $${CID}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: all clean proto-clean install fmt simplify check version build-image run proto proto-host
+.PHONY: all clean proto-clean bin-clean install install-host fmt simplify check version build-image run proto proto-host
 .PHONY: build build-cli-linux build-cli-darwin build-cli-windows build-server build-server-linux build-server-darwin build-server-windows
 .PHONY: dist dist-linux dist-darwin dist-windows
 .PHONY: test test-unit test-cli test-integration test-integration-host
@@ -29,7 +29,10 @@ INTEGRATION_TEST_PACKAGES := $(shell find ./tests/integration -type f -name '*_t
 DIRS = $(shell find . -type d $(EXCLUDE_DIRS_FILTER))
 
 # generated file dependencies for proto rule
-PROTOFILES = $(shell find . -type f -name '*.proto' $(EXCLUDE_DIRS_FILTER))
+PROTOFILES := $(shell find . \( -path ./vendor -o -path ./.git -o -path ./.glide -o -path ./tests \) -prune -o -type f -name '*.proto' -print)
+PROTOTARGETS := $(PROTOFILES:.proto=.pb.go)
+PROTOGWTARGETS := api/rpc/logs/logs.pb.gw.go api/rpc/service/service.pb.gw.go api/rpc/stack/stack.pb.gw.go api/rpc/stats/stats.pb.gw.go api/rpc/topic/topic.pb.gw.go
+PROTOALLTARGETS := $(PROTOTARGETS) $(PROTOGWTARGETS)
 
 # generated files that can be cleaned
 GENERATED := $(shell find . -type f \( -name '*.pb.go' -o -name '*.pb.gw.go' \) $(EXCLUDE_FILES_FILTER))
@@ -88,8 +91,22 @@ update-deps:
     # temporary fix to trace conflict
 	@rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/net/trace
 
-proto: $(PROTOFILES)
+# explicit rule to compile protobuf files
+%.pb.go: %.proto
 	@go run hack/proto.go
+%.pb.gw.go: %.proto
+	@go run hack/proto.go
+
+# used to install when you're already inside a container
+install-host: proto-host
+	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(CLI)
+	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(SERVER)
+	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(AGENT)
+	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(LOGWORKER)
+	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(GATEWAY)
+
+proto:
+	@echo proto: $(PROTOALLTARGETS)
 
 # used to run protoc when you're already inside a container
 proto-host: $(PROTOFILES)
@@ -98,26 +115,50 @@ proto-host: $(PROTOFILES)
 proto-clean:
 	@rm -rf $(GENERATED)
 
-clean:
+bin-clean:
 	@rm -f $$(which $(CLI)) ./$(CLI)
 	@rm -f $$(which $(SERVER)) ./$(SERVER)
 	@rm -f coverage.out coverage-all.out
 	@rm -f $$(which $(AGENT)) ./$(AGENT)
 	@rm -f $$(which $(LOGWORKER)) ./$(LOGWORKER)
 	@rm -f $$(which $(GATEWAY)) ./$(GATEWAY)
+	@rm -f *.exe
 
-install:
+clean: proto-clean bin-clean
+
+install: install-cli install-server install-agent install-log-worker install-gateway
+
+DATASRC := $(shell find ./data -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+APISRC := $(shell find ./api -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+VENDORSRC := $(shell find ./vendor -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+# binaries are compiled as soon as their sources are newer than the existing binary
+CLISRC := $(shell find ./cmd/amp -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+SERVERSRC := $(shell find ./cmd/amplifier -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+AGENTSRC := $(shell find ./cmd/amp-agent -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+LOGWORKERSRC := $(shell find ./cmd/amp-log-worker -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+GATEWAYSRC := $(shell find ./cmd/amplifier-gateway -type f -name '*.go' -not -name '*.pb.go' -not -name '*.pb.gw.go')
+install-cli: $(CLISRC) $(DATASRC) $(APISRC) $(VENDORSRC) $(PROTOALLTARGETS)
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(CLI)
+install-server: $(SERVERSRC) $(DATASRC) $(APISRC) $(VENDORSRC) $(PROTOALLTARGETS)
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(SERVER)
+install-agent: $(AGENTSRC) $(DATASRC) $(APISRC) $(VENDORSRC) $(PROTOALLTARGETS)
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(AGENT)
+install-log-worker: $(LOGWORKERSRC) $(DATASRC) $(APISRC) $(VENDORSRC) $(PROTOALLTARGETS)
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(LOGWORKER)
+install-gateway: $(GATEWAYSRC) $(DATASRC) $(APISRC) $(VENDORSRC) $(PROTOALLTARGETS)
 	@go install $(LDFLAGS) $(REPO)/$(CMDDIR)/$(GATEWAY)
 
-build:
+build: build-cli build-server build-agent build-log-worker build-gateway
+
+build-cli: proto $(CLISRC) $(APISRC) $(VENDORSRC) Makefile
 	@hack/build $(CLI)
+build-server: proto
 	@hack/build $(SERVER)
+build-agent: proto
 	@hack/build $(AGENT)
+build-log-worker: proto
 	@hack/build $(LOGWORKER)
+build-gateway: proto
 	@hack/build $(GATEWAY)
 
 build-server-image:

--- a/build-amp-image.sh
+++ b/build-amp-image.sh
@@ -59,7 +59,7 @@ echo "OK"
 echo "building shrunk image... "
 cp -p .dockerignore .dockerignore.bak
 echo "vendor" >> .dockerignore
-$DOCKER build -f $SHRINK_DOCKER_FILE -t appcelerator/amp:$TAG . >&2
+$DOCKER build -f $SHRINK_DOCKER_FILE -t $REPOSITORY_NAME:$TAG . >&2
 if [ $? -ne 0 ]; then
   mv .dockerignore.bak .dockerignore
   echo "failed"
@@ -73,4 +73,4 @@ rm -f amp amplifier amp-agent amp-log-worker amplifier-gateway
 $DOCKER kill amp-builder >/dev/null 2>&1
 $DOCKER rm amp-builder >/dev/null 2>&1
 $DOCKER rmi $REPOSITORY_NAME:builder
-echo "OK"
+echo "OK, image is $REPOSITORY_NAME:$TAG"


### PR DESCRIPTION
resolves #553 and #562

- target for image build (shrink.sh has been renamed to build-amp-image.sh)
- binaries all have their own target (as was the case before)
- make clean removes also the protobuf files (as was the case before)
- explicit rule for compiling the protobuf files
- compilation time is reduced

## Verification

    $ make clean                        # removes binaries, *.pb.go and *.pb.gw.go
    $ make install                      # compiles source (*.go, *.pb.go, *.pb.gw.go), installs binaries
    $ make install                      # ...subsequent builds are much faster!
    $ make install-cli                  # only builds the CLI and its prerequisites
    $ make build-image                  # builds the image as appcelerator/amp:latest
    $ make TAG=local build-image        # builds the image as appcelerator/amp:local
