### PR TITLE
Enhanced make fmt and lint rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,18 +158,49 @@ clean-server:
 # =============================================================================
 # Quality checks
 # =============================================================================
-GOSRCS := $(AMPSRC) $(AMPLSRC)
+CHECKDIRS := cmd/amp cmd/amplifier api data tests
+CHECKSRCS := $(shell find $(CHECKDIRS) -type f -name '*.go')
 
 # format and simplify if possible (https://golang.org/cmd/gofmt/#hdr-The_simplify_command)
 .PHONY: fmt
 fmt:
-	@gofmt -s -l -w $(GOSRCS)
+	@goimports -l $(CHECKDIRS) && goimports -w $(CHECKDIRS)
+	@gofmt -s -l -w $(CHECKSRCS)
 
 .PHONY: lint
 lint:
-#	@gometalinter --deadline=30s --disable-all --enable=golint --enable=vet --enable=ineffassign --enable=goconst --enable=goimports --vendor --exclude=vendor ./...
-	@gometalinter --deadline=5m --vendor --exclude=vendor ./...
+	@gometalinter --deadline=10m --concurrency=1 --enable-gc --vendor --exclude=vendor --exclude=\.pb\.go \
+		--sort=path --aggregate \
+		--disable-all \
+		--enable=deadcode \
+		--enable=dupl \
+		--enable=errcheck \
+		--enable=gas \
+		--enable=goconst \
+		--enable=gocyclo \
+		--enable=gofmt \
+		--enable=goimports \
+		--enable=golint \
+		--enable=gosimple \
+		--enable=ineffassign \
+		--enable=interfacer \
+		--enable=staticcheck \
+		--enable=structcheck \
+		--enable=test \
+		--enable=unconvert \
+		--enable=unparam \
+		--enable=unused \
+		--enable=varcheck \
+		--enable=vet \
+		--enable=vetshadow \
+		$(CHECKDIRS)
 
+
+# =============================================================================
+# Misc
+# =============================================================================
+
+# Display all the Makefile rules
 .PHONY: rules
 rules:
 	@hack/print-make-rules


### PR DESCRIPTION
New make rules:

