### PR TITLE
Remove dupl from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,6 @@ lint:
 		--sort=path --aggregate \
 		--disable-all \
 		--enable=deadcode \
-		--enable=dupl \
 		--enable=errcheck \
 		--enable=gas \
 		--enable=goconst \


### PR DESCRIPTION
Remove `dupl` for now due to excessive false positives. 