### PR TITLE
ampmake: don't panic when underlying process fails

### DIFF
--- a/cmd/ampmake/main.go
+++ b/cmd/ampmake/main.go
@@ -84,6 +84,10 @@ func main() {
 
 	err = proc.Wait()
 	if err != nil {
-		panic(err)
+		// Just pass along the information that the process exited with a failure;
+		// whatever error information it displayed is what the user will see.
+		// TODO: return the process exit code
+		os.Exit(1)
+
 	}
 }


### PR DESCRIPTION
Having a make rule fail is normal, so panicking isn't helpful. Example:

```
$ ampmake build-server
make -f Makefile.refactor.make build-server
# github.com/appcelerator/amp/cmd/amplifier/server
cmd/amplifier/server/server.go:132: undefined: amp in amp.NatsClusterID
Makefile.refactor.make:134: recipe for target 'cmd/amplifier/amplifier.alpine' failed
make: *** [cmd/amplifier/amplifier.alpine] Error 2
panic: exit status 2

goroutine 1 [running]:
panic(0xc9ce0, 0xc42000ac20)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
main.main()
        /Users/tony/go/src/github.com/appcelerator/amp/cmd/ampmake/main.go:87 +0x451
```

With this update, `ampmake` simply returns an error exit code; whatever error message that is displayed by make is enough for the user. Example:

```
$ ampmake build-server
make -f Makefile.refactor.make build-server
# github.com/appcelerator/amp/cmd/amplifier/server
cmd/amplifier/server/server.go:132: undefined: amp in amp.NatsClusterID
Makefile.refactor.make:134: recipe for target 'cmd/amplifier/amplifier.alpine' failed
make: *** [cmd/amplifier/amplifier.alpine] Error 2
```
