### PR TITLE
Refactor make protoc

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -17,9 +17,20 @@ REPO := github.com/$(OWNER)/amp
 # COMMON FILE AND DIRECTORY FILTERS AND GLOB VARS
 # =============================================================================
 # Everything that should be excluded when walking directory tree
-EXCLUDE_FILES_FILTER := -not -path './vendor/*' -not -path './.test/*' -not -path './.git/*' -not -path './.glide/*'
-EXCLUDE_DIRS_FILTER := $(EXCLUDE_FILES_FILTER) -not -path '.' -not -path './.test' -not -path './vendor' -not -path './.git' -not -path './.glide'
+# EXCLUDE_FILES_FILTER := -not -path './.*' -not -path './vendor/*' -not -path './.test/*' -not -path './.git/*' -not -path './.glide/*'
+# EXCLUDE_DIRS_FILTER := $(EXCLUDE_FILES_FILTER) -not -path './.' -not -path './.test' -not -path './vendor' -not -path './.git' -not -path './.glide'
 
+EXCLUDE_DIRS_FILTER := -not -path './.*' -not -path './.*/*' \
+	-not -path './dist' -not -path './dist/*' \
+	-not -path './docs' -not -path './docs/*' \
+	-not -path './hack' -not -path './hack/*' \
+	-not -path './images' -not -path './images/*' \
+	-not -path './project' -not -path './project/*' \
+	-not -path './vendor' -not -path './vendor/*'
+
+INCLUDE_DIRS_FILTER := -path './*' -path './*/*' $(EXCLUDE_DIRS_FILTER)
+
+SRCDIRS := $(shell find . -type d $(EXCLUDE_DIRS_FILTER))
 GOSRC := $(shell find . -type f -name '*.go' $(EXCLUDE_DIRS_FILTER))
 
 # =============================================================================
@@ -39,8 +50,15 @@ DOCKER_RUN_CMD := docker run -t --rm -u $(UG)
 GOTOOLS := appcelerator/gotools:latest
 
 # =============================================================================
+# DEFAULT TARGET
+# =============================================================================
+all: build
+
+# =============================================================================
 # VENDOR MANAGEMENT (GLIDE)
 # =============================================================================
+.PHONY: install-deps update-deps
+
 # Mount ~/.ssh (for access to private git repos), glide cache, and working directory (for ~/vendor)
 GLIDE_BASE_CMD := $(DOCKER_RUN_CMD) \
                   -e HOME=$${HOME} \
@@ -64,5 +82,45 @@ update-deps:
 	@$(GLIDE_UPDATE_CMD)
 # TODO: temporary fix for trace conflict, remove when resolved
 	@rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/net/trace
+
+# =============================================================================
+# PROTOC (PROTOCOL BUFFER COMPILER)
+# Generate *.pb.go, *.pb.gw.go files in any non-excluded directory
+# with *.proto files.
+# =============================================================================
+.PHONY: protoc protoc-clean
+
+PROTOFILES := $(shell find . -type f -name '*.proto' $(EXCLUDE_DIRS_FILTER))
+PROTOGWFILES := $(shell find . -type f -name '*.proto' $(EXCLUDE_DIRS_FILTER) -exec grep -l 'google.api.http' {} \;)
+PROTOTARGETS := $(PROTOFILES:.proto=.pb.go) $(PROTOGWFILES:.proto=.pb.gw.go) $(PROTOGWFILES:.proto=.swagger.json)
+
+%.pb.go %.pb.gw.go %.swagger.json: %.proto
+	@go run hack/proto.go "/go/src/$(REPO)/$<"
+
+protoc: $(PROTOTARGETS)
+
+protoc-clean:
+	@find . \( -name "*.pb.go" -o -name "*.pb.gw.go" -o -name "*.swagger.json" \) \
+			$(EXCLUDE_DIRS_FILTER) -type f -delete
+
+# =============================================================================
+# CLEAN
+# =============================================================================
+.PHONY: clean
+clean: protoc-clean
+
+# =============================================================================
+# BUILD
+# =============================================================================
+build: $(PROTOTARGETS)
+	@echo To be implemented...
+
+# =============================================================================
+# MISC
+# =============================================================================
+# TODO: used for debugging makefile, will ultimately this remove when all finished
+.PHONY: dump
+dump:
+	@echo $(SRCDIRS)
 
 

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -88,9 +88,11 @@ update-deps:
 
 PROTOFILES := $(shell find . -type f -name '*.proto' $(EXCLUDE_DIRS_FILTER))
 PROTOGWFILES := $(shell find . -type f -name '*.proto' $(EXCLUDE_DIRS_FILTER) -exec grep -l 'google.api.http' {} \;)
