### PR TITLE
Added verbose flag

### DIFF
--- a/hack/proto.go
+++ b/hack/proto.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 )
 
 var (


### PR DESCRIPTION
Refactored, formatted, and added verbose (-v) flag to the protoc script.

    $ make clean
    $ go run hack/proto.go -v

Be aware that the Makefile doesn't seem to be capturing all the proto files that generate swagger files, so `go run hack/proto.go -v` will display and generate more file than `make proto`. This needs to be fixed as a separate Makefile issue.