### PR TITLE
Bump alpine go version to 1.8 for gotools image

### DIFF
--- a/images/amptools/Dockerfile
+++ b/images/amptools/Dockerfile
@@ -4,8 +4,8 @@ RUN apk --no-cache add sudo iproute2
 # Add Docker client from:
 # https://github.com/docker-library/docker/blob/master/1.13/Dockerfile
 ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 1.13.0
-ENV DOCKER_SHA256 fc194bb95640b1396283e5b23b5ff9d1b69a5e418b5b3d774f303a7642162ad6
+ENV DOCKER_VERSION 1.13.1
+ENV DOCKER_SHA256 97892375e756fd29a304bd8cd9ffb256c2e7c8fd759e12a55a6336e15100ad75
 
 RUN set -x \
 	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \

--- a/images/amptools/Dockerfile
+++ b/images/amptools/Dockerfile
@@ -1,4 +1,4 @@
-FROM appcelerator/gotools:1.4.0
+FROM appcelerator/gotools:1.5.0
 RUN apk --no-cache add sudo iproute2
 
 # Add Docker client from:

--- a/images/build-images.sh
+++ b/images/build-images.sh
@@ -41,7 +41,7 @@ for image in $images; do
   case $method in
   docker)
     echo "Building image $name:$tag (docker build)..."
-    docker build -t appcelerator/$name:$tag .
+    docker build -t $name:$tag .
     if [ $? -ne 0 ]; then
       echo "Failed to build $name ($image)"
       exit 1

--- a/images/gotools/Dockerfile
+++ b/images/gotools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.8-alpine
 # This builds a convenience "all-in-one" image for go development.
 # It intentionally does not remove any build prerequisites like most of our other
 # images since this image is meant strictly for building things.

--- a/images/gotools/README.md
+++ b/images/gotools/README.md
@@ -9,6 +9,6 @@ These tools are used by the amp toolchain.
 
 Currently includes
 
-* [Go 1.7](https://hub.docker.com/_/golang/)
+* [Go 1.8](https://hub.docker.com/_/golang/)
 * [Glide](https://glide.sh/) v0.12.3
 * [Golint](https://github.com/golang/lint)


### PR DESCRIPTION
Bump Go version to 1.8 for the gotools image.

[amptools](https://github.com/appcelerator/amp/blob/master/images/amptools/Dockerfile#L1) should be updated to pull the updated image once it's pushed.