-PROTOTARGETS := $(PROTOFILES:.proto=.pb.go) $(PROTOGWFILES:.proto=.pb.gw.go) $(PROTOGWFILES:.proto=.swagger.json)
+# Generate swagger.json files for protobuf types even if only exposed over gRPC, not REST API
+PROTOTARGETS := $(PROTOFILES:.proto=.pb.go) $(PROTOGWFILES:.proto=.pb.gw.go) $(PROTOFILES:.proto=.swagger.json)
 
 %.pb.go %.pb.gw.go %.swagger.json: %.proto
+	@echo $@
 	@go run hack/proto.go "/go/src/$(REPO)/$<"
 
 protoc: $(PROTOTARGETS)

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -16,10 +16,6 @@ REPO := github.com/$(OWNER)/amp
 # =============================================================================
 # COMMON FILE AND DIRECTORY FILTERS AND GLOB VARS
 # =============================================================================
-# Everything that should be excluded when walking directory tree
-# EXCLUDE_FILES_FILTER := -not -path './.*' -not -path './vendor/*' -not -path './.test/*' -not -path './.git/*' -not -path './.glide/*'
-# EXCLUDE_DIRS_FILTER := $(EXCLUDE_FILES_FILTER) -not -path './.' -not -path './.test' -not -path './vendor' -not -path './.git' -not -path './.glide'
-
 EXCLUDE_DIRS_FILTER := -not -path './.*' -not -path './.*/*' \
 	-not -path './dist' -not -path './dist/*' \
 	-not -path './docs' -not -path './docs/*' \

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -1,5 +1,3 @@
-.PHONY: install-deps update-deps
-
 SHELL := /bin/bash
 BASEDIR := $(shell echo $${PWD})
 
@@ -66,4 +64,5 @@ update-deps:
 	@$(GLIDE_UPDATE_CMD)
 # TODO: temporary fix for trace conflict, remove when resolved
 	@rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/net/trace
+
 

--- a/api/rpc/build/build.swagger.json
+++ b/api/rpc/build/build.swagger.json
@@ -15,5 +15,144 @@
     "application/json"
   ],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "buildBuild": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
+        "sha": {
+          "type": "string",
+          "format": "string"
+        },
+        "status": {
+          "type": "string",
+          "format": "string"
+        },
+        "commit_message": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildBuildList": {
+      "type": "object",
+      "properties": {
+        "builds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/buildBuild"
+          }
+        }
+      }
+    },
+    "buildBuildRequest": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
+        "sha": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildLog": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildPing": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildPong": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildProject": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "owner": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
+        "status": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "buildProjectList": {
+      "type": "object",
+      "properties": {
+        "projects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/buildProject"
+          }
+        }
+      }
+    },
+    "buildProjectQuery": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "type": "string",
+          "format": "string"
+        },
+        "latest": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "buildProjectRequest": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    }
+  }
 }

--- a/api/rpc/function/function.swagger.json
+++ b/api/rpc/function/function.swagger.json
@@ -117,11 +117,11 @@
           "type": "string",
           "format": "string"
         },
