### PR TITLE
[Monitoring] Add amp-agent targets to the Makefile

### DIFF
--- a/cmd/amp-agent/Dockerfile
+++ b/cmd/amp-agent/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY amp-agent.alpine /usr/local/bin/amp-agent
+ENTRYPOINT [ "amp-agent" ]

--- a/cmd/amp-agent/README.md
+++ b/cmd/amp-agent/README.md
@@ -1,0 +1,3 @@
+# amp-agent
+
+This is the main entrypoint for the amp-agent executable.


### PR DESCRIPTION
This PR adds amp-agent targets in the Makefile by mimicking what already exists for other binaries, namely:

- build-agent: Build the alpine binary and then build the docker image
- rebuild-agent: Does the same, expect it cleans the binary first
- clean-agent: Cleans the binary

Note the amp-agent code/binary hasn't been updated for now