### PR TITLE
Add service replica checks to deploy script

### DIFF
--- a/hack/deploy
+++ b/hack/deploy
@@ -13,6 +13,7 @@ readonly bootstrap="$SP/../bootstrap/bootstrap"
 readonly clustercheck="$SP/clustercheck"
 readonly curlcheck="$SP/curlcheck"
 readonly swarmcheck="$SP/swarmcheck"
+readonly servicescheck="$SP/servicescheck"
 
 checkexit() {
   [[ $1 -ne 0 ]] && printf "${@:2} (exit $1)\n" && exit $1
@@ -81,6 +82,11 @@ pushimage localhost:5000 appcelerator/agent:local
 echo "deploy stacks to cluster"
 deploystack amplifier.stack.yml amplifier
 deploystack monitoring.stack.yml monitoring
+
+echo "wait for all services replicas to be running"
+$servicescheck 300
+checkexit $? "service replica checks timed out"
+ok
 
 SUCCESS=1
 

--- a/hack/servicescheck
+++ b/hack/servicescheck
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+TIMEOUT="${1:-300}"
+INTERVAL="${2:-2}"
+
+amps="docker run -it --rm --network=hostnet docker --host=m1"
+
+check() {
+  list=$($amps service ls)
+  result=$(echo "$list" | awk '{ print $4 }' | tail -n +2)
+
+  read -ra replicas <<< $result
+
+  for r in "${replicas[@]}"; do
+    # split "1/1" into [actual, desired] replica arrays
+    IFS="/" read -ra e <<< "$r"
+    # if actual != desired then service is not healthy
+    [[ "${e[0]}" -ne "${e[1]}" ]] && return 1
+  done
+}
+
+SECONDS=0
+while true; do
+  check
+  [[ $? -eq 0 ]] && exit 0
+  [[ "${TIMEOUT}" -eq 0 || "${SECONDS}" -gt "${TIMEOUT}" ]] && $amps service ls && exit 1
+  sleep "${INTERVAL}"
+done
+


### PR DESCRIPTION
Updates the `deploy` script used for local development and CI builds to ensure all service replicas are healthy before proceeding to run any subsequent tests.