### PR TITLE
docker-dind

### DIFF
--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker:1.13-dind
+RUN apk --no-cache add iproute2 bind-tools drill
+ENTRYPOINT ["dockerd-entrypoint.sh", "--experimental"]
+CMD []
+

--- a/images/dind/README.md
+++ b/images/dind/README.md
@@ -1,0 +1,37 @@
+# dind
+
+[On Docker Hub](https://hub.docker.com/r/subfuzion/dind/). Cloned from [subfuzion/docker-dind](https://github.com/subfuzion/docker-dind).
+Convenience image based on latest Docker in Docker with experimental flag set and
+a few network utilities (like iproute2, dig and drill).
+
+Why is this useful? Right now if you want to start dind with the experimental flag
+you have to explicitly supply it as follows:
+
+    $ docker run --detach --privileged --name=dind docker:dind --experimental
+    $ docker exec -it dind sh
+    / # docker version
+    Client:
+     Version:      1.13.0
+     API version:  1.25
+     Go version:   go1.7.3
+     Git commit:   49bf474
+     Built:        Wed Jan 18 16:20:26 2017
+     OS/Arch:      linux/amd64
+
+    Server:
+     Version:      1.13.0
+     API version:  1.25 (minimum version 1.12)
+     Go version:   go1.7.3
+     Git commit:   49bf474
+     Built:        Wed Jan 18 16:20:26 2017
+     OS/Arch:      linux/amd64
+     Experimental: true
+
+You can see from the last line that the daemon was started in experimental mode.
+With this image, however, experimental mode is the default:
+
+    $ docker run --detach --privileged --name=dind subfuzion:dind
+
+This image also adds a few convenient network tools, [iproute2](http://baturin.org/docs/iproute2/)
+[dig](https://linux.die.net/man/1/dig), and [drill](https://linux.die.net/man/1/drill) (from the [ldns project](https://www.nlnetlabs.nl/projects/ldns/)).
+

--- a/images/dind/README.md
+++ b/images/dind/README.md
@@ -1,6 +1,6 @@
 # dind
 
-[On Docker Hub](https://hub.docker.com/r/subfuzion/dind/). Cloned from [subfuzion/docker-dind](https://github.com/subfuzion/docker-dind).
+[On Docker Hub](https://hub.docker.com/r/appcelerator/dind/).
 Convenience image based on latest Docker in Docker with experimental flag set and
 a few network utilities (like iproute2, dig and drill).
 
@@ -30,8 +30,7 @@ you have to explicitly supply it as follows:
 You can see from the last line that the daemon was started in experimental mode.
 With this image, however, experimental mode is the default:
 
-    $ docker run --detach --privileged --name=dind subfuzion:dind
+    $ docker run --detach --privileged --name=dind appcelerator/dind
 
 This image also adds a few convenient network tools, [iproute2](http://baturin.org/docs/iproute2/)
 [dig](https://linux.die.net/man/1/dig), and [drill](https://linux.die.net/man/1/drill) (from the [ldns project](https://www.nlnetlabs.nl/projects/ldns/)).
-


### PR DESCRIPTION
Convenience image based on latest Docker in Docker with experimental flag set and a few network utilities (like iproute2, dig and drill).