### PR TITLE
Add make rule to print all the make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-.PHONY: all clean proto-clean bin-clean install install-host fmt simplify check version build-image run proto proto-host
+.PHONY: all clean proto-clean bin-clean install install-host fmt simplify check version build-image run proto proto-host rules
 .PHONY: build build-cli-linux build-cli-darwin build-cli-windows build-server build-server-linux build-server-darwin build-server-windows
 .PHONY: dist dist-linux dist-darwin dist-windows
 .PHONY: test test-unit test-cli test-integration test-integration-host
@@ -304,3 +303,7 @@ cover:
 		go test -coverprofile=coverage.out -covermode=count $(pkg);\
 		tail -n +2 coverage.out >> coverage-all.out;)
 	go tool cover -html=coverage-all.out
+
+rules:
+	@hack/print-make-rules
+

--- a/hack/print-make-rules
+++ b/hack/print-make-rules
@@ -1,0 +1,3 @@
+#!/bin/bash
+make -qp | awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}' | sort
+


### PR DESCRIPTION
The Makefile has quite a few rules at this point, and they're getting hard to remember. This adds a rule to print all the rules in sorted order, which can be a bit quicker than opening and inspecting the Makefile.

    $ make rules