-        "image": {
+        "name": {
           "type": "string",
           "format": "string"
         },
-        "name": {
+        "image": {
           "type": "string",
           "format": "string"
         }

--- a/api/rpc/logs/logs.swagger.json
+++ b/api/rpc/logs/logs.swagger.json
@@ -67,10 +67,6 @@
           "type": "string",
           "format": "string"
         },
-        "infra": {
-          "type": "boolean",
-          "format": "boolean"
-        },
         "message": {
           "type": "string",
           "format": "string"
@@ -79,36 +75,32 @@
           "type": "string",
           "format": "string"
         },
-        "service": {
-          "type": "string",
-          "format": "string"
-        },
         "size": {
           "type": "string",
           "format": "int64"
         },
+        "service": {
+          "type": "string",
+          "format": "string"
+        },
         "stack": {
           "type": "string",
           "format": "string"
+        },
+        "infra": {
+          "type": "boolean",
+          "format": "boolean"
         }
       }
     },
     "logsLogEntry": {
       "type": "object",
       "properties": {
-        "container_id": {
+        "timestamp": {
           "type": "string",
           "format": "string"
         },
-        "message": {
-          "type": "string",
-          "format": "string"
-        },
-        "node_id": {
-          "type": "string",
-          "format": "string"
-        },
-        "role": {
+        "time_id": {
           "type": "string",
           "format": "string"
         },
@@ -120,11 +112,15 @@
           "type": "string",
           "format": "string"
         },
-        "stack_id": {
+        "message": {
           "type": "string",
           "format": "string"
         },
-        "stack_name": {
+        "container_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "node_id": {
           "type": "string",
           "format": "string"
         },
@@ -136,11 +132,15 @@
           "type": "string",
           "format": "string"
         },
-        "time_id": {
+        "stack_id": {
           "type": "string",
           "format": "string"
         },
-        "timestamp": {
+        "stack_name": {
+          "type": "string",
+          "format": "string"
+        },
+        "role": {
           "type": "string",
           "format": "string"
         }

--- a/api/rpc/oauth/oauth.swagger.json
+++ b/api/rpc/oauth/oauth.swagger.json
@@ -15,5 +15,36 @@
     "application/json"
   ],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "oauthAuthReply": {
+      "type": "object",
+      "properties": {
+        "sessionKey": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "oauthAuthRequest": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "format": "string"
+        },
+        "password": {
+          "type": "string",
+          "format": "string"
+        },
+        "otp": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    }
+  }
 }

--- a/api/rpc/project/project.swagger.json
+++ b/api/rpc/project/project.swagger.json
@@ -15,5 +15,28 @@
     "application/json"
   ],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "projectCreateReply": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "projectCreateRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    }
+  }
 }

--- a/api/rpc/service/service.swagger.json
+++ b/api/rpc/service/service.swagger.json
@@ -74,26 +74,22 @@
     "serviceNetworkAttachment": {
       "type": "object",
       "properties": {
+        "target": {
+          "type": "string",
+          "format": "string"
+        },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string",
             "format": "string"
           }
-        },
-        "target": {
-          "type": "string",
-          "format": "string"
         }
       }
     },
     "servicePublishSpec": {
       "type": "object",
       "properties": {
-        "internal_port": {
-          "type": "integer",
-          "format": "int64"
-        },
         "name": {
           "type": "string",
           "format": "string"
@@ -103,6 +99,10 @@
           "format": "string"
         },
         "publish_port": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "internal_port": {
           "type": "integer",
           "format": "int64"
         }
@@ -155,9 +155,36 @@
     "serviceServiceSpec": {
       "type": "object",
       "properties": {
-        "args": {
+        "image": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
+        "replicated": {
+          "$ref": "#/definitions/serviceReplicatedService"
+        },
+        "global": {
+          "$ref": "#/definitions/serviceGlobalService"
+        },
+        "env": {
           "type": "array",
           "items": {
+            "type": "string",
+            "format": "string"
+          }
+        },
+        "networks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/serviceNetworkAttachment"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
             "type": "string",
             "format": "string"
           }
@@ -169,23 +196,15 @@
             "format": "string"
           }
         },
-        "env": {
+        "publish_specs": {
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "string"
+            "$ref": "#/definitions/servicePublishSpec"
           }
         },
-        "global": {
-          "$ref": "#/definitions/serviceGlobalService"
-        },
-        "image": {
-          "type": "string",
-          "format": "string"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
+        "args": {
+          "type": "array",
+          "items": {
             "type": "string",
             "format": "string"
           }
@@ -197,28 +216,9 @@
             "format": "string"
           }
         },
-        "name": {
-          "type": "string",
-          "format": "string"
-        },
-        "networks": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceNetworkAttachment"
-          }
-        },
-        "publish_specs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/servicePublishSpec"
-          }
-        },
         "registry_auth": {
           "type": "string",
           "format": "string"
-        },
-        "replicated": {
-          "$ref": "#/definitions/serviceReplicatedService"
         }
       }
     }

