### PR TITLE
binary builds robustness

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -108,7 +108,7 @@ AMPSRC := $(shell find $(AMPDIRS) -type f -name '*.go')
 
 $(AMPTARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(AMPSRC)
 	@go build $(LDFLAGS) -o $(AMPTARGET) $(REPO)/$(CMDDIR)/$(AMP)
-	@$(DOCKER_CMD) build -t $(AMPIMG) $(CMDDIR)/$(AMP)
+	@$(DOCKER_CMD) build -t $(AMPIMG) $(CMDDIR)/$(AMP) || (rm -f $(AMPTARGET); exit 1)
 
 build-cli: $(AMPTARGET)
 
@@ -116,7 +116,7 @@ rebuild-cli: clean-cli build-cli
 
 .PHONY: clean-cli
 clean-cli:
-	@rm -f $(CLITARGET)
+	@rm -f $(AMPTARGET)
 
 # =============================================================================
 # BUILD SERVER (`amplifier`)
@@ -133,7 +133,7 @@ AMPLSRC := $(shell find $(AMPLDIRS) -type f -name '*.go')
 
 $(AMPLTARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(AMPLSRC)
 	@go build $(LDFLAGS) -o $(AMPLTARGET) $(REPO)/$(CMDDIR)/$(AMPL)
-	@$(DOCKER_CMD) build -t $(AMPLIMG) $(CMDDIR)/$(AMPL)
+	@$(DOCKER_CMD) build -t $(AMPLIMG) $(CMDDIR)/$(AMPL) || (rm -f $(AMPLTARGET); exit 1)
 
 build-server: $(AMPLTARGET)
 


### PR DESCRIPTION
If something goes wrong at the last step of a binary target build (step = Docker image build), a subsequent make _target_ will not run the build again, leaving the related image inexistent (or worse, outdated).

This PR adds:
- cleanup in case the image build fails
- fix on the clean-cli target

## how to test

### CLI

```
hack/amptools make -f Makefile.refactor.make build-cli
ls cmd/amp/amp.alpine # file exists
hack/amptools make -f Makefile.refactor.make clean-cli
ls cmd/amp/amp.alpine # file does NOT exist
DOCKER_CMD=false hack/amptools make -f Makefile.refactor.make build-cli
ls cmd/amp/amp.alpine # file does NOT exist
hack/amptools make -f Makefile.refactor.make build-cli
file cmd/amp/amp.alpine # file exists (ELF 64-bit LSB executable)
```

### Server

```
hack/amptools make -f Makefile.refactor.make build-server
ls cmd/amplifier/amplifier.alpine # file exists
hack/amptools make -f Makefile.refactor.make clean-server
ls cmd/amplifier/amplifier.alpine # file does NOT exist
DOCKER_CMD=false hack/amptools make -f Makefile.refactor.make build-server
ls cmd/amplifier/amplifier.alpine # file does NOT exist
hack/amptools make -f Makefile.refactor.make build-server
file cmd/amplifier/amplifier.alpine # file exists (ELF 64-bit LSB executable)
```
