### PR TITLE
Refactor make

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -89,8 +89,8 @@ cleanall: clean cleanall-glide
 # =============================================================================
 # BUILD
 # =============================================================================
-#
-DOCKER_CMD := sudo docker
+# When running in the amptools container, set DOCKER_CMD="sudo docker"
+DOCKER_CMD ?= "docker"
 
 build: $(PROTOTARGETS)
 	@echo To be implemented...
@@ -107,7 +107,8 @@ CLISRC := $(shell find ./cmd/amp -type f -name '*.go')
 # to run the docker command with sudo, set the with_sudo variable
 
 $(CLITARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(CLISRC)
-	@GOPATH=/go go build $(LDFLAGS) -o $(CLITARGET) $(REPO)/$(CMDDIR)/$(CLI)
+	@go build $(LDFLAGS) -o $(CLITARGET) $(REPO)/$(CMDDIR)/$(CLI)
+	@ echo $(DOCKER_CMD) build -t $(CLIIMG) $(CMDDIR)/$(CLI)
 	@$(DOCKER_CMD) build -t $(CLIIMG) $(CMDDIR)/$(CLI)
 
 build-cli: $(CLITARGET)

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -108,7 +108,6 @@ CLISRC := $(shell find ./cmd/amp -type f -name '*.go')
 
 $(CLITARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(CLISRC)
 	@go build $(LDFLAGS) -o $(CLITARGET) $(REPO)/$(CMDDIR)/$(CLI)
-	@ echo $(DOCKER_CMD) build -t $(CLIIMG) $(CMDDIR)/$(CLI)
 	@$(DOCKER_CMD) build -t $(CLIIMG) $(CMDDIR)/$(CLI)
 
 build-cli: $(CLITARGET)
@@ -117,12 +116,4 @@ build-cli: $(CLITARGET)
 clean-cli:
 	@rm -f $(CLITARGET)
 
-# =============================================================================
-# BUILD AMPLIFIER (`amplifier`)
-# Saves binary to `cmd/amplifier/amplifier.alpine`,
-# then builds `appcelerator/amplifier` image
-# =============================================================================
-
-dump:
-	@echo $(DOCKER_CMD)
 

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -87,6 +87,15 @@ clean: clean-glide clean-protoc clean-cli
 cleanall: clean cleanall-glide
 
 # =============================================================================
+# BUILD
+# =============================================================================
+#
+DOCKER_CMD := sudo docker
+
+build: $(PROTOTARGETS)
+	@echo To be implemented...
+
+# =============================================================================
 # BUILD CLI (`amp`)
 # Saves binary to `cmd/amp/amp.alpine`, then builds `appcelerator/amp` image
 # =============================================================================
@@ -96,11 +105,6 @@ CLIIMG := appcelerator/amp
 CLITARGET := $(CMDDIR)/$(CLI)/$(CLIBINARY)
 CLISRC := $(shell find ./cmd/amp -type f -name '*.go')
 # to run the docker command with sudo, set the with_sudo variable
-ifdef with_sudo
-DOCKER_CMD := sudo docker
-else
-DOCKER_CMD := docker
-endif
 
 $(CLITARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(CLISRC)
 	@GOPATH=/go go build $(LDFLAGS) -o $(CLITARGET) $(REPO)/$(CMDDIR)/$(CLI)
@@ -113,10 +117,11 @@ clean-cli:
 	@rm -f $(CLITARGET)
 
 # =============================================================================
-# BUILD
+# BUILD AMPLIFIER (`amplifier`)
+# Saves binary to `cmd/amplifier/amplifier.alpine`,
+# then builds `appcelerator/amplifier` image
 # =============================================================================
-build: $(PROTOTARGETS)
-	@echo To be implemented...
 
 dump:
-	@echo $(CLISRC)
+	@echo $(DOCKER_CMD)
+

--- a/hack/amptools
+++ b/hack/amptools
@@ -4,48 +4,61 @@ echo $@
 
 set -euo pipefail
 
-# expected from makefile
-export UG="${UG:-$(id -u):$(id -g)}"
+# defaults
+export UG="0:0"
 export VERSION="${VERSION:-0.0.0}"
 export BUILD="${BUILD:-$(git rev-parse HEAD | cut -c1-8)}"
 export OWNER="${OWNER:-appcelerator}"
 export REPO="${REPO:-github.com/$OWNER/amp}"
+export DOCKER_CMD="${DOCKER_CMD:-sudo docker}"
 
 TOOLS_VERSION=1.1.0
 TOOLS=appcelerator/amptools:$TOOLS_VERSION
 LOCALTOOLS=amptools:$TOOLS_VERSION
+IMAGE=$TOOLS
 
-tmpdir=$(mktemp -d)
+TMP=$(mktemp -d)
 
 # Map the host user id to the container user ("sudoer") so that the
-# user has sudo permission in the container. This allows sudo access
-# to Docker while able to save files in mounted volumes on the host
-# with the correct owner (not root).
+# user has sudo permission in the container. This allows sudo root
+# access to Docker while also ensuring files can be saved in mounted
+# volumes with the correct owner on the host when not root.
 # Based on code thanks to @ndegory after brainstorming session about using sudo.
 map_user() {
-cat > $tmpdir/Dockerfile << EOF
+UG="$(id -u):$(id -g)}"
+cat > $TMP/Dockerfile << EOF
 FROM $TOOLS
 RUN sed -i "s/sudoer:x:[0-9]*:[0-9]*/sudoer:x:$UG/" /etc/passwd
 EOF
-    docker build -t $LOCALTOOLS $tmpdir
+    docker build -t $LOCALTOOLS $TMP
 }
 
-docker image list $LOCALTOOLS | grep -q "amptools" || map_user
+# Special case handling for linux (not an issue with Docker for Mac / Docker for Windows)
+case "$OSTYPE" in
+linux*)
+    # build the local image "amptools" for the current user, if not available
+    # TODO: need an option to force build
+    docker image list $LOCALTOOLS | grep -q "amptools" || map_user
+    IMAGE=$LOCALTOOLS
+    ;;
+esac
 
 docker run -it --rm --name amptools \
-    -u $UG \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $HOME/.ssh:/root/.ssh:ro \
-    -v $PWD:/go/src/$REPO \
-    -w /go/src/$REPO \
-    -e VERSION=$VERSION \
-    -e BUILD=$BUILD \
-    -e OWNER=$OWNER \
-    -e REPO=$REPO \
-    $LOCALTOOLS "$@"
+    -u "$UG" \
+    -v "/var/run/docker.sock:/var/run/docker.sock" \
+    -v "$HOME/.ssh:/root/.ssh:ro" \
+    -v "$PWD:/go/src/$REPO" \
+    -w "/go/src/$REPO" \
+    -e "VERSION=$VERSION" \
+    -e "BUILD=$BUILD" \
+    -e "OWNER=$OWNER" \
+    -e "REPO=$REPO" \
+    -e "DOCKER_CMD=$DOCKER_CMD" \
+    -e "GOPATH=/go" \
+    $IMAGE "$@"
 
 cleanup() {
-  rm -rf $tmpdir
+    rm -rf $TMP
 }
 
 trap cleanup EXIT

--- a/hack/amptools
+++ b/hack/amptools
@@ -32,8 +32,6 @@ EOF
 
 docker image list $LOCALTOOLS | grep -q "amptools" || map_user
 
-SUDOOPTS=""
-echo "$@" | grep -qv make || SUDOOPTS="-e with_sudo=1"
 docker run -it --rm --name amptools \
     -u $UG \
     -v /var/run/docker.sock:/var/run/docker.sock \
@@ -44,7 +42,6 @@ docker run -it --rm --name amptools \
     -e BUILD=$BUILD \
     -e OWNER=$OWNER \
     -e REPO=$REPO \
-    $SUDOOPTS \
     $LOCALTOOLS "$@"
 
 cleanup() {


### PR DESCRIPTION
These updates allow make to succeed whether executed in a container or not. It ensures that GOPATH is set properly for a container (regardless of shell environment) without interfering with the host $GOPATH. It ensures docker is executed with sudo root in the container, but defaults to not sudo when make is invoked directly (but either way allows this to be overridden by setting `DOCKER_CMD` env var). It does not update uid/gid unless actually running under linux (since Docker for Mac and Docker for Windows will ensure that files created in mounted volumes will be owned by the correct user on the host).

## Verification

Verify on Docker for Mac and Linux only for right now. Docker for Windows errors should be noted in a new issue, but shouldn't prevent this PR from being merged right now.

### RUNNING MAKE DIRECTLY
```
$ touch cmd/amp/main.go​​​
$ time make -f Makefile.refactor.make build-cli
...
Successfully built 77dad4e09b33
real    0m18.492s
user    0m41.161s
sys     0m6.373s
```

### RUNNING MAKE IN CONTAINER
```
$ touch cmd/amp/main.go
$ time hack/amptools make -f Makefile.refactor.make build-cli
make -f Makefile.refactor.make build-cli
sudo docker build -t appcelerator/amp cmd/amp
...
Successfully built 948c827b45e8
real    0m38.185s
user    0m0.018s
sys     0m0.020s
```