--- a/api/rpc/stack/stack.swagger.json
+++ b/api/rpc/stack/stack.swagger.json
@@ -212,26 +212,22 @@
     "serviceNetworkAttachment": {
       "type": "object",
       "properties": {
+        "target": {
+          "type": "string",
+          "format": "string"
+        },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string",
             "format": "string"
           }
-        },
-        "target": {
-          "type": "string",
-          "format": "string"
         }
       }
     },
     "servicePublishSpec": {
       "type": "object",
       "properties": {
-        "internal_port": {
-          "type": "integer",
-          "format": "int64"
-        },
         "name": {
           "type": "string",
           "format": "string"
@@ -241,6 +237,10 @@
           "format": "string"
         },
         "publish_port": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "internal_port": {
           "type": "integer",
           "format": "int64"
         }
@@ -258,9 +258,36 @@
     "serviceServiceSpec": {
       "type": "object",
       "properties": {
-        "args": {
+        "image": {
+          "type": "string",
+          "format": "string"
+        },
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
+        "replicated": {
+          "$ref": "#/definitions/serviceReplicatedService"
+        },
+        "global": {
+          "$ref": "#/definitions/serviceGlobalService"
+        },
+        "env": {
           "type": "array",
           "items": {
+            "type": "string",
+            "format": "string"
+          }
+        },
+        "networks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/serviceNetworkAttachment"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
             "type": "string",
             "format": "string"
           }
@@ -272,23 +299,15 @@
             "format": "string"
           }
         },
-        "env": {
+        "publish_specs": {
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "string"
+            "$ref": "#/definitions/servicePublishSpec"
           }
         },
-        "global": {
-          "$ref": "#/definitions/serviceGlobalService"
-        },
-        "image": {
-          "type": "string",
-          "format": "string"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
+        "args": {
+          "type": "array",
+          "items": {
             "type": "string",
             "format": "string"
           }
@@ -300,28 +319,9 @@
             "format": "string"
           }
         },
-        "name": {
-          "type": "string",
-          "format": "string"
-        },
-        "networks": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceNetworkAttachment"
-          }
-        },
-        "publish_specs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/servicePublishSpec"
-          }
-        },
         "registry_auth": {
           "type": "string",
           "format": "string"
-        },
-        "replicated": {
-          "$ref": "#/definitions/serviceReplicatedService"
         }
       }
     },
@@ -354,12 +354,6 @@
     "stackNetworkIPAM": {
       "type": "object",
       "properties": {
-        "config": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/stackNetworkIPAMConfig"
-          }
-        },
         "driver": {
           "type": "string",
           "format": "string"
@@ -370,20 +364,19 @@
             "type": "string",
             "format": "string"
           }
+        },
+        "config": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/stackNetworkIPAMConfig"
+          }
         }
       }
     },
     "stackNetworkIPAMConfig": {
       "type": "object",
       "properties": {
-        "aux_address": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "format": "string"
-          }
-        },
-        "gateway": {
+        "subnet": {
           "type": "string",
           "format": "string"
         },
@@ -391,15 +384,26 @@
           "type": "string",
           "format": "string"
         },
-        "subnet": {
+        "gateway": {
           "type": "string",
           "format": "string"
+        },
+        "aux_address": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "format": "string"
+          }
         }
       }
     },
     "stackNetworkSpec": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
         "driver": {
           "type": "string",
           "format": "string"
@@ -408,16 +412,19 @@
           "type": "boolean",
           "format": "boolean"
         },
