### PR TITLE
fix proto files compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-  
 .PHONY: all clean proto-clean bin-clean install install-host fmt simplify check version build-image run proto proto-host rules
 .PHONY: build build-cli-linux build-cli-darwin build-cli-windows build-server build-server-linux build-server-darwin build-server-windows
 .PHONY: dist dist-linux dist-darwin dist-windows
@@ -26,14 +25,10 @@ UNIT_TEST_PACKAGES        := $(shell find .                   -type f -name '*_t
 CLI_TEST_PACKAGES         := $(shell find ./tests/cli         -type f -name '*_test.go'                        $(EXCLUDE_DIRS_FILTER) -exec dirname {} \; | sort -u)
 INTEGRATION_TEST_PACKAGES := $(shell find ./tests/integration -type f -name '*_test.go'                        $(EXCLUDE_DIRS_FILTER) -exec dirname {} \; | sort -u)
 
-DIRS = $(shell find . -type d $(EXCLUDE_DIRS_FILTER))
-
 # generated file dependencies for proto rule
 PROTOFILES := $(shell find . \( -path ./vendor -o -path ./.git -o -path ./.glide -o -path ./tests \) -prune -o -type f -name '*.proto' -print)
-PROTOGWFILES := $(shell find . \( -path ./vendor -o -path ./.git -o -path ./.glide -o -path ./tests \) -prune -o -type f -name '*.proto' -exec grep -l google/api/annotations {} \;)
-PROTOTARGETS := $(PROTOFILES:.proto=.pb.go)
-PROTOGWTARGETS := $(PROTOGWFILES:.proto=.pb.gw.go)
-PROTOALLTARGETS := $(PROTOTARGETS) $(PROTOGWTARGETS)
+PROTOGWFILES := $(shell find . \( -path ./vendor -o -path ./.git -o -path ./.glide -o -path ./tests \) -prune -o -type f -name '*.proto' -exec grep -l 'google.api.http' {} \;)
+PROTOALLTARGETS := $(PROTOFILES:.proto=.pb.go) $(PROTOGWFILES:.proto=.pb.gw.go)
 
 # generated files that can be cleaned
 GENERATED := $(shell find . -type f \( -name '*.pb.go' -o -name '*.pb.gw.go' \) $(EXCLUDE_FILES_FILTER))
@@ -98,9 +93,7 @@ update-deps:
 	@rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/net/trace
 
 # explicit rule to compile protobuf files
-%.pb.go: %.proto
-	@go run hack/proto.go
-%.pb.gw.go: %.proto
+%.pb.go %.pb.gw.go: %.proto
 	@go run hack/proto.go
 
 # used to install when you're already inside a container


### PR DESCRIPTION
fixes #658 

The dynamic list for *.pb.gw.go targets was broken, the resulting list contained files that were never generated, triggering systematically the proto compilation, loosing a lot of time.

- fixing the dynamic proto targets
- combining the explicit rules
- removing unneeded lines

## How to compare
Timing below are on a Mac, YMMV.
You can notice a big difference in the total cpu time.

### Before modification

```
~/Development/src/github.com/appcelerator/amp(master ✔) make clean
~/Development/src/github.com/appcelerator/amp(master ✔) time make install-cli ; time make install-cli
make install-cli  9.91s user 3.74s system 14% cpu 1:36.78 total
make install-cli  9.45s user 3.98s system 20% cpu 1:07.01 total

```
### After the modification

```
~/Development/src/github.com/appcelerator/amp(master ✗) make clean
~/Development/src/github.com/appcelerator/amp(master ✗) time make install-cli ; time make install-cli
make install-cli  9.12s user 2.73s system 33% cpu 34.871 total
make install-cli  4.27s user 1.19s system 100% cpu 5.417 total

```