### PR TITLE
[refactor] moved amp confighelper

### DIFF
--- a/cmd/amp/cli/cli.go
+++ b/cmd/amp/cli/cli.go
@@ -2,13 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
 
 	"github.com/fatih/color"
-	"github.com/mitchellh/go-homedir"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -34,32 +30,4 @@ func PrintErr(err error) {
 	color.Set(color.FgRed)
 	fmt.Println(err)
 	os.Exit(1)
-}
-
-// SaveConfiguration saves the configuration to ~/.config/amp/amp.yaml
-func SaveConfiguration(c interface{}) (err error) {
-	var configdir string
-	xdgdir := os.Getenv("XDG_CONFIG_HOME")
-	if xdgdir != "" {
-		configdir = path.Join(xdgdir, "amp")
-	} else {
-		homedir, err := homedir.Dir()
-		if err != nil {
-			return err
-		}
-		configdir = path.Join(homedir, ".config/amp")
-	}
-	err = os.MkdirAll(configdir, 0755)
-	if err != nil {
-		return
-	}
-	contents, err := yaml.Marshal(c)
-	if err != nil {
-		return
-	}
-	err = ioutil.WriteFile(path.Join(configdir, "amp.yaml"), contents, os.ModePerm)
-	if err != nil {
-		return
-	}
-	return
 }

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -58,7 +58,7 @@ var (
 // All main does is process commands and flags and invoke the app
 func main() {
 	cobra.OnInitialize(func() {
-		InitConfig(configFile, Config, verbose, serverAddr)
+		cli.InitConfig(configFile, Config, verbose, serverAddr)
 		if addr := RootCmd.Flag("server").Value.String(); addr != "" {
 			Config.ServerAddress = addr
 		}
@@ -67,7 +67,7 @@ func main() {
 		}
 		AMP = client.NewAMP(Config)
 		if AMP.Verbose() == false {
-			RootCmd.SilenceErrors = true
+			;RootCmd.SilenceErrors = true
 			RootCmd.SilenceUsage = true
 		}
 		cli.AtExit(func() {

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -67,7 +67,7 @@ func main() {
 		}
 		AMP = client.NewAMP(Config)
 		if AMP.Verbose() == false {
-			;RootCmd.SilenceErrors = true
+			RootCmd.SilenceErrors = true
 			RootCmd.SilenceUsage = true
 		}
 		cli.AtExit(func() {


### PR DESCRIPTION
Moved `amp/confighelper` to `amp/cli/confighelper`, and moved the `SaveConfiguration` function that was in `amp/cli/cli` to match up with the `InitFunction`.

## Verification

    $ make install-cli
    $ amp config # should display config
    $ amp config Verbose true
    $ amp config Verbose # verify true
    $ amp config Verbose false
    $ amp config Verbose # verify false
