### PR TITLE
Amplifier updates

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -99,7 +99,8 @@ build: install-deps protoc build-server build-cli
 # =============================================================================
 AMP := amp
 AMPBINARY=$(AMP).alpine
-AMPIMG := appcelerator/amp
+AMPTAG := local
+AMPIMG := appcelerator/$(AMP):$(AMPTAG)
 AMPTARGET := $(CMDDIR)/$(AMP)/$(AMPBINARY)
 AMPDIRS := cmd/$(AMP) tests
 AMPSRC := $(shell find $(AMPDIRS) -type f -name '*.go')
@@ -124,7 +125,8 @@ clean-cli:
 # =============================================================================
 AMPL := amplifier
 AMPLBINARY=$(AMPL).alpine
-AMPLIMG := appcelerator/amplifier
+AMPLTAG := local
+AMPLIMG := appcelerator/$(AMPL):$(AMPLTAG)
 AMPLTARGET := $(CMDDIR)/$(AMPL)/$(AMPLBINARY)
 AMPLDIRS := cmd/$(AMPL) api data tests
 AMPLSRC := $(shell find $(AMPLDIRS) -type f -name '*.go')

--- a/api/runtime/runtime.go
+++ b/api/runtime/runtime.go
@@ -8,8 +8,12 @@ import (
 	"github.com/docker/docker/client"
 )
 