Code quality checks using [gometalinter](https://github.com/alecthomas/gometalinter) (using all installed linters except gotype and safesql):

    $ ampmake lint

Format code (using both goimports and gofmt):

    $ ampmake fmt

## Current lint results:

```
api/rpc/account/account.go:204::warning: duplicate of rpc/account/account.go:339-359 (dupl)
api/rpc/account/account.go:315::warning: duplicate of rpc/account/account.go:300-312 (dupl)
api/rpc/account/account.go:394::warning: duplicate of rpc/account/account.go:409-421 (dupl)
api/rpc/account/account.go:379::warning: duplicate of rpc/account/account.go:446-458 (dupl)
api/rpc/account/account.go:352::warning: duplicate of rpc/function/function.go:42-49 (dupl)
api/rpc/account/account.go:409::warning: duplicate of rpc/account/account.go:394-406 (dupl)
api/rpc/account/account.go:339::warning: duplicate of rpc/account/account.go:204-225 (dupl)
api/rpc/account/account.go:218::warning: duplicate of rpc/account/account.go:352-359 (dupl)
api/rpc/account/account.go:300::warning: duplicate of rpc/account/account.go:315-327 (dupl)
api/rpc/account/account.go:446::warning: duplicate of rpc/account/account.go:379-391 (dupl)
api/rpc/function/function.go:42::warning: duplicate of rpc/account/account.go:218-225 (dupl)
api/rpc/logs/logs.go:204::warning: duplicate of rpc/logs/logs.go:199-203 (dupl)
api/rpc/logs/logs.go:199::warning: duplicate of rpc/logs/logs.go:204-208 (dupl)
cmd/amp/account-helper.go:1::warning: file is not goimported (goimports)
cmd/amp/account-org.go:198::warning: duplicate of account-user.go:206-224 (dupl)
cmd/amp/account-org.go:281::warning: duplicate of account-org.go:252-277 (dupl)
cmd/amp/account-org.go:371::warning: duplicate of account-team.go:360-367 (dupl)
cmd/amp/account-org.go:385:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-org.go:252::warning: duplicate of account-org.go:281-306 (dupl)
cmd/amp/account-org.go:164:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-org.go:239:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-team.go:196::warning: duplicate of account-team.go:167-192 (dupl)
cmd/amp/account-team.go:251:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-team.go:360::warning: duplicate of account-org.go:371-378 (dupl)
cmd/amp/account-team.go:161:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-team.go:257:17:warning: parameter amp is unused (unparam)
cmd/amp/account-team.go:264::warning: duplicate of account-team.go:300-332 (dupl)
cmd/amp/account-team.go:167::warning: duplicate of account-team.go:196-221 (dupl)
cmd/amp/account-team.go:300::warning: duplicate of account-team.go:264-296 (dupl)
cmd/amp/account-team.go:373:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-team.go:257:31:warning: parameter cmd is unused (unparam)
cmd/amp/account-user.go:200:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-user.go:247:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/account-user.go:206::warning: duplicate of account-org.go:198-216 (dupl)
cmd/amp/bootstrap.go:82:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
cmd/amp/bootstrap.go:42:12:warning: parameter amp is unused (unparam)
cmd/amp/bootstrap.go:45:11:warning: parameter amp is unused (unparam)
cmd/amp/bootstrap.go:42:26:warning: parameter cmd is unused (unparam)
cmd/amp/bootstrap.go:45:25:warning: parameter cmd is unused (unparam)
cmd/amp/bootstrap.go:53::warning: Subprocess launching with variable.,HIGH,HIGH (gas)
cmd/amp/config.go:15::warning: cyclomatic complexity 12 of function init() is high (> 10) (gocyclo)
cmd/amp/config.go:56:11:warning: error return value not checked (f.Set(args[1])) (errcheck)
cmd/amp/config.go:26::warning: Errors unhandled.,LOW,HIGH (gas)
cmd/amp/config.go:32:12:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/config.go:54:11:warning: error return value not checked (f.Set(b)) (errcheck)
cmd/amp/function.go:121:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/function.go:1::warning: file is not goimported (goimports)
cmd/amp/logs.go:14::warning: duplicate of stats.go:22-33 (dupl)
cmd/amp/logs.go:70:2:warning: ineffectual assignment to meta (ineffassign)
cmd/amp/logs.go:74:2:warning: ineffectual assignment to follow (ineffassign)
cmd/amp/logs.go:42::warning: cyclomatic complexity 15 of function Logs() is high (> 10) (gocyclo)
cmd/amp/main.go:104::warning: duplicate of main.go:92-102 (dupl)
cmd/amp/main.go:92::warning: duplicate of main.go:104-114 (dupl)
cmd/amp/stats.go:417::warning: Subprocess launching with partial path.,MEDIUM,HIGH (gas)
cmd/amp/stats.go:81:47:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:89:39 stats.go:92:39 stats.go:95:38 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/stats.go:285::warning: duplicate of stats.go:252-261 (dupl)
cmd/amp/stats.go:252::warning: duplicate of stats.go:285-294 (dupl)
cmd/amp/stats.go:419:9:warning: error return value not checked (cmd.Run()) (errcheck)
cmd/amp/stats.go:92:39:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:81:47 stats.go:89:39 stats.go:95:38 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/stats.go:77:45:warning: 7 other occurrence(s) of "true" found in: stats.go:79:47 stats.go:81:47 stats.go:89:39 stats.go:92:39 stats.go:95:38 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/stats.go:68::warning: cyclomatic complexity 18 of function Stats() is high (> 10) (gocyclo)
cmd/amp/stats.go:187::warning: cyclomatic complexity 11 of function displayStatsQueryParameters() is high (> 10) (gocyclo)
cmd/amp/stats.go:109:42:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:81:47 stats.go:89:39 stats.go:92:39 stats.go:95:38 stats.go:98:39 (goconst)
cmd/amp/stats.go:89:39:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:81:47 stats.go:92:39 stats.go:95:38 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/stats.go:98:39:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:81:47 stats.go:89:39 stats.go:92:39 stats.go:95:38 stats.go:109:42 (goconst)
cmd/amp/stats.go:22::warning: duplicate of logs.go:14-25 (dupl)
cmd/amp/stats.go:79:47:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:81:47 stats.go:89:39 stats.go:92:39 stats.go:95:38 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/stats.go:95:38:warning: 7 other occurrence(s) of "true" found in: stats.go:77:45 stats.go:79:47 stats.go:81:47 stats.go:89:39 stats.go:92:39 stats.go:98:39 stats.go:109:42 (goconst)
cmd/amp/storage.go:124::warning: duplicate of storage.go:100-120 (dupl)
cmd/amp/storage.go:167:9:warning: error return value not checked (w.Flush()) (errcheck)
cmd/amp/storage.go:100::warning: duplicate of storage.go:124-144 (dupl)
cmd/amp/version.go:80::warning: declaration of "err" shadows declaration at version.go:47 (vetshadow)
cmd/amplifier/main.go:39:2:warning: unused variable or constant dockerVersion (varcheck)
cmd/amplifier/main.go:39:2:warning: var dockerVersion is unused (U1000) (unused)
cmd/amplifier/main.go:29:1:warning: dockerVersion is unused (deadcode)
cmd/amplifier/main.go:80:2:warning: should replace loop with config.EtcdEndpoints = append(config.EtcdEndpoints, strings.Split(etcdEndpoints, ",")...) (S1011) (gosimple)
data/accounts/authz.go:39::warning: duplicate of accounts/authz.go:53-65 (dupl)
data/accounts/authz.go:53::warning: duplicate of accounts/authz.go:39-51 (dupl)
data/accounts/store.go:239::warning: duplicate of accounts/store.go:48-56 (dupl)
data/accounts/store.go:29::warning: duplicate of functions/store.go:60-70 (dupl)
data/accounts/store.go:437::warning: duplicate of functions/store.go:90-100 (dupl)
data/accounts/store.go:48::warning: duplicate of accounts/store.go:239-247 (dupl)
data/functions/store.go:60::warning: duplicate of accounts/store.go:29-38 (dupl)
data/functions/store.go:90::warning: duplicate of accounts/store.go:437-447 (dupl)
data/storage/etcd/store.go:257::warning: duplicate of storage/etcd/store.go:263-266 (dupl)
data/storage/etcd/store.go:263::warning: duplicate of storage/etcd/store.go:257-260 (dupl)
tests/cli/cli_test.go:128::warning: duplicate of cli/cli_test.go:95-108 (dupl)
tests/cli/cli_test.go:95::warning: duplicate of cli/cli_test.go:128-141 (dupl)
tests/integration/rpc/account_test.go:1331::warning: duplicate of integration/rpc/account_test.go:1584-1598 (dupl)
tests/integration/rpc/account_test.go:113::warning: duplicate of integration/rpc/account_test.go:460-473 (dupl)
tests/integration/rpc/account_test.go:1191::warning: duplicate of integration/rpc/account_test.go:611-623 (dupl)
tests/integration/rpc/account_test.go:460::warning: duplicate of integration/rpc/account_test.go:113-124 (dupl)
tests/integration/rpc/account_test.go:811::warning: duplicate of integration/rpc/account_test.go:976-999 (dupl)
tests/integration/rpc/account_test.go:1411::warning: duplicate of integration/rpc/account_test.go:1384-1409 (dupl)
tests/integration/rpc/account_test.go:353::warning: duplicate of integration/rpc/account_test.go:399-420 (dupl)
tests/integration/rpc/account_test.go:543::warning: duplicate of integration/rpc/account_test.go:1135-1147 (dupl)
tests/integration/rpc/account_test.go:1641::warning: duplicate of integration/rpc/account_test.go:1783-1811 (dupl)
tests/integration/rpc/account_test.go:1135::warning: duplicate of integration/rpc/account_test.go:543-553 (dupl)
tests/integration/rpc/account_test.go:1736::warning: duplicate of integration/rpc/account_test.go:214-224 (dupl)
tests/integration/rpc/account_test.go:752::warning: duplicate of integration/rpc/account_test.go:929-942 (dupl)
tests/integration/rpc/account_test.go:422::warning: duplicate of integration/rpc/account_test.go:353-374 (dupl)
tests/integration/rpc/account_test.go:1384::warning: duplicate of integration/rpc/account_test.go:1411-1436 (dupl)
tests/integration/rpc/account_test.go:1783::warning: duplicate of integration/rpc/account_test.go:719-732 (dupl)
tests/integration/rpc/account_test.go:1163::warning: duplicate of integration/rpc/account_test.go:1177-1189 (dupl)
tests/integration/rpc/account_test.go:1314::warning: duplicate of integration/rpc/account_test.go:1538-1555 (dupl)
tests/integration/rpc/account_test.go:214::warning: duplicate of integration/rpc/account_test.go:1736-1748 (dupl)
tests/integration/rpc/account_test.go:1037::warning: duplicate of integration/rpc/account_test.go:1314-1329 (dupl)
tests/integration/rpc/account_test.go:1798::warning: duplicate of integration/rpc/account_test.go:752-765 (dupl)
tests/integration/rpc/account_test.go:611::warning: duplicate of integration/rpc/account_test.go:625-637 (dupl)
tests/integration/rpc/account_test.go:625::warning: duplicate of integration/rpc/account_test.go:1191-1203 (dupl)
tests/integration/rpc/account_test.go:1641::warning: duplicate of integration/rpc/account_test.go:1783-1796 (dupl)
tests/integration/rpc/account_test.go:1584::warning: duplicate of integration/rpc/account_test.go:1331-1345 (dupl)
tests/integration/rpc/account_test.go:570::warning: duplicate of integration/rpc/account_test.go:1104-1133 (dupl)
tests/integration/rpc/account_test.go:1297::warning: duplicate of integration/rpc/account_test.go:1519-1555 (dupl)
tests/integration/rpc/account_test.go:1538::warning: duplicate of integration/rpc/account_test.go:1037-1053 (dupl)
tests/integration/rpc/account_test.go:1519::warning: duplicate of integration/rpc/account_test.go:1297-1329 (dupl)
tests/integration/rpc/account_test.go:786::warning: duplicate of integration/rpc/account_test.go:811-834 (dupl)
tests/integration/rpc/account_test.go:976::warning: duplicate of integration/rpc/account_test.go:786-809 (dupl)
tests/integration/rpc/account_test.go:1177::warning: duplicate of integration/rpc/account_test.go:1163-1175 (dupl)
tests/integration/rpc/account_test.go:929::warning: duplicate of integration/rpc/account_test.go:1656-1669 (dupl)
tests/integration/rpc/account_test.go:1656::warning: duplicate of integration/rpc/account_test.go:1798-1811 (dupl)
tests/integration/rpc/account_test.go:1783::warning: duplicate of integration/rpc/account_test.go:1641-1669 (dupl)
tests/integration/rpc/account_test.go:1104::warning: duplicate of integration/rpc/account_test.go:570-595 (dupl)
tests/integration/rpc/account_test.go:719::warning: duplicate of integration/rpc/account_test.go:1641-1654 (dupl)
tests/integration/rpc/account_test.go:399::warning: duplicate of integration/rpc/account_test.go:422-443 (dupl)
tests/integration/rpc/logs_test.go:89::warning: duplicate of integration/rpc/logs_test.go:109-127 (dupl)
tests/integration/rpc/logs_test.go:240::warning: duplicate of integration/rpc/logs_test.go:226-238 (dupl)
tests/integration/rpc/logs_test.go:254::warning: duplicate of integration/rpc/logs_test.go:296-308 (dupl)
tests/integration/rpc/logs_test.go:296::warning: duplicate of integration/rpc/logs_test.go:254-266 (dupl)
tests/integration/rpc/logs_test.go:109::warning: duplicate of integration/rpc/logs_test.go:89-107 (dupl)
tests/integration/rpc/logs_test.go:129::warning: duplicate of integration/rpc/logs_test.go:160-178 (dupl)
tests/integration/rpc/logs_test.go:160::warning: duplicate of integration/rpc/logs_test.go:129-147 (dupl)
tests/integration/rpc/logs_test.go:226::warning: duplicate of integration/rpc/logs_test.go:240-252 (dupl)
tests/integration/rpc/stats_test.go:14::warning: duplicate of integration/rpc/stats_test.go:37-58 (dupl)
tests/integration/rpc/stats_test.go:100::warning: duplicate of integration/rpc/stats_test.go:14-35 (dupl)
tests/integration/rpc/stats_test.go:60::warning: duplicate of integration/rpc/stats_test.go:100-121 (dupl)
tests/integration/rpc/stats_test.go:37::warning: duplicate of integration/rpc/stats_test.go:60-81 (dupl)
```