-        "external": {
-          "type": "string",
-          "format": "string"
+        "ipam": {
+          "$ref": "#/definitions/stackNetworkIPAM"
         },
         "internal": {
           "type": "boolean",
           "format": "boolean"
         },
-        "ipam": {
-          "$ref": "#/definitions/stackNetworkIPAM"
+        "options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "format": "string"
+          }
         },
         "labels": {
           "type": "object",
@@ -426,29 +433,22 @@
             "format": "string"
           }
         },
-        "name": {
+        "external": {
           "type": "string",
           "format": "string"
-        },
-        "options": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "format": "string"
-          }
         }
       }
     },
     "stackRemoveRequest": {
       "type": "object",
       "properties": {
-        "force": {
-          "type": "boolean",
-          "format": "boolean"
-        },
         "stack_ident": {
           "type": "string",
           "format": "string"
+        },
+        "force": {
+          "type": "boolean",
+          "format": "boolean"
         }
       },
       "title": "struct for remove request function"
@@ -456,17 +456,19 @@
     "stackStack": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "format": "string"
+        },
         "id": {
           "type": "string",
           "format": "string"
         },
-        "is_public": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "name": {
-          "type": "string",
-          "format": "string"
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/serviceServiceSpec"
+          }
         },
         "networks": {
           "type": "array",
@@ -474,11 +476,9 @@
             "$ref": "#/definitions/stackNetworkSpec"
           }
         },
-        "services": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceServiceSpec"
-          }
+        "is_public": {
+          "type": "boolean",
+          "format": "boolean"
         }
       },
       "title": "Stack struct"
