### PR TITLE
Alpine 3.5

### DIFF
--- a/Dockerfile.shrink
+++ b/Dockerfile.shrink
@@ -1,4 +1,4 @@
-FROM appcelerator/alpine:20160928
+FROM appcelerator/alpine:3.5.1
 COPY ./amp /usr/local/bin/amp
 COPY ./amplifier /usr/local/bin/amplifier
 COPY ./amp-agent /usr/local/bin/amp-agent

--- a/cmd/amp/platform_infrastructure.go
+++ b/cmd/amp/platform_infrastructure.go
@@ -13,12 +13,12 @@ const (
 
 const (
 	ampVersion           = "latest"
-	influxDBVersion      = "1.1.2"
-	kapacitorVersion     = "1.1.2"
-	telegrafVersion      = "1.1.1"
-	grafanaVersion       = "1.1.0"
-	elasticsearchVersion = "5.1.1"
-	etcdVersion          = "3.1.0-rc.1"
+	influxDBVersion      = "1.1.3"
+	kapacitorVersion     = "1.1.3"
+	telegrafVersion      = "1.1.2"
+	grafanaVersion       = "1.1.3"
+	elasticsearchVersion = "5.1.2"
+	etcdVersion          = "3.1.0"
 	natsVersion          = "0.3.0"
 	haproxyVersion       = "1.0.3"
 	registryVersion      = "2.5.1"


### PR DESCRIPTION
ref #621 
close #663

- build AMP image based on Alpine 3.5
- use newly built AMP infra images with Alpine 3.5

test with:
```
$ make clean install
$ make TAG=local build-image
$ amp pf pull && amp pf start --local && make test
```