### PR TITLE
Refactor make build-server, all

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -116,3 +116,4 @@ build-cli: $(CLITARGET)
 clean-cli:
 	@rm -f $(CLITARGET)
 
+

--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -116,4 +116,3 @@ build-cli: $(CLITARGET)
 clean-cli:
 	@rm -f $(CLITARGET)
 
-

--- a/cmd/amplifier/Dockerfile
+++ b/cmd/amplifier/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY amplifier.alpine /usr/local/bin/amp
+ENTRYPOINT [ "amplifier" ]

--- a/cmd/amplifier/Dockerfile
+++ b/cmd/amplifier/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine
-COPY amplifier.alpine /usr/local/bin/amp
+COPY amplifier.alpine /usr/local/bin/amplifier
 ENTRYPOINT [ "amplifier" ]


### PR DESCRIPTION
Adds rule for `build-server`, supports `make build` and just `make`. Updates `clean* rules`.

Now generates separate images for `amp` and `amplifier`. The intention is to lay the groundwork here to have `amp` (cli) run in a container attached to the same overlay network that `amplifier` is running in the platform swarm.

## Verification

Touch various *.proto and *.go files in related source directories (api, cmd, config, test), touch `glide.yaml` or remove `vendor`, etc., and run `make -f Makefile.refactor.make` for default `all` rule, or explicitly test `build` or various other rules in the Makefile.

Ex:

    $ hack/amptools make -f Makefile.refactor.make clean
    $ hack/amptools make -f Makefile.refactor.make


