### PR TITLE
fix default value for adminserveraddress

### DIFF
--- a/api/client/amp.go
+++ b/api/client/amp.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	//DefaultServerAddress amplifier address + port default
-	DefaultServerAddress = "127.0.0.1:8080"
+	DefaultServerAddress      = "127.0.0.1:8080"
+	DefaultAdminServerAddress = "127.0.0.1:31315"
 )
 
 var (

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -65,6 +65,9 @@ func main() {
 		if Config.ServerAddress == "" {
 			Config.ServerAddress = client.DefaultServerAddress
 		}
+		if Config.AdminServerAddress == "" {
+			Config.AdminServerAddress = client.DefaultAdminServerAddress
+		}
 		AMP = client.NewAMP(Config, cli.NewLogger(Config.Verbose))
 		if !Config.Verbose {
 			RootCmd.SilenceErrors = true


### PR DESCRIPTION
add default value for adminServerAddress in config

Test:
- make install
- rm ~/.config/amp/amp.yaml
- amp config Verbose true (for instance)
- verify the adminServerAddress value is well: 127.0.0.1:31315