### PR TITLE
Update amp cluster commands

### DIFF
--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -8,6 +8,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type clusterOpts struct {
+	managers int
+	workers int
+	driver string
+	name string
+}
+
+var (
+	opts = &clusterOpts{}
+	flagMap map[string]string
+)
+
 // NewClusterCommand returns a new instance of the cluster command.
 func NewClusterCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
@@ -18,6 +30,7 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 	}
 	cmd.AddCommand(NewCreateCommand(c))
 	cmd.AddCommand(NewDestroyCommand(c))
+	cmd.AddCommand(NewUpdateCommand(c))
 	return cmd
 }
 

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -11,12 +11,12 @@ import (
 type clusterOpts struct {
 	managers int
 	workers int
-	driver string
+	provider string
 	name string
 }
 
 var (
-	opts = &clusterOpts{}
+	opts = &clusterOpts{3,2,"local", ""}
 	flagMap map[string]string
 )
 
@@ -31,6 +31,7 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 	cmd.AddCommand(NewCreateCommand(c))
 	cmd.AddCommand(NewDestroyCommand(c))
 	cmd.AddCommand(NewUpdateCommand(c))
+	cmd.AddCommand(NewStatusCommand(c))
 	return cmd
 }
 

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -18,7 +18,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags := cmd.Flags()
 	flags.IntVarP(&opts.workers, "workers", "w", 2, "Initial number of worker nodes")
 	flags.IntVarP(&opts.managers, "managers", "m", 3, "Intial number of manager nodes")
-	flags.StringVarP(&opts.driver, "driver", "d", "local", "Cluster deployment target")
+	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
 	return cmd
 }
@@ -31,8 +31,8 @@ func create(c cli.Interface, cmd *cobra.Command, args []string) error {
 	if cmd.Flag("managers").Changed {
 		flagMap["-m"] = cmd.Flag("managers").Value.String()
 	}
-	if cmd.Flag("driver").Changed {
-		flagMap["-t"] = cmd.Flag("driver").Value.String()
+	if cmd.Flag("provider").Changed {
+		flagMap["-t"] = cmd.Flag("provider").Value.String()
 	}
 	if cmd.Flag("name").Changed {
 		flagMap["-l"] = cmd.Flag("name").Value.String()

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -10,8 +10,9 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a local amp cluster",
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return create(c, cmd, args)
+			return create(c, cmd)
 		},
 	}
 
@@ -23,22 +24,17 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	return cmd
 }
 
-func create(c cli.Interface, cmd *cobra.Command, args []string) error {
-	flagMap = make(map[string]string)
-	if cmd.Flag("workers").Changed {
-		flagMap["-w"] = cmd.Flag("workers").Value.String()
+// Map cli cluster flags to target bootstrap cluster command flags and update the cluster
+func create(c cli.Interface, cmd *cobra.Command) error {
+	// This is a map from cli cluster flag name to bootstrap script flag name
+	m := map[string]string{
+		"workers":  "-w",
+		"managers": "-m",
+		"provider": "-t",
+		"name":     "-l",
 	}
-	if cmd.Flag("managers").Changed {
-		flagMap["-m"] = cmd.Flag("managers").Value.String()
-	}
-	if cmd.Flag("provider").Changed {
-		flagMap["-t"] = cmd.Flag("provider").Value.String()
-	}
-	if cmd.Flag("name").Changed {
-		flagMap["-l"] = cmd.Flag("name").Value.String()
-	}
-	for k, v := range flagMap {
-		args = append(args, k, v)
-	}
-	return updateCluster(c, args)
+
+	args := []string{}
+	return updateCluster(c, reflag(cmd, m, args))
 }
+

--- a/cli/command/cluster/destroy.go
+++ b/cli/command/cluster/destroy.go
@@ -14,12 +14,13 @@ func NewDestroyCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy a local amp cluster",
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return destroy(c, args)
+			return destroy(c)
 		},
 	}
 }
 
