### PR TITLE
fix build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 /amp-function-listener
 /amp-function-worker
 /amp-cluster
+/adm-agent
+/adm-server
+/ampadm
 /dist
 /*.exe
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ build-adm-server: proto
 build-adm-agent: proto
 	@hack/build $(CLUSTERAGENT)
 build-ampadm: proto
-	@hack/build $(CLUSTERADM)
+	@hack/build $(AMPADM)
 build-fn-listener: proto
 	@hack/build $(FUNCTION_LISTENER)
 build-fn-worker: proto

--- a/hack/proto.go
+++ b/hack/proto.go
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 
 	// run protoc on command line args if provided
-	if len(os.Args) > 0 {
+	if flag.NArg() > 0 {
 		for _, p := range os.Args[1:] {
 			// filter out options
 			if !strings.HasPrefix(p, "-") {


### PR DESCRIPTION
fix #718 

- better management of options in protoc compilation
- fix ampadm target in Makefile
- adapt gitignore following the renaming of ampadm

how to test:
```make``` shouldn't produce any error