### PR TITLE
Stack routing failure

### DIFF
--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -253,7 +253,7 @@ func (s *Server) processService(ctx context.Context, stack *Stack, serv *service
 // add HAProxy service dedicated to the stack reverse proxy
 func (s *Server) addHAProxyService(ctx context.Context, stack *Stack) (string, error) {
 	serv := service.ServiceSpec{
-		Image: "appcelerator/haproxy:1.0.1",
+		Image: "appcelerator/haproxy:1.0.4", //TODO: use shared HAProxy image name when issue#674 will be done
 		Name:  "haproxy",
 		Env:   []string{"STACKNAME=" + stack.Name},
 		Networks: []*service.NetworkAttachment{

--- a/cmd/adm-server/servercore/infrastructure.go
+++ b/cmd/adm-server/servercore/infrastructure.go
@@ -20,7 +20,7 @@ const (
 	elasticsearchVersion = "5.1.1"
 	etcdVersion          = "3.1.0-rc.1"
 	natsVersion          = "0.3.0"
-	haproxyVersion       = "1.0.3"
+	haproxyVersion       = "1.0.4"
 	registryVersion      = "2.5.1"
 )
 
@@ -137,7 +137,7 @@ func getAMPInfrastructureStack(m *AMPInfraManager) *ampStack {
 				},
 			},
 		},
-		"etcd")
+		"etcd", "amplifier-gateway", "amp-function-listener")
 
 	//add nats
 	stack.addService(m, "nats", "nats", 1,

--- a/cmd/amp/platform_infrastructure.go
+++ b/cmd/amp/platform_infrastructure.go
@@ -20,7 +20,7 @@ const (
 	elasticsearchVersion = "5.1.1"
 	etcdVersion          = "3.1.0-rc.1"
 	natsVersion          = "0.3.0"
-	haproxyVersion       = "1.0.3"
+	haproxyVersion       = "1.0.4"
 	registryVersion      = "2.5.1"
 )
 
@@ -137,7 +137,7 @@ func getAMPInfrastructureStack(m *ampManager) *ampStack {
 				},
 			},
 		},
-		"etcd")
+		"etcd", "amplifier-gateway", "amp-function-listener")
 
 	//add nats
 	stack.addService(m, "nats", "nats", 1,


### PR DESCRIPTION
related to #690 

fixed

test:
- make install
- amp pf stop
- amp pf pull  (should pull appcelerator/haproxy:1.0.4)
- amp pf start -v
- amp stack up test1 -f ./examples/stacks/pinger/stack.yml
- wait for stack started
- curl url http://www.test1.local.atomiq.io/ping -> "pong"
- amp stack up test2 -f ./examples/stacks/pinger/stack.yml
- wait for stack started
- curl url http://www.test1.local.atomiq.io/ping ->  "pong"
- curl url http://www.test2.local.atomiq.io/ping ->  "pong"
- amp stack rm -f test1
- wait for stack removed
- amp stack up test1 -f ./examples/stacks/pinger/stack.yml
- wait for stack started
- curl url http://www.test1.local.atomiq.io/ping -> "pong"
- curl url http://www.test2.local.atomiq.io/ping -> "pong"

regression tests:
make test