-func destroy(c cli.Interface, args []string) error {
-	return updateCluster(c, append(destroyArgs[:], args[:]...))
+func destroy(c cli.Interface) error {
+	return updateCluster(c, destroyArgs)
 }

--- a/cli/command/cluster/destroy.go
+++ b/cli/command/cluster/destroy.go
@@ -14,7 +14,6 @@ func NewDestroyCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy a local amp cluster",
-		Long:  `The destroy command stops and removes the amp cluster.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return destroy(c, args)
 		},

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -3,32 +3,22 @@ package cluster
 import (
 	"github.com/appcelerator/amp/cli"
 	"github.com/spf13/cobra"
-	"os/exec"
 )
 
-var (
-	err error
-	cmdOut []byte
-)
 // NewStatusCommand returns a new instance of the status command for by providing groups and instances of local cluster.
 func NewStatusCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Retrieve details about a local amp cluster",
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return status(c, args)
+			return status(c)
 		},
 	}
 }
 
-func status(c cli.Interface, args []string) error {
-	cmdName := "docker"
-	args = []string{"container", "ls"}
-	if cmdOut, err = exec.Command(cmdName, args...).Output(); err != nil {
-		c.Console().Fatalf("error while executing command: %v\n", err)
-	}
-	status := string(cmdOut)
-	c.Console().Println(status)
-	return err
+func status(c cli.Interface) error {
+	// TODO call api to get status
+	return nil
 }
 

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+	"os/exec"
+)
+
+var (
+	err error
+	cmdOut []byte
+)
+// NewStatusCommand returns a new instance of the status command for by providing groups and instances of local cluster.
+func NewStatusCommand(c cli.Interface) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Retrieve details about a local amp cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return status(c, args)
+		},
+	}
+}
+
+func status(c cli.Interface, args []string) error {
+	cmdName := "docker"
+	args = []string{"container", "ls"}
+	if cmdOut, err = exec.Command(cmdName, args...).Output(); err != nil {
+		c.Console().Fatalf("error while executing command: %v\n", err)
+	}
+	status := string(cmdOut)
+	c.Console().Println(status)
+	return err
+}
+

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -5,37 +5,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCreateCommand returns a new instance of the create command for bootstrapping a local development cluster.
-func NewCreateCommand(c cli.Interface) *cobra.Command {
+// NewUpdateCommand returns a new instance of the update command for updating local development cluster.
+func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a local amp cluster",
+		Use:   "update",
+		Short: "Update a local amp cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return create(c, cmd, args)
+			return update(c, cmd, args)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.IntVarP(&opts.workers, "workers", "w", 2, "Initial number of worker nodes")
 	flags.IntVarP(&opts.managers, "managers", "m", 3, "Intial number of manager nodes")
-	flags.StringVarP(&opts.driver, "driver", "d", "local", "Cluster deployment target")
-	flags.StringVar(&opts.name, "name", "", "Cluster Label")
 	return cmd
 }
 
-func create(c cli.Interface, cmd *cobra.Command, args []string) error {
+func update(c cli.Interface, cmd *cobra.Command, args []string) error {
 	flagMap = make(map[string]string)
 	if cmd.Flag("workers").Changed {
 		flagMap["-w"] = cmd.Flag("workers").Value.String()
 	}
 	if cmd.Flag("managers").Changed {
 		flagMap["-m"] = cmd.Flag("managers").Value.String()
-	}
-	if cmd.Flag("driver").Changed {
-		flagMap["-t"] = cmd.Flag("driver").Value.String()
-	}
-	if cmd.Flag("name").Changed {
-		flagMap["-l"] = cmd.Flag("name").Value.String()
 	}
 	for k, v := range flagMap {
 		args = append(args, k, v)

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -8,10 +8,11 @@ import (
 // NewUpdateCommand returns a new instance of the update command for updating local development cluster.
 func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update a local amp cluster",
+		Use:     "update",
+		Short:   "Update a local amp cluster",
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return update(c, cmd, args)
+			return update(c, cmd)
 		},
 	}
 
@@ -21,16 +22,13 @@ func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	return cmd
 }
 
-func update(c cli.Interface, cmd *cobra.Command, args []string) error {
-	flagMap = make(map[string]string)
-	if cmd.Flag("workers").Changed {
-		flagMap["-w"] = cmd.Flag("workers").Value.String()
+func update(c cli.Interface, cmd *cobra.Command) error {
+	// This is a map from cli cluster flag name to bootstrap script flag name
+	m := map[string]string{
+		"workers":  "-w",
+		"managers": "-m",
 	}
-	if cmd.Flag("managers").Changed {
-		flagMap["-m"] = cmd.Flag("managers").Value.String()
-	}
-	for k, v := range flagMap {
-		args = append(args, k, v)
-	}
-	return updateCluster(c, args)
+
+	args := []string{}
+	return updateCluster(c, reflag(cmd, m, args))
 }


### PR DESCRIPTION
#839
 
Updated `amp cluster` commands on the AMP CLI to include additional commands for 
- update cluster (scale number of worker and manager nodes)
- cluster status (details about group/cluster information)