### PR TITLE
[WIP] bootstrap cleanup ikt.vol and temp files 

### DIFF
--- a/hack/deploy
+++ b/hack/deploy
@@ -23,6 +23,7 @@ cleanup() {
   [[ SUCCESS -ne 1 && ! -z $CID ]] && echo "clean up" && $bootstrap -d $CID
 }
 trap cleanup EXIT
+trap 'rm -f bootstrap/ikt.vol.*' EXIT
 
 ok() {
   echo ok $1
@@ -152,4 +153,3 @@ checkexit $? "service ping check failed: elasticsearch"
 ok "service ping check succeeded: elasticsearch"
 
 SUCCESS=1
-


### PR DESCRIPTION
Using ctrl+c to exit hack/deploy script early leaves `ikt.vol.*` files in bootstrap dir. 

Adds trap statement to clean up `ikt.vol.*` files

to test:
 - `watch ls bootstrap`
 - `hack/deploy`
 - ctrl+c 

 `ikt.vol.*` file should appear and then be removed.