### PR TITLE
amp help command

### DIFF
--- a/cmd/amp/login.go
+++ b/cmd/amp/login.go
@@ -14,7 +14,7 @@ import (
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login via GitHub",
-	Long:  `Create a GitHub access token and store it in your Config file to authenticate further commands.`,
+	Long:  `Login command creates a GitHub access token and store it in your Config file to authenticate further commands.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := AMP.Connect()
 		if err != nil {

--- a/cmd/amp/logs.go
+++ b/cmd/amp/logs.go
@@ -14,7 +14,7 @@ import (
 var logsCmd = &cobra.Command{
 	Use:   "logs [OPTIONS] [SERVICE]",
 	Short: "Fetch log entries matching provided criteria",
-	Long:  `Fetch log entries matching provided criteria. If provided, SERVICE can be a partial or full service id or service name.`,
+	Long:  `Log command fetches log entries matching provided criteria. If provided, SERVICE can be a partial or full service id or service name.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := AMP.Connect()
 		if err != nil {

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/appcelerator/amp/api/client"
 	"github.com/appcelerator/amp/cmd/amp/cli"
@@ -36,6 +37,9 @@ var (
 	RootCmd = &cobra.Command{
 		Use:   `amp [OPTIONS] COMMAND [arg...]`,
 		Short: "Appcelerator Microservice Platform.",
+		Long: `Appcelerator Microservice Platform(AMP) is an open-source Container-as-a-Service (CaaS) platform
+for managing and monitoring containerized applications and microservices
+as part of a unified serverless computing environment.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if displayConfigFilePath {
 				configFilePath := viper.ConfigFileUsed()
@@ -83,14 +87,32 @@ func main() {
 	// infoCmd represents the amp information
 	infoCmd := &cobra.Command{
 		Use:   "info",
-		Short: "Display amp version and server information",
-		Long:  `Display amp version and server information.`,
+		Short: "Display AMP version",
+		Long:  `Display the current amp version and server information.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("amp (cli version: %s, build: %s)\n", Version, Build)
 			fmt.Printf("Server: %s\n", Config.ServerAddress)
 		},
 	}
 	RootCmd.AddCommand(infoCmd)
+
+	// helpCmd displays help about amp Commands
+	var helpCmd = &cobra.Command{
+		Use:   "help [command]",
+		Short: "Help about the command",
+		Long:  `Display the help and usage information about AMP commands.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			cmd, args, e := RootCmd.Find(os.Args[2:])
+			if cmd == nil || e != nil || len(args) > 0 {
+				return fmt.Errorf("unknown help topic: %v", strings.Join(args, " "))
+			}
+
+			helpFunc := cmd.HelpFunc()
+			helpFunc(cmd, args)
+			return nil
+		},
+	}
+	RootCmd.AddCommand(helpCmd)
 
 	RootCmd.SetUsageTemplate(usageTemplate)
 	RootCmd.SetHelpTemplate(helpTemplate)
@@ -116,7 +138,9 @@ func main() {
 
 var usageTemplate = `Usage:	{{if not .HasSubCommands}}{{.UseLine}}{{end}}{{if .HasSubCommands}}{{ .CommandPath}} COMMAND{{end}}
 
-{{ .Short | trim }}{{if gt .Aliases 0}}
+{{ .Short | trim }}
+
+{{ .Long | trim }}{{if gt .Aliases 0}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}

--- a/cmd/amp/platform.go
+++ b/cmd/amp/platform.go
@@ -8,7 +8,7 @@ import (
 var PlatformCmd = &cobra.Command{
 	Use:     "platform",
 	Short:   "Platform operations (alias: pf)",
-	Long:    `Manage platform-related operations.`,
+	Long:    `Platform command manages all platform-related operations.`,
 	Aliases: []string{"pf"},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return nil

--- a/cmd/amp/platform_monitor.go
+++ b/cmd/amp/platform_monitor.go
@@ -9,7 +9,7 @@ import (
 var PlatformMonitor = &cobra.Command{
 	Use:   "monitor",
 	Short: "Display AMP platform services",
-	Long:  `Display AMP platform services information and states.`,
+	Long:  `Monitor command displays information about AMP platform services and states.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		displayAMPServiceStatus(cmd, args)
 	},

--- a/cmd/amp/platform_pull.go
+++ b/cmd/amp/platform_pull.go
@@ -10,7 +10,7 @@ import (
 var PlatformPull = &cobra.Command{
 	Use:   "pull",
 	Short: "Pull platform images",
-	Long:  `Pull all AMP platform images.`,
+	Long:  `Pull command pulls all the updated AMP platform images available from AMP Infrastructure stack.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		pullAMPImages(cmd, args)
 	},

--- a/cmd/amp/platform_start.go
+++ b/cmd/amp/platform_start.go
@@ -10,7 +10,8 @@ import (
 var PlatformStart = &cobra.Command{
 	Use:   "start",
 	Short: "Start platform",
-	Long:  `Start all AMP platform services.`,
+	Long: `Start command starts all AMP platform services available in the AMP Infrastructure stack.
+If the AMP platform is already running, it returns an appropriate message along with an option to force a re-start.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		startAMP(cmd, args)
 	},

--- a/cmd/amp/platform_status.go
+++ b/cmd/amp/platform_status.go
@@ -10,7 +10,8 @@ import (
 var PlatformStatus = &cobra.Command{
 	Use:   "status",
 	Short: "Get AMP platform status",
-	Long:  `Get AMP platform global status (stopped, partially running, running command return 1 if status is not running.`,
+	Long: `Status command retrieves AMP platform global status (stopped, partially running, running)
+- the command returns 1 if status is not running.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		getAMPStatus(cmd, args)
 	},

--- a/cmd/amp/platform_stop.go
+++ b/cmd/amp/platform_stop.go
@@ -10,7 +10,8 @@ import (
 var PlatformStop = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop platform",
-	Long:  `Stop all AMP platform services.`,
+	Long: `Stop command stops all the running AMP platform services.
+If the AMP platform is already stopped, it returns an appropriate message.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		stopAMP(cmd, args)
 	},

--- a/cmd/amp/registry.go
+++ b/cmd/amp/registry.go
@@ -21,7 +21,7 @@ import (
 var RegCmd = &cobra.Command{
 	Use:   "registry",
 	Short: "Registry operations",
-	Long:  `Manage registry-related operations.`,
+	Long:  `Registry command manages all registry-related operations.`,
 }
 
 var (
@@ -31,7 +31,7 @@ var (
 	pushCmd  = &cobra.Command{
 		Use:   "push [image]",
 		Short: "Push an image to the amp registry",
-		Long:  `Push an image to the amp registry.`,
+		Long:  `Push command pushes an image to the amp registry.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RegistryPush(AMP, cmd, args)
 		},
@@ -39,7 +39,7 @@ var (
 	reglsCmd = &cobra.Command{
 		Use:   "ls",
 		Short: "List the amp registry images",
-		Long:  `List the amp registry images.`,
+		Long:  `List command lists all the available amp registry images.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RegistryLs(AMP, cmd, args)
 		},

--- a/cmd/amp/service-create.go
+++ b/cmd/amp/service-create.go
@@ -18,7 +18,7 @@ var (
 	serviceCreateCmd = &cobra.Command{
 		Use:   "create [OPTIONS] IMAGE [CMD] [ARG...]",
 		Short: "Create a new service",
-		Long:  `Create a new service.`,
+		Long:  `Create command creates a new service with a specified image and/or options and arguments.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return serviceCreate(AMP, cmd, args)
 		},

--- a/cmd/amp/service-rm.go
+++ b/cmd/amp/service-rm.go
@@ -16,7 +16,7 @@ var (
 	serviceRmCmd = &cobra.Command{
 		Use:   "rm [OPTIONS] SERVICE [SERVICE...]",
 		Short: "Remove one or more services",
-		Long:  `Remove one or more services.`,
+		Long:  `Remove command removes one or more services based on specified options.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return serviceRm(AMP, cmd, args)
 		},

--- a/cmd/amp/service.go
+++ b/cmd/amp/service.go
@@ -8,7 +8,7 @@ import (
 var ServiceCmd = &cobra.Command{
 	Use:   "service",
 	Short: "Manage services",
-	Long:  `Manage services.`,
+	Long:  `Service command manages all service-related operations.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return AMP.Connect()
 	},

--- a/cmd/amp/stack.go
+++ b/cmd/amp/stack.go
@@ -18,7 +18,7 @@ import (
 var StackCmd = &cobra.Command{
 	Use:   "stack",
 	Short: "Stack operations",
-	Long:  `Manage stack-related operations.`,
+	Long:  `Stack command manages all stack-related operations.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return AMP.Connect()
 	},
@@ -28,7 +28,7 @@ var (
 	stackCreateCmd = &cobra.Command{
 		Use:   "create [-f FILE] [name]",
 		Short: "Create a stack",
-		Long:  `Create a stack.`,
+		Long:  `Create command creates a stack according to the specified file path and name.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackCreate(AMP, cmd, args)
 		},
@@ -36,7 +36,7 @@ var (
 	stackUpCmd = &cobra.Command{
 		Use:   "up [-f FILE] [name]",
 		Short: "Create and deploy a stack",
-		Long:  `Create and deploy a stack.`,
+		Long:  `Up command creates and deploys a stack according to the specified file path and name.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackUp(AMP, cmd, args)
 		},
@@ -46,7 +46,7 @@ var (
 	stackStartCmd = &cobra.Command{
 		Use:   "start [stack name or id]",
 		Short: "Start a stopped stack",
-		Long:  `Start a stopped stack.`,
+		Long:  `Start command starts a stopped stack according to the specified stack name or id.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackStart(AMP, cmd, args)
 		},
@@ -54,7 +54,7 @@ var (
 	stackStopCmd = &cobra.Command{
 		Use:   "stop [stack name or id]",
 		Short: "Stop a stack",
-		Long:  `Stop all services of a stack.`,
+		Long:  `Stop command stops all services of the specified stack name or id.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackStop(AMP, cmd, args)
 		},
@@ -62,7 +62,7 @@ var (
 	stackRmCmd = &cobra.Command{
 		Use:   "rm [stack name or id]",
 		Short: "Remove a stack",
-		Long:  `Remove a stack completly including ETCD data.`,
+		Long:  `Remove command removes the specified stack name or id completely, including ETCD data.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackRm(AMP, cmd, args)
 		},
@@ -70,7 +70,7 @@ var (
 	stackListCmd = &cobra.Command{
 		Use:   "ls",
 		Short: "List available stacks",
-		Long:  `List available stacks.`,
+		Long:  `List command lists all available stacks.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackList(AMP, cmd, args)
 		},
@@ -78,7 +78,7 @@ var (
 	stackTasksCmd = &cobra.Command{
 		Use:   "ps [stack name or id]",
 		Short: "List the tasks of a stack",
-		Long:  `List the tasks of a stack.`,
+		Long:  `PS command lists the tasks of a stack based on specified name or id.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackTasks(AMP, cmd, args)
 		},
@@ -86,7 +86,7 @@ var (
 	stackUrlsCmd = &cobra.Command{
 		Use:   "urls [stack name or id . . .]",
 		Short: "List the urls for a stack",
-		Long:  `List the urls for a stack.`,
+		Long:  `URL command lists the urls for a stack based on specified name or id.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stackUrls(AMP, cmd, args)
 		},

--- a/cmd/amp/stats.go
+++ b/cmd/amp/stats.go
@@ -22,7 +22,7 @@ const (
 var statsCmd = &cobra.Command{
 	Use:   "stats [service name or id] or --flags...",
 	Short: "Display resource usage statistics",
-	Long:  `Get statistics on containers, services, nodes about cpu, memory, io, net.`,
+	Long:  `Stats command manages all statistics-related operations on containers, services, nodes about cpu, memory, io, net.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := AMP.Connect()
 		if err != nil {

--- a/cmd/amp/storage.go
+++ b/cmd/amp/storage.go
@@ -16,7 +16,7 @@ import (
 var StorageCmd = &cobra.Command{
 	Use:   "kv",
 	Short: "Storage operations",
-	Long:  `Manage storage-related operations.`,
+	Long:  `KV command manages all key-value based storage operations in the ETCD.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return AMP.Connect()
 	},
@@ -27,7 +27,8 @@ var (
 	storagePutCmd = &cobra.Command{
 		Use:   "put [key] [val]",
 		Short: "Assign specified value with specified key",
-		Long:  `Assign specified value with specified key`,
+		Long: `Put command (amp kv put) creates a storage object with the key-value input if the key does not already exist.
+Else, it updates the existing key with the new input value.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return storagePut(AMP, cmd, args)
 		},
@@ -36,16 +37,18 @@ var (
 	storageGetCmd = &cobra.Command{
 		Use:   "get [key]",
 		Short: "Retrieve a storage object",
-		Long:  `Retrieve a storage object`,
+		Long: `Get command (amp kv get) retrieves a key-value pair based on the specified input key.
+If not found, an appropriate message is returned.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return storageGet(AMP, cmd, args)
 		},
 	}
 	// storageDeleteCmd represents the deletion of storage value based on key
 	storageDeleteCmd = &cobra.Command{
-		Use:     "del [key]",
-		Short:   "Delete a storage object (alias: rm)",
-		Long:    `Delete a storage object (alias: rm)`,
+		Use:   "del [key]",
+		Short: "Delete a storage object (alias: rm)",
+		Long: `Delete command (amp kv del or amp kv rm) deletes the key-value pair in storage based on the specified input key.
+If not found, an appropriate message is returned.`,
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return storageDelete(AMP, cmd, args)
@@ -55,7 +58,8 @@ var (
 	storageListCmd = &cobra.Command{
 		Use:   "ls",
 		Short: "List all storage objects",
-		Long:  `List all storage objects`,
+		Long: `List command (amp kv ls) returns a list of all the key-value pair in storage.
+If no key-value pair is present, an appropriate message is returned.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return storageList(AMP, cmd, args)
 		},

--- a/cmd/amp/topic-create.go
+++ b/cmd/amp/topic-create.go
@@ -14,7 +14,7 @@ var (
 	createTopicCmd = &cobra.Command{
 		Use:   "create [OPTIONS] NAME",
 		Short: "Create a topic",
-		Long:  `Create a topic.`,
+		Long:  `Create command creates a topic with specified name and options.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createTopic(AMP, cmd, args)
 		},

--- a/cmd/amp/topic-ls.go
+++ b/cmd/amp/topic-ls.go
@@ -19,7 +19,7 @@ var (
 	listTopicCmd = &cobra.Command{
 		Use:   "ls [OPTIONS]",
 		Short: "List topics",
-		Long:  `List topics.`,
+		Long:  `List command returns all topics present.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listTopic(AMP, cmd, args)
 		},

--- a/cmd/amp/topic-rm.go
+++ b/cmd/amp/topic-rm.go
@@ -14,7 +14,7 @@ var (
 	removeTopicCmd = &cobra.Command{
 		Use:   "rm [OPTIONS] TOPIC",
 		Short: "Remove topic",
-		Long:  `Remove topic.`,
+		Long:  `Remove command removes the specified topic and options.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeTopic(AMP, cmd, args)
 		},

--- a/cmd/amp/topic.go
+++ b/cmd/amp/topic.go
@@ -8,7 +8,7 @@ import (
 var TopicCmd = &cobra.Command{
 	Use:   "topic",
 	Short: "Topic operations",
-	Long:  `Manage topic-related operations.`,
+	Long:  `Topic command manages all topic-related operations.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return AMP.Connect()
 	},

--- a/cmd/amp/version.go
+++ b/cmd/amp/version.go
@@ -30,7 +30,7 @@ Amplifier:
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Display the version info for AMP and Amplifier",
-	Long:  `Display the version info for AMP and Amplifier`,
+	Long:  `Version command displays the version info for AMP and Amplifier, including the current version and build.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return list(AMP, cmd, args)
 	},


### PR DESCRIPTION
Ref: #565  #604 

Added `amp help` command, which mimicks `docker help` functionality. Also included the Long message to be displayed in the help command.
`amp help <command>` displays usage for a particular command.
However, using `amp <command> help` for certain commands like `stats`, `info` and `config` does not print usage. 

```
$ amp help

Usage:	amp COMMAND

Appcelerator Microservice Platform.

Appcelerator Microservice Platform(AMP) is an open-source Container-as-a-Service (CaaS) platform 
for managing and monitoring containerized applications and microservices
as part of a unified serverless computing environment.

Options:
      --config-used         Display config file used (if any)
  -h, --help                Display help
      --server string       Server address
      --use-config string   Specify config file (overrides default at $HOME/.config/amp/amp.yaml)
  -v, --verbose             Verbose output
  -V, --version             Version number

Commands:
  config      Display or update the current configuration
  function    function operations
  help        Help about the command
  info        Display AMP version
  kv          Storage operations
  login       Login via GitHub
  logs        Fetch log entries matching provided criteria
  platform    Platform operations (alias: pf)
  registry    Registry operations
  service     Manage services
  stack       Stack operations
  stats       Display resource usage statistics
  topic       Topic operations
  version     Display the version info for AMP and Amplifier

Run 'amp COMMAND --help' for more information on a command.
```