### PR TITLE
Add cli exec helper

### DIFF
--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -7,8 +7,8 @@ import (
 	"github.com/appcelerator/amp/cli"
 )
 
-// Command is a helper to exec an os command using the streams configured for the cli.
-func Command(c cli.Interface, name string, args []string) error {
+// Run is a helper to exec an os command using the streams configured for the cli.
+func Run(c cli.Interface, name string, args []string) error {
 	proc := exec.Command(name, args...)
 	stdout, err := proc.StdoutPipe()
 	if err != nil {

--- a/cli/exec/exec.go
+++ b/cli/exec/exec.go
@@ -1,0 +1,49 @@
+package exec
+
+import (
+	"bufio"
+	"os/exec"
+
+	"github.com/appcelerator/amp/cli"
+)
+
+// Command is a helper to exec an os command using the streams configured for the cli.
+func Command(c cli.Interface, name string, args []string) error {
+	proc := exec.Command(name, args...)
+	stdout, err := proc.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := proc.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	outscanner := bufio.NewScanner(stdout)
+	go func() {
+		for outscanner.Scan() {
+			c.Console().Println(outscanner.Text())
+		}
+	}()
+	errscanner := bufio.NewScanner(stderr)
+	go func() {
+		for errscanner.Scan() {
+			c.Console().Println(errscanner.Text())
+		}
+	}()
+
+	err = proc.Start()
+	if err != nil {
+		return err
+	}
+
+	err = proc.Wait()
+	if err != nil {
+		// Just pass along the information that the process exited with a failure;
+		// whatever error information it displayed is what the user will see.
+		return err
+
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a helper for CLI commands that need to exec an os command. It uses the streams specified by the CLI configuration.