### PR TITLE
Use dupl linter

### DIFF
--- a/api/rpc/account/account.go
+++ b/api/rpc/account/account.go
@@ -201,6 +201,7 @@ func (s *Server) ForgotLogin(ctx context.Context, in *ForgotLoginRequest) (*empt
 }
 
 // GetUser implements account.GetUser
+// nolint : dupl
 func (s *Server) GetUser(ctx context.Context, in *GetUserRequest) (*GetUserReply, error) {
 	// Get the user
 	user, err := s.Accounts.GetUser(ctx, in.Name)
@@ -215,6 +216,7 @@ func (s *Server) GetUser(ctx context.Context, in *GetUserRequest) (*GetUserReply
 }
 
 // ListUsers implements account.ListUsers
+// nolint : dupl
 func (s *Server) ListUsers(ctx context.Context, in *ListUsersRequest) (*ListUsersReply, error) {
 	users, err := s.Accounts.ListUsers(ctx)
 	if err != nil {
@@ -297,6 +299,7 @@ func (s *Server) CreateOrganization(ctx context.Context, in *CreateOrganizationR
 }
 
 // AddUserToOrganization implements account.AddOrganizationMember
+// nolint : dupl
 func (s *Server) AddUserToOrganization(ctx context.Context, in *AddUserToOrganizationRequest) (*empty.Empty, error) {
 	if err := s.Accounts.AddUserToOrganization(ctx, in.OrganizationName, in.UserName); err != nil {
 		return &empty.Empty{}, convertError(err)
@@ -312,6 +315,7 @@ func (s *Server) AddUserToOrganization(ctx context.Context, in *AddUserToOrganiz
 }
 
 // RemoveUserFromOrganization implements account.RemoveOrganizationMember
+// nolint : dupl
 func (s *Server) RemoveUserFromOrganization(ctx context.Context, in *RemoveUserFromOrganizationRequest) (*empty.Empty, error) {
 	if err := s.Accounts.RemoveUserFromOrganization(ctx, in.OrganizationName, in.UserName); err != nil {
 		return &empty.Empty{}, convertError(err)
@@ -336,6 +340,7 @@ func (s *Server) ChangeOrganizationMemberRole(ctx context.Context, in *ChangeOrg
 }
 
 // GetOrganization implements account.GetOrganization
+// nolint : dupl
 func (s *Server) GetOrganization(ctx context.Context, in *GetOrganizationRequest) (*GetOrganizationReply, error) {
 	organization, err := s.Accounts.GetOrganization(ctx, in.Name)
 	if err != nil {
@@ -349,6 +354,7 @@ func (s *Server) GetOrganization(ctx context.Context, in *GetOrganizationRequest
 }
 
 // ListOrganizations implements account.ListOrganizations
+// nolint : dupl
 func (s *Server) ListOrganizations(ctx context.Context, in *ListOrganizationsRequest) (*ListOrganizationsReply, error) {
 	organizations, err := s.Accounts.ListOrganizations(ctx)
 	if err != nil {
@@ -359,6 +365,7 @@ func (s *Server) ListOrganizations(ctx context.Context, in *ListOrganizationsReq
 }
 
 // DeleteOrganization implements account.DeleteOrganization
+// nolint : dupl
 func (s *Server) DeleteOrganization(ctx context.Context, in *DeleteOrganizationRequest) (*empty.Empty, error) {
 	if err := s.Accounts.DeleteOrganization(ctx, in.Name); err != nil {
 		return nil, convertError(err)
@@ -376,6 +383,7 @@ func (s *Server) DeleteOrganization(ctx context.Context, in *DeleteOrganizationR
 // Teams
 
 // CreateTeam implements account.CreateTeam
+// nolint : dupl
 func (s *Server) CreateTeam(ctx context.Context, in *CreateTeamRequest) (*empty.Empty, error) {
 	if err := s.Accounts.CreateTeam(ctx, in.OrganizationName, in.TeamName); err != nil {
 		return nil, convertError(err)
@@ -391,6 +399,7 @@ func (s *Server) CreateTeam(ctx context.Context, in *CreateTeamRequest) (*empty.
 }
 
 // AddUserToTeam implements account.AddUserToTeam
+// nolint : dupl
 func (s *Server) AddUserToTeam(ctx context.Context, in *AddUserToTeamRequest) (*empty.Empty, error) {
 	if err := s.Accounts.AddUserToTeam(ctx, in.OrganizationName, in.TeamName, in.UserName); err != nil {
 		return &empty.Empty{}, convertError(err)
@@ -406,6 +415,7 @@ func (s *Server) AddUserToTeam(ctx context.Context, in *AddUserToTeamRequest) (*
 }
 
 // RemoveUserFromTeam implements account.RemoveUserFromTeam
+// nolint : dupl
 func (s *Server) RemoveUserFromTeam(ctx context.Context, in *RemoveUserFromTeamRequest) (*empty.Empty, error) {
 	if err := s.Accounts.RemoveUserFromTeam(ctx, in.OrganizationName, in.TeamName, in.UserName); err != nil {
 		return &empty.Empty{}, convertError(err)
@@ -443,6 +453,7 @@ func (s *Server) ListTeams(ctx context.Context, in *ListTeamsRequest) (*ListTeam
 }
 
 // DeleteTeam implements account.DeleteTeam
+// nolint : dupl
 func (s *Server) DeleteTeam(ctx context.Context, in *DeleteTeamRequest) (*empty.Empty, error) {
 	if err := s.Accounts.DeleteTeam(ctx, in.OrganizationName, in.TeamName); err != nil {
 		return nil, convertError(err)

--- a/api/rpc/function/function.go
+++ b/api/rpc/function/function.go
@@ -40,6 +40,7 @@ func (s *Server) Create(ctx context.Context, in *CreateRequest) (*CreateReply, e
 }
 
 // List implements function.Server
+// nolint : dupl
 func (s *Server) List(ctx context.Context, in *ListRequest) (*ListReply, error) {
 	functions, err := s.Functions.ListFunctions(ctx)
 	if err != nil {

--- a/api/rpc/logs/logs.go
+++ b/api/rpc/logs/logs.go
@@ -187,6 +187,7 @@ func parseProtoLogEntry(data []byte) (logEntry LogEntry, err error) {
 	return
 }
 
+// nolint : dupl
 func filter(entry *LogEntry, in *GetRequest) bool {
 	match := true
 	if in.Container != "" {

--- a/data/accounts/authz.go
+++ b/data/accounts/authz.go
@@ -37,6 +37,7 @@ var (
 		},
 	}
 
+	// nolint : dupl
 	teamsAdminByOrgOwnersAndMembers = &ladon.DefaultPolicy{
 		ID:        stringid.GenerateNonCryptoID(),
 		Subjects:  []string{"<.*>"},
@@ -51,6 +52,7 @@ var (
 		},
 	}
 
+	// nolint : dupl
 	functionsAdminByOrgOwnersAndMembers = &ladon.DefaultPolicy{
 		ID:        stringid.GenerateNonCryptoID(),
 		Subjects:  []string{"<.*>"},

--- a/data/accounts/store.go
+++ b/data/accounts/store.go
@@ -26,7 +26,7 @@ func NewStore(store storage.Interface) *Store {
 }
 
 // Users
-
+// nolint : dupl
 func (s *Store) rawUser(ctx context.Context, name string) (*User, error) {
 	user := &User{}
 	if err := s.store.Get(ctx, path.Join(usersRootKey, name), user, true); err != nil {
@@ -46,6 +46,7 @@ func secureUser(user *User) *User {
 	return user
 }
 
+// nolint : dupl
 func (s *Store) getUser(ctx context.Context, name string) (user *User, err error) {
 	if user, err = s.rawUser(ctx, name); err != nil {
 		return nil, err
@@ -236,7 +237,7 @@ func (s *Store) DeleteUser(ctx context.Context, name string) error {
 }
 
 // Organizations
-
+// nolint : dupl
 func (s *Store) getOrganization(ctx context.Context, name string) (organization *Organization, err error) {
 	if organization, err = s.GetOrganization(ctx, name); err != nil {
 		return nil, err
@@ -435,6 +436,7 @@ func (s *Store) GetOrganization(ctx context.Context, name string) (*Organization
 }
 
 // ListOrganizations lists organizations
+// nolint : dupl
 func (s *Store) ListOrganizations(ctx context.Context) ([]*Organization, error) {
 	protos := []proto.Message{}
 	if err := s.store.List(ctx, organizationsRootKey, storage.Everything, &Organization{}, &protos); err != nil {

--- a/data/functions/store.go
+++ b/data/functions/store.go
@@ -58,6 +58,7 @@ func (s *Store) CreateFunction(ctx context.Context, name string, image string) (
 }
 
 // GetFunction fetches a function by id
+// nolint : dupl
 func (s *Store) GetFunction(ctx context.Context, id string) (*Function, error) {
 	function := &Function{}
 	if err := s.store.Get(ctx, path.Join(functionsRootKey, id), function, true); err != nil {
@@ -88,6 +89,7 @@ func (s *Store) GetFunctionByName(ctx context.Context, name string) (*Function, 
 }
 
 // ListFunctions lists functions
+// nolint : dupl
 func (s *Store) ListFunctions(ctx context.Context) ([]*Function, error) {
 	protos := []proto.Message{}
 	if err := s.store.List(ctx, functionsRootKey, storage.Everything, &Function{}, &protos); err != nil {

--- a/data/storage/etcd/store.go
+++ b/data/storage/etcd/store.go
@@ -254,12 +254,14 @@ func (s *etcd) CompareAndSet(ctx context.Context, key string, expect proto.Messa
 }
 
 // Watch implements storage.Interface.Watch.
+// nolint : dupl
 func (s *etcd) Watch(ctx context.Context, key string, resourceVersion int64, filter storage.Filter) (storage.WatchInterface, error) {
 	key = s.prefix(key)
 	return s.watch(ctx, key, resourceVersion, filter, false)
 }
 
 // WatchList implements storage.Interface.WatchList.
+// nolint : dupl
 func (s *etcd) WatchList(ctx context.Context, key string, resourceVersion int64, filter storage.Filter) (storage.WatchInterface, error) {
 	key = s.prefix(key)
 	return s.watch(ctx, key, resourceVersion, filter, true)


### PR DESCRIPTION
Use of [dupl](https://github.com/mibk/dupl#dupl-) for detecting clones in backend code.
Since some of the functions have similar implementation, `// nolint : dupl` has been added to suppress the warnings.

To test -
`ampmake lint`