### PR TITLE
Update amptools to docker 17.03

### DIFF
--- a/images/amptools/Dockerfile
+++ b/images/amptools/Dockerfile
@@ -2,10 +2,10 @@ FROM appcelerator/gotools:1.6.0
 RUN apk --no-cache add sudo iproute2
 
 # Add Docker client from:
-# https://github.com/docker-library/docker/blob/master/1.13/Dockerfile
+# https://github.com/docker-library/docker/blob/master/17.03/Dockerfile
 ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 1.13.1
-ENV DOCKER_SHA256 97892375e756fd29a304bd8cd9ffb256c2e7c8fd759e12a55a6336e15100ad75
+ENV DOCKER_VERSION 17.03.0-ce
+ENV DOCKER_SHA256 4a9766d99c6818b2d54dc302db3c9f7b352ad0a80a2dc179ec164a3ba29c2d3e
 
 RUN set -x \
 	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
@@ -19,7 +19,6 @@ RUN set -x \
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY sudoers /etc/sudoers.d/amp
 RUN chmod 0440 /etc/sudoers.d/amp
-
 RUN adduser -S -s /bin/sh sudoer
 
 # pass commands through docker-entrypoint first for special handling


### PR DESCRIPTION
Another update for amptools, this one to bump the Docker version.