+// Runtime access to initialized clients for various services
 var (
-	// Store is the interface used to access the key/value storage backend
+	// Docker is the Docker client
+	Docker *client.Client
+
+	// Store is the key/value storage client
 	Store storage.Interface
 
 	// Elasticsearch is the elasticsearch client
@@ -18,9 +22,6 @@ var (
 	// Influx is the influxDB client
 	Influx influx.Influx
 
-	// Docker is the Docker client
-	Docker *client.Client
-
-	//NatsStreaming is the nats streaming client
+	// NatsStreaming is the nats streaming client
 	NatsStreaming ns.NatsStreaming
 )

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
-	"github.com/appcelerator/amp/api/server"
+	"github.com/appcelerator/amp/cmd/amplifier/server"
 	"github.com/appcelerator/amp/pkg/config"
 	flag "github.com/spf13/pflag"
-	"os"
 )
 
 const (

--- a/cmd/amplifier/server/config.go
+++ b/cmd/amplifier/server/config.go
@@ -8,13 +8,13 @@ import (
 type Config struct {
 	Version          string
 	Port             string
-	EtcdEndpoints    []string
-	ElasticsearchURL string
 	ClientID         string
 	ClientSecret     string
-	InfluxURL        string
 	DockerURL        string
 	DockerVersion    string
+	EtcdEndpoints    []string
+	ElasticsearchURL string
+	InfluxURL        string
 	NatsURL          string
 }
 

--- a/stacks/amplifier.stack.yml
+++ b/stacks/amplifier.stack.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: swarmnet
+
+services:
+  amplifier:
+    image: appcelerator/amplifier:local
+    networks:
+    - default
+    ports:
+    - "50101:50101"
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints:
+        - node.role == manager
+

--- a/stacks/amplifier.stack.yml
+++ b/stacks/amplifier.stack.yml
@@ -3,7 +3,7 @@ version: "3"
 networks:
   default:
     external:
-      name: swarmnet
+      name: ampnet
 
 services:
   amplifier:

--- a/stacks/amplifier.stack.yml
+++ b/stacks/amplifier.stack.yml
@@ -6,6 +6,19 @@ networks:
       name: ampnet
 
 services:
+
+  visualizer:
+    image: manomarks/visualizer
+    networks:
+    - default
+    ports:
+    - "8080:8080/tcp"
+    volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+
   amplifier:
     image: appcelerator/amplifier:local
     networks:
@@ -13,10 +26,11 @@ services:
     ports:
     - "50101:50101"
     deploy:
-      replicas: 1
+      replicas: 3
       restart_policy:
         condition: on-failure
       placement:
         constraints:
         - node.role == manager
+
 

--- a/stacks/local-bootstrap
+++ b/stacks/local-bootstrap
@@ -53,7 +53,7 @@ init_swarm() {
 
 node_exists() {
   name=$1
-  docker ps -q --filter="name=${name}" | grep "${name}"
+  docker ps -aq --filter="name=${name}" | grep "${name}"
 }
 
 remove_node() {
@@ -61,7 +61,7 @@ remove_node() {
   # remove existing instances
   # TODO: don't just filter on name, also filter on label
   #docker node rm -f $(docker node ls --filter="name=$name" -q) &> /dev/null && true
-  (docker rm -f $(docker ps -q --filter="name=$name")) &> /dev/null || true
+  (docker rm -f $(docker ps -aq --filter="name=$name")) &> /dev/null || true
 }
 
 start_node() {
@@ -88,6 +88,7 @@ create_managers() {
 # SWARMIP=$(docker info --format "{{.Swarm.NodeAddr}}")
   echo "swarm manager ip (m1): ${SWARMIP}"
   host="127.0.0.1:${port}"
+  sleep 5
   (docker --host="${host}" swarm init --advertise-addr="${SWARMIP}:2377") &> /dev/null
   MTOKEN=$(docker --host="${host}" swarm join-token -q manager)
   WTOKEN=$(docker --host="${host}" swarm join-token -q worker)

--- a/stacks/local-bootstrap
+++ b/stacks/local-bootstrap
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -e
+trap 'onexit $LINENO' EXIT
+
+# These will be passed on as `docker run` options when creating the swarm manager
+# (mainly for exposing extra ports)
+# Use normal `docker run [OPTIONS]` syntax. Ex: `local-bootstrap -p=3000:3000 -p8000:8000`
+SWARMOPTS="$@"
+
+MANAGERS=${MANAGERS:-3}
+WORKERS=${WORKERS:-2}
+
+REGISTRY=registry_mirror
+SWARMNET=swarmnet
+SWARMIP=""
+MTOKEN=""
+WTOKEN=""
+
+main() {
+  init_overlay_network
+  init_registry_mirror
+  init_swarm
+}
+
+init_overlay_network() {
+  (docker network ls | grep ${SWARMNET} &> /dev/null) || ( \
+    echo "create overlay network: ${SWARMNET}" && \
+    docker network create -d overlay --attachable ${SWARMNET} )
+}
+
+init_registry_mirror() {
+  (docker service ls | grep ${REGISTRY} &> /dev/null ) || ( \
+    echo start registry service: ${REGISTRY} && \
+    docker service create \
+      --name=${REGISTRY} \
+      --network=${SWARMNET} \
+      -p=5000:5000 \
+      --restart-condition=any \
+      -e=REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+      registry
+    sleep 5 )
+}
+
+init_swarm() {
+#  docker node inspect self &> /dev/null || docker swarm init &> /dev/null
+#  SWARMIP=$(docker info --format "{{.Swarm.NodeAddr}}")
+#  MTOKEN=$(docker swarm join-token -q manager)
+#  WTOKEN=$(docker swarm join-token -q worker)
+  create_managers
+  create_workers
+}
+
+node_exists() {
+  name=$1
+  docker ps -q --filter="name=${name}" | grep "${name}"
+}
+
+remove_node() {
+  name=$1
+  # remove existing instances
+  # TODO: don't just filter on name, also filter on label
+  #docker node rm -f $(docker node ls --filter="name=$name" -q) &> /dev/null && true
+  (docker rm -f $(docker ps -q --filter="name=$name")) &> /dev/null || true
+}
+
+start_node() {
+  node=$1
+  port=$2
+  opts="${@:3}"
+  remove_node $name
+  docker run --privileged --detach --name=$name --hostname=$name \
+    --network=${SWARMNET} \
+    -p="${port}":2375 \
+    --label="ampswarm" \
+    ${opts} \
+    subfuzion/dind --registry-mirror=http://${REGISTRY}:5000
+}
+
+create_managers() {
+  name=m1
+  port="62001"
+  echo starting manager: ${name} on port ${port}
+  start_node "${name}" "${port}" "-p=3000:3000" "${SWARMOPTS}"
+  SWARMIP=$(docker inspect "${name}" --format '{{ .NetworkSettings.Networks.swarmnet.IPAMConfig.IPv4Address }}')
+# SWARMIP=$(docker info --format "{{.Swarm.NodeAddr}}")
+  echo "swarm manager ip (m1): ${SWARMIP}"
+  host="127.0.0.1:${port}"
+  (docker --host="${host}" swarm init --advertise-addr="${SWARMIP}:2377") &> /dev/null
+  MTOKEN=$(docker --host="${host}" swarm join-token -q manager)
+  WTOKEN=$(docker --host="${host}" swarm join-token -q worker)
+
+  count=$((MANAGERS-1))
+  for m in $(seq ${count}); do
+    i=$((m+1))
+    name="m$i"
+    port="6200$i"
+    echo "starting manager $i: ${name} on port ${port}"
+    start_node $name $port
+    echo "joining manager ${name} to swarm at: m1:2377 (127.0.0.1:62001 on host)"
+    docker --host="127.0.0.1:${port}" swarm join --token "${MTOKEN}" m1:2377
+  done
+}
+
+create_workers() {
+  for w in $(seq "${WORKERS}"); do
+    name="w$w"
+    port="6300$w"
+    echo "starting worker $w: ${name} on port ${port}"
+    start_node $name $port
+    echo "joining worker ${name} to swarm at: m1:2377 (127.0.0.1:62001 on host)"
+    docker --host="127.0.0.1:${port}" swarm join --token "${WTOKEN}" m1:2377
+  done
+}
+
+onexit() {
+  if [[ "$?" -eq 0 ]]; then
+    echo "---------------------------------------------------------------------------"
+    echo "swarm running at 127.0.0.1:62001"
+    echo "---------------------------------------------------------------------------"
+    docker --host="127.0.0.1:62001" node ls
+  else
+    echo "bootstrap failed, line: $1"
+  fi
+}
+
+main
+

--- a/stacks/local-bootstrap
+++ b/stacks/local-bootstrap
@@ -11,15 +11,16 @@ SWARMOPTS="$@"
 MANAGERS=${MANAGERS:-3}
 WORKERS=${WORKERS:-2}
 
-REGISTRY=registry_mirror
+REGISTRY=registry
 SWARMNET=swarmnet
 SWARMIP=""
 MTOKEN=""
 WTOKEN=""
+AMPNET=ampnet
 
 main() {
   init_overlay_network
-  init_registry_mirror
+  init_registry
   init_swarm
 }
 
@@ -29,7 +30,7 @@ init_overlay_network() {
     docker network create -d overlay --attachable ${SWARMNET} )
 }
 
-init_registry_mirror() {
+init_registry() {
   (docker service ls | grep ${REGISTRY} &> /dev/null ) || ( \
     echo start registry service: ${REGISTRY} && \
     docker service create \
@@ -37,8 +38,7 @@ init_registry_mirror() {
       --network=${SWARMNET} \
       -p=5000:5000 \
       --restart-condition=any \
-      -e=REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
-      registry
+      registry:2
     sleep 5 )
 }
 
@@ -75,13 +75,15 @@ start_node() {
     --label="ampswarm" \
     ${opts} \
     subfuzion/dind --registry-mirror=http://${REGISTRY}:5000
+#    subfuzion/dind
 }
 
 create_managers() {
   name=m1
   port="62001"
   echo starting manager: ${name} on port ${port}
-  start_node "${name}" "${port}" "-p=3000:3000" "${SWARMOPTS}"
+  # publish common default ports plus whatever got passed to this script as options
+  start_node "${name}" "${port}" "-p=3000:3000" "-p=80:80" "-p=8080:8080" "-p=50101:50101" "${SWARMOPTS}"
   SWARMIP=$(docker inspect "${name}" --format '{{ .NetworkSettings.Networks.swarmnet.IPAMConfig.IPv4Address }}')
 # SWARMIP=$(docker info --format "{{.Swarm.NodeAddr}}")
   echo "swarm manager ip (m1): ${SWARMIP}"
@@ -89,6 +91,7 @@ create_managers() {
   (docker --host="${host}" swarm init --advertise-addr="${SWARMIP}:2377") &> /dev/null
   MTOKEN=$(docker --host="${host}" swarm join-token -q manager)
   WTOKEN=$(docker --host="${host}" swarm join-token -q worker)
+  docker --host="${host}" network create -d overlay --attachable ${AMPNET}
 
   count=$((MANAGERS-1))
   for m in $(seq ${count}); do


### PR DESCRIPTION
The PR leverages the new containerized toolchain:

```sh
$ ampmake build
```

To bootstrap the swarm, use the following command:

```sh
$ stacks/local-bootstrap
. . .
---------------------------------------------------------------------------
swarm running at 127.0.0.1:62001
---------------------------------------------------------------------------
ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
gs2ehb4w3x0cd759dpwkt5cno    m2        Ready   Active        Reachable
k14m20l44gh0wfau4wy6tn491    w2        Ready   Active        
od7fas5v6utjef9oc59dtqpig    w1        Ready   Active        
qr9vvw494gfoxv9mv2mqztej6    m3        Ready   Active        Reachable
ymvb8h5rn2qct8l1pqg6xy1r9 *  m1        Ready   Active        Leader
```

You can provide additional options for creating the swarm manager, primarily for publishing any extra ports besides the default ones on the swarm that gets created (`80`, `8080`, `3000`, `50101`).

You can deploy the `amplifier` and `amp` images to the registry for the cluster:

```sh
# amplifier
$ docker tag appcelerator/amplifier:local 127.0.0.1:5000/appcelerator/amplifier:local
$ docker push 127.0.0.1:5000/appcelerator/amplifier:local

# amp cli
$ docker tag appcelerator/amp:local 127.0.0.1:5000/appcelerator/amp:local
$ docker push 127.0.0.1:5000/appcelerator/amp:local
```

You then deploy `amplifier` to the swarm with the following command:

    $ docker --host=127.0.0.1:62001 deploy -c stacks/amplifier.stack.yml amp

To connect the `amp` cli to to `amplifier`, enter the following with or without cli commands (note: only the `version` command works right now):

You can then start the `amp` cli inside the swarm:

    $  docker --host=127.0.0.1:62001 run -it --rm --name amp --network=ampnet appcelerator/amp:local --server=amplifier:50101

For example, the following command causes the cli to query `amplifier` for version information from the server:

    $  docker --host=127.0.0.1:62001 run -it --rm --name amp --network=ampnet appcelerator/amp:local --server=amplifier:50101 version

![image](https://cloud.githubusercontent.com/assets/159738/22911454/9ad36150-f214-11e6-8c6a-ebecfd155585.png)

And you can connect to the swarm visualizer at `localhost:8080`:

![image](https://cloud.githubusercontent.com/assets/159738/22911467/b3a33b56-f214-11e6-8b51-14c8fde3fbee.png)
