### PR TITLE
Run make in container - doesn't need sudo anymore

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -95,10 +95,16 @@ CLIBINARY=$(CLI).alpine
 CLIIMG := appcelerator/amp
 CLITARGET := $(CMDDIR)/$(CLI)/$(CLIBINARY)
 CLISRC := $(shell find ./cmd/amp -type f -name '*.go')
+# to run the docker command with sudo, set the with_sudo variable
+ifdef with_sudo
+DOCKER_CMD := sudo docker
+else
+DOCKER_CMD := docker
+endif
 
 $(CLITARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(CLISRC)
 	@GOPATH=/go go build $(LDFLAGS) -o $(CLITARGET) $(REPO)/$(CMDDIR)/$(CLI)
-	@docker build -t $(CLIIMG) $(CMDDIR)/$(CLI)
+	@$(DOCKER_CMD) build -t $(CLIIMG) $(CMDDIR)/$(CLI)
 
 build-cli: $(CLITARGET)
 

--- a/hack/amptools
+++ b/hack/amptools
@@ -11,7 +11,7 @@ export BUILD="${BUILD:-$(git rev-parse HEAD | cut -c1-8)}"
 export OWNER="${OWNER:-appcelerator}"
 export REPO="${REPO:-github.com/$OWNER/amp}"
 
-TOOLS_VERSION=1.0.0
+TOOLS_VERSION=1.1.0
 TOOLS=appcelerator/amptools:$TOOLS_VERSION
 LOCALTOOLS=amptools:$TOOLS_VERSION
 

--- a/hack/amptools
+++ b/hack/amptools
@@ -32,6 +32,8 @@ EOF
 
 docker image list $LOCALTOOLS | grep -q "amptools" || map_user
 
+SUDOOPTS=""
+echo "$@" | grep -qv make || SUDOOPTS="-e with_sudo=1"
 docker run -it --rm --name amptools \
     -u $UG \
     -v /var/run/docker.sock:/var/run/docker.sock \
@@ -42,6 +44,7 @@ docker run -it --rm --name amptools \
     -e BUILD=$BUILD \
     -e OWNER=$OWNER \
     -e REPO=$REPO \
+    $SUDOOPTS \
     $LOCALTOOLS "$@"
 
 cleanup() {

--- a/images/amptools/Dockerfile
+++ b/images/amptools/Dockerfile
@@ -1,4 +1,4 @@
-FROM appcelerator/gotools:latest
+FROM appcelerator/gotools:1.4.0
 RUN apk --no-cache add sudo iproute2
 
 # Add Docker client from:


### PR DESCRIPTION
Follows #726 

- when running a build task, there's no need for an explicit sudo, the Makefile can add it if a docker command is executed (the only place where sudo is needed)
- tagged version of appcelerator/gotools and appcelerator/amptools

how to test:
- hack/amptools make -f Makefile.refactor.make build-cli # no more sudo, should build the cli but not the vendors (they should be already up to date)
- rm ./api/rpc/service/service.pb.go
- hack/amptools make -f Makefile.refactor.make proto # should compile the missing proto file
- rm -rf vendor
- hack/amptools make -f Makefile.refactor.make build-cli # should install vendors and build the CLI
- docker run -it --rm appcelerator/amp info # should display version and build number (31f985d1)