### PR TITLE
CLI to server connection test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,15 @@ install:
   - sudo apt-get update
   - sudo apt-get install docker-engine
   - docker swarm init --advertise-addr 127.0.0.1
+  - docker network create -d overlay --attachable swarmnet
+  - make fmt check
   - hack/amptools make -f Makefile.refactor.make cleanall
   - hack/amptools make -f Makefile.refactor.make build
-  - make fmt check install
-  - make TAG=local build-image
-  - amp platform pull --local
-  - amp platform start --local
 
 script:
-  - make test
+  - tests/refactored-tests.sh
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
-      docker tag appcelerator/amp:local appcelerator/amp:latest &&
-      timeout 30 docker push appcelerator/amp:latest;
+      echo "Docker image publication has been disabled for now";
     fi

--- a/tests/refactored-tests.sh
+++ b/tests/refactored-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+NETWORK=swarmnet
+TAG=local
+SERVER_PORT=50101
+
+echo "Starting the amplifier service... "
+docker service create --name amplifier --network $NETWORK appcelerator/amplifier:$TAG
+if [ $? -ne 0 ]; then
+  echo "Failed to start amplifier service"
+  exit 1
+fi
+echo "Waiting for the amplifier service to be up... "
+maxretries=10
+retries=0
+while [ $retries -le $maxretries ]; do
+  docker service ps  amplifier | awk '{print $6}' | grep -qw Running && break
+  echo -n "."
+  sleep 1
+  ((retries+1))
+done
+if [ $retries -eq $maxretries ]; then
+  echo "amplifier failed to start in a sensible time"
+  docker service rm amplifier
+  exit 1
+fi
+echo
+echo "Connecting to amplifier with the CLI... "
+# test the CLI and the connection to the server
+# if connection fails, the container will return a non zero code
+docker run --rm --name cli --network $NETWORK appcelerator/amp:$TAG --server amplifier:$SERVER_PORT version
+if [ $? -ne 0 ]; then
+  echo "Failed to connect"
+  docker service rm amplifier
+  exit 1
+fi
+docker service rm amplifier
+echo "Passed"


### PR DESCRIPTION
follow-up of #746

update the travis configuration to only test the AMP CLI container connection to the amplifier service.