### PR TITLE
[Monitoring] Add ampbeat targets to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ clean-protoc:
 .PHONY: clean cleanall
 # clean doesn't remove the vendor directory since installing is time-intensive;
 # you can do this explicitly: `ampmake clean-deps clean`
-clean: clean-protoc clean-cli clean-server
+clean: clean-protoc clean-cli clean-server clean-beat
 cleanall: clean cleanall-deps
 
 # =============================================================================
@@ -86,7 +86,7 @@ cleanall: clean cleanall-deps
 # When running in the amptools container, set DOCKER_CMD="sudo docker"
 DOCKER_CMD ?= "docker"
 
-build: install-deps protoc build-server build-cli
+build: install-deps protoc build-server build-cli build-beat
 
 # =============================================================================
 # BUILD CLI (`amp`)
@@ -151,9 +151,34 @@ build-server: $(AMPLTARGET)
 
 rebuild-server: clean-server build-server
 
-.PHONY: clean-cli
+.PHONY: clean-server
 clean-server:
 	@rm -f $(AMPLTARGET)
+
+# =============================================================================
+# BUILD BEAT (`ampbeat`)
+# Saves binary to `cmd/ampbeat/ampbeat.alpine`,
+# then builds `appcelerator/ampbeat` image
+# =============================================================================
+BEAT := ampbeat
+BEATBINARY=$(BEAT).alpine
+BEATTAG := local
+BEATIMG := appcelerator/$(BEAT):$(BEATTAG)
+BEATTARGET := $(CMDDIR)/$(BEAT)/$(BEATBINARY)
+BEATDIRS := cmd/$(BEAT) api data tests
+BEATSRC := $(shell find $(BEATDIRS) -type f -name '*.go')
+
+$(BEATTARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(BEATSRC)
+	@go build -ldflags $(LDFLAGS) -o $(BEATTARGET) $(REPO)/$(CMDDIR)/$(BEAT)
+
+build-beat: $(BEATTARGET)
+	@$(DOCKER_CMD) build -t $(BEATIMG) $(CMDDIR)/$(BEAT) || (rm -f $(BEATTARGET); exit 1)
+
+rebuild-beat: clean-beat build-beat
+
+.PHONY: clean-beat
+clean-beat:
+	@rm -f $(BEATTARGET)
 
 # =============================================================================
 # Quality checks

--- a/cmd/ampbeat/Dockerfile
+++ b/cmd/ampbeat/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY ampbeat.alpine /usr/local/bin/ampbeat
+ENTRYPOINT [ "ampbeat" ]

--- a/cmd/ampbeat/README.md
+++ b/cmd/ampbeat/README.md
@@ -1,0 +1,3 @@
+# ampbeat
+
+This is the main entrypoint for the ampbeat executable.

--- a/cmd/ampbeat/_meta/beat.yml
+++ b/cmd/ampbeat/_meta/beat.yml
@@ -1,0 +1,7 @@
+################### Ampbeat Configuration Example #########################
+
+############################# Ampbeat ######################################
+
+ampbeat:
+  # Defines how often an event is sent to the output
+  period: 1s

--- a/cmd/ampbeat/_meta/fields.yml
+++ b/cmd/ampbeat/_meta/fields.yml
@@ -1,0 +1,9 @@
+- key: ampbeat
+  title: ampbeat
+  description:
+  fields:
+    - name: counter
+      type: long
+      required: true
+      description: >
+        PLEASE UPDATE DOCUMENTATION

--- a/cmd/ampbeat/beater/ampbeat.go
+++ b/cmd/ampbeat/beater/ampbeat.go
@@ -1,0 +1,62 @@
+package beater
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher"
+
+	"github.com/appcelerator/amp/cmd/ampbeat/config"
+)
+
+type Ampbeat struct {
+	done   chan struct{}
+	config config.Config
+	client publisher.Client
+}
+
+// Creates beater
+func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
+	config := config.DefaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, fmt.Errorf("Error reading config file: %v", err)
+	}
+
+	bt := &Ampbeat{
+		done:   make(chan struct{}),
+		config: config,
+	}
+	return bt, nil
+}
+
+func (bt *Ampbeat) Run(b *beat.Beat) error {
+	logp.Info("ampbeat is running! Hit CTRL-C to stop it.")
+
+	bt.client = b.Publisher.Connect()
+	ticker := time.NewTicker(bt.config.Period)
+	counter := 1
+	for {
+		select {
+		case <-bt.done:
+			return nil
+		case <-ticker.C:
+		}
+
+		event := common.MapStr{
+			"@timestamp": common.Time(time.Now()),
+			"type":       b.Name,
+			"counter":    counter,
+		}
+		bt.client.PublishEvent(event)
+		logp.Info("Event sent")
+		counter++
+	}
+}
+
+func (bt *Ampbeat) Stop() {
+	bt.client.Close()
+	close(bt.done)
+}

--- a/cmd/ampbeat/config/config.go
+++ b/cmd/ampbeat/config/config.go
@@ -1,0 +1,14 @@
+// Config is put into a different package to prevent cyclic imports in case
+// it is needed in several locations
+
+package config
+
+import "time"
+
+type Config struct {
+	Period time.Duration `config:"period"`
+}
+
+var DefaultConfig = Config{
+	Period: 1 * time.Second,
+}

--- a/cmd/ampbeat/main.go
+++ b/cmd/ampbeat/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+
+	"github.com/appcelerator/amp/cmd/ampbeat/beater"
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+func main() {
+	err := beat.Run("ampbeat", "", beater.New)
+	if err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR adds `ampbeat` targets in the Makefile by mimicking what already exists for other binaries, namely:
 - `build-beat`: Build the alpine binary and then build the docker image
 - `rebuild-beat`: Does the same, expect it cleans the binary first
 - `clean-beat`: Cleans the binary

Note the `ampbeat` binary is only a skeleton and is not integrated to the monitoring stack yet.