### PR TITLE
Exclude cmd/amp from lint check for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	@gometalinter --deadline=10m --concurrency=1 --enable-gc --vendor --exclude=vendor --exclude=\.pb\.go \
+	@gometalinter --deadline=10m --concurrency=1 --enable-gc --vendor --exclude=vendor --exclude=\.pb\.go --exclude=cmd/amp \
 		--sort=path --aggregate \
 		--disable-all \
 		--enable=deadcode \


### PR DESCRIPTION
Exclude cmd/amp from lint check for now (until the refactored CLI is ready)