### PR TITLE
amp infra stack yml files for tests

### DIFF
--- a/ampadmin.yml
+++ b/ampadmin.yml
@@ -1,0 +1,47 @@
+version: "3"
+
+services:
+
+    server:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["adm-server"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+                io.amp.mapping: "amplifier:tcp:31315:31315"
+            placement:
+                constraints: [node.role == manager]
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock                  
+        networks:
+            infra:
+                aliases:
+                    - adm-server
+            public:
+
+    agent:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["adm-agent"]
+        deploy:
+            mode: global
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock                
+        networks:
+            infra: 
+                aliases:
+                    - adm-agent
+
+networks:
+    infra:
+        external:
+            name: ampcore_infra
+    public:
+        external:
+            name: ampcore_public
+
+  
+

--- a/ampcore.yml
+++ b/ampcore.yml
@@ -1,0 +1,100 @@
+version: "3"
+services:
+
+    etcd:
+        image: appcelerator/etcd:${etcdVersion:-3.1.0-rc.1}
+        command: ["--name etcd", "--listen-client-urls http://0.0.0.0:2379", "--advertise-client-urls http://etcd:2379"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        volumes:
+            - amp-etcd:/data
+        networks:
+            - infra
+
+    nats:
+        image: appcelerator/amp-nats-streaming:${natsVersion:-0.3.0}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        networks:
+            - infra 
+
+    registry:
+        image: registry:${registryVersion:-2.5.1}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+                io.amp.mapping: "registry:5000"
+        volumes:
+            - amp-etcd:/var/lib/registry               
+        networks:
+            - infra 
+            - public
+
+    amplifier:
+        image: appcelerator/amp:${ampVersion:-latest}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+                io.amp.mapping: "amplifier:tcp:8080:50101"
+            placement:
+                constraints: [node.role == manager]
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+        networks:
+            - infra 
+        depends_on:
+            - etcd            
+            - nats
+
+    gateway:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["amplifier-gateway", "--amplifier_endpoint", "amplifier:50101"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+                io.amp.mapping: "gateway:80"
+        networks:
+            - infra 
+        depends_on:
+            - amplifier           
+
+    haproxy:
+        image: appcelerator/haproxy:${haproxyVersion:-1.0.4}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        ports:
+            - "80:80"
+            - "8080:8080"
+        networks:
+            - infra 
+            - public  
+        depends_on:
+            - etcd
+            - amplifier
+            - amplifier-gateway
+
+volumes:
+    amp-etcd:
+    amp-registry:
+networks:
+    infra:
+        driver: overlay
+    public:
+        driver: overlay
+  
+

--- a/ampfunction.yml
+++ b/ampfunction.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+services:
+
+    listener:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["amp-function-listener"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+                io.amp.infra.mapping: "fn:80"
+        networks:
+            - infra
+            - public
+
+    worker:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["amp-function-worker"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock                
+        networks:
+            - infra 
+
+networks:
+    infra:
+        external:
+            name: ampcore_infra
+    public:
+        external:
+            name: ampcore_public
+
+  
+

--- a/ampinfra.var
+++ b/ampinfra.var
@@ -1,0 +1,10 @@
+ampVersion           = latest
+influxDBVersion      = 1.1.2
+kapacitorVersion     = 1.1.2
+telegrafVersion      = 1.1.1
+grafanaVersion       = 1.1.0
+elasticsearchVersion = 5.1.1
+etcdVersion          = 3.1.0-rc.1
+natsVersion          = 0.3.0
+haproxyVersion       = 1.0.4
+registryVersion      = 2.5.1

--- a/amplog.yml
+++ b/amplog.yml
@@ -1,0 +1,53 @@
+version: "3"
+
+services:
+
+    elasticsearch:
+        image: appcelerator/elasticsearch-amp:${elasticsearchVersion:-5.1.1}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        networks:
+            - infra
+
+    agent:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["amp-agent"]
+        deploy:
+            mode: global
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock         
+        networks:
+            - infra 
+        depends_on:
+            - elasticsearch            
+
+    worker:
+        image: appcelerator/amp:${ampVersion:-latest}
+        command: ["amp-log-worker"]
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock                
+        networks:
+            - infra 
+        depends_on:
+            - elasticsearch           
+
+networks:
+    infra:
+        external:
+            name: ampcore_infra
+    public:
+        external:
+            name: ampcore_public
+
+  
+

--- a/ampmonitor.yml
+++ b/ampmonitor.yml
@@ -1,0 +1,110 @@
+version: "3"
+
+services:
+
+    influxdb:
+        image: appcelerator/influxdb-amp:${influxDBVersion:-1.1.2}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        networks:
+            - infra
+
+    agent:
+        image: appcelerator/telegraf:telegraf-${telegrafVersion:-1.1.1}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        environment: [
+            "OUTPUT_INFLUXDB_ENABLED=true",
+            "INFLUXDB_URL=http://influxdb:8086",
+            "TAG_datacenter=dc1",
+            "TAG_type=core",
+            "INPUT_DOCKER_ENABLED=true",
+            "INPUT_CPU_ENABLED=true",
+            "INPUT_DISK_ENABLED=true",
+            "INPUT_DISKIO_ENABLED=true",
+            "INPUT_KERNEL_ENABLED=true",
+            "INPUT_MEM_ENABLED=true",
+            "INPUT_PROCESS_ENABLED=true",
+            "INPUT_SWAP_ENABLED=true",
+            "INPUT_SYSTEM_ENABLED=true",
+            "INPUT_NET_ENABLED=true",
+            "INPUT_HAPROXY_ENABLED=false",
+            "INFLUXDB_TIMEOUT=20",
+      ]                
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock  
+            - /var/run/utmp:/var/run/utmp                         
+        networks:
+            - infra 
+        depends_on:
+            - influxdb        
+
+    agent-haproxy:
+        image: appcelerator/telegraf:telegraf-${telegrafVersion:-1.1.1}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"
+        environment: [
+            "OUTPUT_INFLUXDB_ENABLED=true",
+            "INFLUXDB_URL=http://influxdb:8086",
+            "INPUT_DOCKER_ENABLED=false",
+            "INPUT_CPU_ENABLED=false",
+            "INPUT_NET_ENABLED=false",
+            "INPUT_DISK_ENABLED=false",
+            "INPUT_DISKIO_ENABLED=false",
+            "INPUT_KERNEL_ENABLED=false",
+            "INPUT_MEM_ENABLED=false",
+            "INPUT_PROCESS_ENABLED=false",
+            "INPUT_SWAP_ENABLED=false",
+            "INPUT_SYSTEM_ENABLED=false",
+            "INPUT_HAPROXY_ENABLED=true",
+            "INPUT_HAPROXY_SERVER=http://haproxy:8082/admin?stats",
+            "INFLUXDB_TIMEOUT=20",
+      ]                                      
+        networks:
+            - infra 
+        depends_on:
+            - influxdb                  
+
+    grafana:
+        image: appcelerator/grafana-amp:${grafanaVersion:-1.1.0}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"             
+        networks:
+            - infra 
+        depends_on:
+            - influxdb           
+
+    kapacitor:
+        image: appcelerator/kapacitor-amp:${kapacitorVersion:-1.1.2}
+        deploy:
+            mode: replicated
+            replicas: 1
+            labels:
+                io.amp.role: "amp.InfrastructureRole"             
+        networks:
+            - infra 
+        depends_on:
+            - influxdb  
+
+networks:
+    infra:
+        external:
+            name: ampcore_infra
+    public:
+        external:
+            name: ampcore_public
+
+  
+

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -39,7 +39,9 @@ func initDependencies(config Config) {
 	var wg sync.WaitGroup
 	type initFunc func(Config) error
 
-	initFuncs := []initFunc{initEtcd, initElasticsearch, initNats, initInfluxDB, initDocker}
+	//For test
+	initFuncs := []initFunc{initEtcd, initNats, initDocker}
+	//initFuncs := []initFunc{initEtcd, initElasticsearch, initNats, initInfluxDB, initDocker}
 	for _, f := range initFuncs {
 		wg.Add(1)
 		go func(f initFunc) {


### PR DESCRIPTION
# Do  not merge this PR, it's for test only:

docker compose files sample for amp infra stacks:
core, function, log, monitor (admin on going)
to start them:

- make install
- make TAG=local build-image
- export ampVersion=local
- launch amp pf monitor, to monitor the services
- docker stack deploy ampcore -c ampcore.yml
- docker stack deploy ampfunction -c ampfunction.yml
- docker stack deploy amplog -c amplog.yml
- docker stack deploy ampmonitor -c ampmonitor.yml
- use docker stack rm ampxxx to rmeove a stack

ampcore should be started first and stopped last (it's not controlled right now)

amplifier image should be rebuild to suppress dependencies on elasticsearch and influxdb, so log and monitoring don't work anymore. The connection to these two database will be dynamic in the future.

ampcore.var will contain all the version variables and will be used in future version.

