### PR TITLE
Update makefile glide rules

### DIFF
--- a/Makefile.refactor.make
+++ b/Makefile.refactor.make
@@ -42,12 +42,13 @@ update-deps:
 # TODO: temporary fix for trace conflict, remove when resolved
 	@rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/net/trace
 
-.PHONY: clean-glide
-clean-glide:
+.PHONY: clean-deps
+clean-deps:
 	@rm -rf vendor
 
-.PHONY: cleanall-glide
-cleanall-glide: clean-glide
+.PHONY: cleanall-deps
+# cleanall-deps will effectively causes `install-deps` to behave like `update-deps`
+cleanall-deps: clean-deps
 	@rm -rf .glide glide.lock
 
 # =============================================================================
@@ -82,8 +83,10 @@ clean-protoc:
 # CLEAN
 # =============================================================================
 .PHONY: clean cleanall
-clean: clean-glide clean-protoc clean-cli clean-server
-cleanall: clean cleanall-glide
+# clean doesn't remove the vendor directory since installing is time-intensive;
+# you can do this explicitly: `ampmake clean-deps clean`
+clean: clean-protoc clean-cli clean-server
+cleanall: clean cleanall-deps
 
 # =============================================================================
 # BUILD


### PR DESCRIPTION
Renames
  `clean-glide` -> `clean-deps`
  `cleanall-glide` -> `cleanall-deps`

`clean` no longer removes the `vendor` directory, because reinstalling is so time-intensive. If a developer really wants to remove vendor, then that needs to be explicit; ie: `ampmake clean-deps` (or `ampmake clean-deps clean`).
