### PR TITLE
Docker gotools

### DIFF
--- a/images/gotools/Dockerfile
+++ b/images/gotools/Dockerfile
@@ -22,6 +22,7 @@ RUN go-getter /go/Gofile
 # Install glide for vendoring support
 RUN curl https://glide.sh/get | sh
 # Use /tmp/glide for the glide cache
+RUN mkdir -p /tmp/glide && chmod 777 /tmp/glide
 VOLUME /tmp/glide
 
 # Customize the shell in root/.bashrc, add other shell support here, etc.

--- a/images/gotools/Dockerfile
+++ b/images/gotools/Dockerfile
@@ -6,10 +6,13 @@ FROM golang:1.7-alpine
 # The alpine-sdk adds a bunch of essential tools, such as
 # ca-certificates, musl, musl-dev, openssl, curl, make, gcc, g++, libstdc++, libc-dev, tar, bzip2, git
 # The rest are for building grpc or for any other convenience.
-RUN apk --no-cache add alpine-sdk bash vim autoconf automake libtool
+RUN apk --no-cache add alpine-sdk bash vim autoconf automake libtool bind-tools drill
 
 # Helper commands, like go-getter and install-protoc
 ADD bin /usr/local/bin/
+
+# Install protoc (download source, build and install -- required by protoc-gen-go and related tools)
+RUN install-protoc
 
 # Use go-getter for getting specific package versions (when possible).
 # Add go packages to be installed to Gofile
@@ -20,9 +23,6 @@ RUN go-getter /go/Gofile
 RUN curl https://glide.sh/get | sh
 # Use /tmp/glide for the glide cache
 VOLUME /tmp/glide
-
-# Install protoc (download source, build and install -- required by protoc-gen-go and related tools)
-RUN install-protoc
 
 # Customize the shell in root/.bashrc, add other shell support here, etc.
 ADD bash /root

--- a/images/gotools/Dockerfile
+++ b/images/gotools/Dockerfile
@@ -18,6 +18,8 @@ RUN go-getter /go/Gofile
 
 # Install glide for vendoring support
 RUN curl https://glide.sh/get | sh
+# Use /tmp/glide for the glide cache
+VOLUME /tmp/glide
 
 # Install protoc (download source, build and install -- required by protoc-gen-go and related tools)
 RUN install-protoc

--- a/images/gotools/Dockerfile
+++ b/images/gotools/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.7-alpine
+# This builds a convenience "all-in-one" image for go development.
+# It intentionally does not remove any build prerequisites like most of our other
+# images since this image is meant strictly for building things.
+
+# The alpine-sdk adds a bunch of essential tools, such as
+# ca-certificates, musl, musl-dev, openssl, curl, make, gcc, g++, libstdc++, libc-dev, tar, bzip2, git
+# The rest are for building grpc or for any other convenience.
+RUN apk --no-cache add alpine-sdk bash vim autoconf automake libtool
+
+# Helper commands, like go-getter and install-protoc
+ADD bin /usr/local/bin/
+
+# Use go-getter for getting specific package versions (when possible).
+# Add go packages to be installed to Gofile
+ADD Gofile /go
+RUN go-getter /go/Gofile
+
+# Install glide for vendoring support
+RUN curl https://glide.sh/get | sh
+
+# Install protoc (download source, build and install -- required by protoc-gen-go and related tools)
+RUN install-protoc
+
+# Customize the shell in root/.bashrc, add other shell support here, etc.
+ADD bash /root
+
+# TODO: might want to use /go as the work directory...
+WORKDIR /go/src
+CMD [ "echo", "[gotools] specify the command to run" ]
+

--- a/images/gotools/Gofile
+++ b/images/gotools/Gofile
@@ -1,0 +1,7 @@
+google.golang.org/grpc v1.0.5
+github.com/golang/protobuf/protoc-gen-go 8ee79997227bf9b34611aee7946ae64735e6fd93
+github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+
+github.com/golang/lint/golint
+

--- a/images/gotools/README.md
+++ b/images/gotools/README.md
@@ -10,5 +10,5 @@ These tools are used by the amp toolchain.
 Currently includes
 
 * [Go 1.7](https://hub.docker.com/_/golang/)
-* [Glide](https://glide.sh/) v0.12.0
+* [Glide](https://glide.sh/) v0.12.3
 * [Golint](https://github.com/golang/lint)

--- a/images/gotools/README.md
+++ b/images/gotools/README.md
@@ -1,0 +1,14 @@
+# gotools
+
+[On Docker Hub](https://hub.docker.com/r/subfuzion/gotools). Clone from [subfuzion/gotools](https://github.com/subfuzion/docker-gotools).
+
+This is a collection of Go tools that can be used from in a container for convenience
+and from makefiles so they don't need to be installed as prerequisites.
+
+These tools are used by the amp toolchain.
+
+Currently includes
+
+* [Go 1.7](https://hub.docker.com/_/golang/)
+* [Glide](https://glide.sh/) v0.12.0
+* [Golint](https://github.com/golang/lint)

--- a/images/gotools/bash/.bashrc
+++ b/images/gotools/bash/.bashrc
@@ -1,0 +1,1 @@
+alias ll='ls -lAF'

--- a/images/gotools/bin/go-getter
+++ b/images/gotools/bin/go-getter
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Like 'go get' but with pinned package versions. https://github.com/joewalnes/go-getter
+set -e
+: ${GOPATH?"GOPATH not set"}
+: ${1?"Usage: $0 [path-to-go-deps]"}
+sed -e 's/#.*//' $1 | grep -v -e '^[[:space:]]*$' | while read PKG HASH; do
+  echo "$PKG ($HASH)"
+  DEST=$GOPATH/src/$PKG
+  go get -d -u $PKG || true
+  FOUND_VCS=0
+  while [[ "$DEST" != "$GOPATH/src" ]] && [[ -d $DEST ]]
+  do
+    cd $DEST
+    if [ -d "$DEST/.git" ]; then
+      FOUND_VCS=1
+      echo "git checkout -q $HASH"
+      git checkout -q $HASH || true
+      git submodule update --init || true
+      echo "done"
+      break
+    elif [ -d "$DEST/.hg" ]; then
+      FOUND_VCS=1
+      hg update -q -c $HASH
+      break
+    elif [ -d "$DEST/.bzr" ]; then
+      FOUND_VCS=1
+      bzr update -q -r $HASH
+      break
+    elif [ -d "$DEST/.svn" ]; then
+      FOUND_VCS=1
+      svn update -q -r $HASH
+      break
+    else
+      DEST="$(readlink -f $DEST/..)"
+    fi
+  done
+  if [ $FOUND_VCS -eq 0 ]; then
+    echo "WARNING: Unrecognized VCS system for the golang package $PKG"
+  fi
+  go install $PKG || true
+done

--- a/images/gotools/bin/install-protoc
+++ b/images/gotools/bin/install-protoc
@@ -1,0 +1,11 @@
+#!/bin/sh
+git clone https://github.com/google/protobuf.git --branch v3.1.0 --depth 1
+cd protobuf
+git submodule update --init
+./autogen.sh
+./configure
+make -j 3
+make install
+make clean
+cd ..
+rm -r protobuf


### PR DESCRIPTION
Collection of Go tools in an alpine image. Used by the amp toolchain. Among other things, this is specifically for building alpines images at the moment. We may want to generate ubuntu binaries again down the road.