@@ -495,11 +495,11 @@
     "stackStackInfo": {
       "type": "object",
       "properties": {
-        "id": {
+        "name": {
           "type": "string",
           "format": "string"
         },
-        "name": {
+        "id": {
           "type": "string",
           "format": "string"
         },

--- a/api/rpc/stats/stats.swagger.json
+++ b/api/rpc/stats/stats.swagger.json
@@ -36,21 +36,10 @@
     "statsStatsEntry": {
       "type": "object",
       "properties": {
-        "container_id": {
+        "time": {
           "type": "string",
-          "format": "string"
-        },
-        "container_image": {
-          "type": "string",
-          "format": "string"
-        },
-        "container_name": {
-          "type": "string",
-          "format": "string"
-        },
-        "cpu": {
-          "type": "number",
-          "format": "double"
+          "format": "int64",
+          "title": "Common data"
         },
         "datacenter": {
           "type": "string",
@@ -60,52 +49,23 @@
           "type": "string",
           "format": "string"
         },
-        "io_read": {
-          "type": "number",
-          "format": "double"
-        },
-        "io_write": {
-          "type": "number",
-          "format": "double"
-        },
-        "mem": {
-          "type": "number",
-          "format": "double"
-        },
-        "mem_limit": {
-          "type": "number",
-          "format": "double"
-        },
-        "mem_usage": {
-          "type": "number",
-          "format": "double"
-        },
-        "net_rx_bytes": {
-          "type": "number",
-          "format": "double"
-        },
-        "net_tx_bytes": {
-          "type": "number",
-          "format": "double"
-        },
-        "node_id": {
+        "container_id": {
           "type": "string",
           "format": "string"
         },
-        "number": {
-          "type": "number",
-          "format": "double",
-          "title": "CPU Metrics fields"
+        "container_name": {
+          "type": "string",
+          "format": "string"
+        },
+        "container_image": {
+          "type": "string",
+          "format": "string"
         },
         "service_id": {
           "type": "string",
           "format": "string"
         },
         "service_name": {
-          "type": "string",
-          "format": "string"
-        },
-        "sort_type": {
           "type": "string",
           "format": "string"
         },
@@ -117,14 +77,54 @@
           "type": "string",
           "format": "string"
         },
-        "time": {
+        "node_id": {
           "type": "string",
-          "format": "int64",
-          "title": "Common data"
+          "format": "string"
         },
         "type": {
           "type": "string",
           "format": "string"
+        },
+        "sort_type": {
+          "type": "string",
+          "format": "string"
+        },
+        "number": {
+          "type": "number",
+          "format": "double",
+          "title": "CPU Metrics fields"
+        },
+        "cpu": {
+          "type": "number",
+          "format": "double"
+        },
+        "mem": {
+          "type": "number",
+          "format": "double"
+        },
+        "mem_usage": {
+          "type": "number",
+          "format": "double"
+        },
+        "mem_limit": {
+          "type": "number",
+          "format": "double"
+        },
+        "io_read": {
+          "type": "number",
+          "format": "double"
+        },
+        "io_write": {
+          "type": "number",
+          "format": "double"
+        },
+        "net_tx_bytes": {
+          "type": "number",
+          "format": "double"
+        },
+        "net_rx_bytes": {
+          "type": "number",
+          "format": "double"
         }
       }
     },
@@ -142,19 +142,27 @@
     "statsStatsRequest": {
       "type": "object",
       "properties": {
+        "stats_cpu": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "stats_mem": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "stats_io": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "stats_net": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "stats_follow": {
+          "type": "boolean",
+          "format": "boolean"
+        },
         "discriminator": {
-          "type": "string",
-          "format": "string"
-        },
-        "filter_container_id": {
-          "type": "string",
-          "format": "string"
-        },
-        "filter_container_image": {
-          "type": "string",
-          "format": "string"
-        },
-        "filter_container_name": {
           "type": "string",
           "format": "string"
         },
@@ -166,15 +174,19 @@
           "type": "string",
           "format": "string"
         },
-        "filter_node_id": {
+        "filter_container_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "filter_container_name": {
+          "type": "string",
+          "format": "string"
+        },
+        "filter_container_image": {
           "type": "string",
           "format": "string"
         },
         "filter_service_id": {
-          "type": "string",
-          "format": "string"
-        },
-        "filter_service_ident": {
           "type": "string",
           "format": "string"
         },
@@ -190,7 +202,11 @@
           "type": "string",
           "format": "string"
         },
-        "period": {
+        "filter_node_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "filter_service_ident": {
           "type": "string",
           "format": "string"
         },
@@ -198,31 +214,15 @@
           "type": "string",
           "format": "string"
         },
-        "stats_cpu": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "stats_follow": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "stats_io": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "stats_mem": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "stats_net": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "time_group": {
+        "until": {
           "type": "string",
           "format": "string"
         },
-        "until": {
+        "period": {
+          "type": "string",
+          "format": "string"
+        },
+        "time_group": {
           "type": "string",
           "format": "string"
         }

--- a/api/rpc/version/version.swagger.json
+++ b/api/rpc/version/version.swagger.json
@@ -47,7 +47,11 @@
     "versionVersionInfo": {
       "type": "object",
       "properties": {
-        "arch": {
+        "version": {
+          "type": "string",
+          "format": "string"
+        },
+        "port": {
           "type": "string",
           "format": "string"
         },
@@ -59,11 +63,7 @@
           "type": "string",
           "format": "string"
         },
-        "port": {
-          "type": "string",
-          "format": "string"
-        },
-        "version": {
+        "arch": {
           "type": "string",
           "format": "string"
         }

--- a/cmd/adm-agent/agentgrpc/cluster-agent.swagger.json
+++ b/cmd/adm-agent/agentgrpc/cluster-agent.swagger.json
@@ -15,5 +15,132 @@
     "application/json"
   ],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "agentgrpcAgentRet": {
+      "type": "object"
+    },
+    "agentgrpcGetNodeInfoRequest": {
+      "type": "object"
+    },
+    "agentgrpcNodeInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "string"
+        },
+        "role": {
+          "type": "string",
+          "format": "string"
+        },
+        "availability": {
+          "type": "string",
+          "format": "string"
+        },
+        "hostname": {
+          "type": "string",
+          "format": "string"
+        },
+        "host_architecture": {
+          "type": "string",
+          "format": "string"
+        },
+        "host_os": {
+          "type": "string",
+          "format": "string"
+        },
+        "cpu": {
+          "type": "string",
+          "format": "int64"
+        },
+        "memory": {
+          "type": "string",
+          "format": "int64"
+        },
+        "docker_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "status": {
+          "type": "string",
+          "format": "string"
+        },
+        "address": {
+          "type": "string",
+          "format": "string"
+        },
+        "nb_containers": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_running": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_paused": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_stopped": {
+          "type": "string",
+          "format": "int64"
+        },
+        "images": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "agentgrpcPullImageRequest": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "agentgrpcPurgeNodeAnswer": {
+      "type": "object",
+      "properties": {
+        "nb_containers": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nb_volumes": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nb_images": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "agentgrpcPurgeNodeRequest": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "type": "string",
+          "format": "string"
+        },
+        "container": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "volume": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "image": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "force": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    }
+  }
 }

--- a/cmd/adm-server/servergrpc/cluster-server.swagger.json
+++ b/cmd/adm-server/servergrpc/cluster-server.swagger.json
@@ -15,5 +15,316 @@
     "application/json"
   ],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "servergrpcAgentHealthRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcAmpMonitorAnswers": {
+      "type": "object",
+      "properties": {
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/servergrpcTypedOutput"
+          }
+        }
+      }
+    },
+    "servergrpcAmpRequest": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "silence": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "verbose": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "force": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "local": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "node": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcAmpRet": {
+      "type": "object"
+    },
+    "servergrpcAmpStatusAnswer": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcClientMes": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "function": {
+          "type": "string",
+          "format": "string"
+        },
+        "output": {
+          "$ref": "#/definitions/servergrpcTypedOutput"
+        }
+      }
+    },
+    "servergrpcGetNodesInfoRequest": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "node": {
+          "type": "string",
+          "format": "string"
+        },
+        "more": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "servergrpcNodeInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "string"
+        },
+        "role": {
+          "type": "string",
+          "format": "string"
+        },
+        "availability": {
+          "type": "string",
+          "format": "string"
+        },
+        "hostname": {
+          "type": "string",
+          "format": "string"
+        },
+        "host_architecture": {
+          "type": "string",
+          "format": "string"
+        },
+        "host_os": {
+          "type": "string",
+          "format": "string"
+        },
+        "cpu": {
+          "type": "string",
+          "format": "int64"
+        },
+        "memory": {
+          "type": "string",
+          "format": "int64"
+        },
+        "docker_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "status": {
+          "type": "string",
+          "format": "string"
+        },
+        "leader": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "reachability": {
+          "type": "string",
+          "format": "string"
+        },
+        "address": {
+          "type": "string",
+          "format": "string"
+        },
+        "nb_containers": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_running": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_paused": {
+          "type": "string",
+          "format": "int64"
+        },
+        "nb_containers_stopped": {
+          "type": "string",
+          "format": "int64"
+        },
+        "images": {
+          "type": "string",
+          "format": "int64"
+        },
+        "error": {
+          "type": "string",
+          "format": "string"
+        },
+        "agentId": {
+          "type": "string",
+          "format": "string"
+        },
+        "nodeName": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcNodesInfo": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/servergrpcNodeInfo"
+          }
+        }
+      }
+    },
+    "servergrpcPurgeNodeAnswer": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "agent_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "nb_containers": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nb_volumes": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nb_images": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "error": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcPurgeNodesAnswers": {
+      "type": "object",
+      "properties": {
+        "agents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/servergrpcPurgeNodeAnswer"
+          }
+        }
+      }
+    },
+    "servergrpcPurgeNodesRequest": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "node": {
+          "type": "string",
+          "format": "string"
+        },
+        "container": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "volume": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "image": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "force": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "servergrpcRegisterRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "string"
+        },
+        "node_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "hostname": {
+          "type": "string",
+          "format": "string"
+        },
+        "address": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcServerRet": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "format": "string"
+        },
+        "error": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "servergrpcTypedOutput": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "string"
+        },
+        "output_type": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Runs protoc on individual files, adds `protoc` and `protoc-clean` rules to the new makefile. Ensures that generated files are created and correctly cleaned up.

## Verification

    $ make -f Makefile.refactor.make clean
    # verify that generated `*.pb.go`, `*.pb.gw.go`, and `*.swagger.json` files have been removed
    $ make -f Makefile.refactor.make build
    # verify that generated files are created correctly

