### PR TITLE
Improve deploy script service lookups and ping checks

### DIFF
--- a/hack/deploy
+++ b/hack/deploy
@@ -94,6 +94,10 @@ $servicescheck $maxwait
 checkexit $? "monitoring-core service replica checks timed out"
 ok
 
+# sanity checks after starting stack
+$curlcheck elasticsearch:9200 30
+$curlcheck nats:8222 30
+
 echo "deploy monitoring-aux stack to cluster"
 deploystack monitoring-aux.stack.yml monitoring-aux
 echo "wait for all monitoring-aux service replicas to be running ($maxwait sec)"

--- a/hack/deploy
+++ b/hack/deploy
@@ -25,7 +25,7 @@ cleanup() {
 trap cleanup EXIT
 
 ok() {
-  echo ok
+  echo ok $1
 }
 
 pushimage() {
@@ -42,6 +42,18 @@ deploystack() {
   docker run -it --rm --network=hostnet -v $(dirname $SP)/stacks:/stacks docker --host=m1 stack deploy -c /stacks/$1 $2
   checkexit $? "error deploying stack"
   ok
+}
+
+# can only use this once the swarm is ready
+lookup() {
+  [[ -z $amps ]] && echo "error to use lookup before swarm is created" && return 1
+  $amps run --rm --network=ampnet appcelerator/alpine:3.5.2 nslookup $1
+}
+
+# can only use this once the swarm is ready
+kurl() {
+  [[ -z $amps ]] && echo "error to use kurl before swarm is created" && return 1
+  $amps run --rm --network=ampnet appcelerator/alpine:3.5.2 curl -L -s -o /dev/null -w '%{http_code}\n' $1
 }
 
 if [ -z $CID ]; then
@@ -69,6 +81,9 @@ $swarmcheck 300
 checkexit $? "swarm mode timed out"
 ok
 
+# helper for any subsequent docker commands
+amps="docker run -it --rm --network=hostnet -v $(dirname $SP)/stacks:/stacks docker --host=m1"
+
 echo "wait for registry"
 $curlcheck localhost:5000/v2/ 200 10
 checkexit $? "registry timed out"
@@ -94,10 +109,6 @@ $servicescheck $maxwait
 checkexit $? "monitoring-core service replica checks timed out"
 ok
 
-# sanity checks after starting stack
-$curlcheck elasticsearch:9200 30
-$curlcheck nats:8222 30
-
 echo "deploy monitoring-aux stack to cluster"
 deploystack monitoring-aux.stack.yml monitoring-aux
 echo "wait for all monitoring-aux service replicas to be running ($maxwait sec)"
@@ -112,11 +123,33 @@ $servicescheck $maxwait
 checkexit $? "monitoring-agent service replica checks timed out"
 ok
 
-# final sanity check
-$servicescheck 1
-checkexit $? "global service replica checks timed out"
+# final sanity checks
+# ===================
+
+$servicescheck 0
+checkexit $? "final service replica smoke check failed"
 ok
-docker run -it --rm --network=hostnet docker --host=m1 service ls
+
+echo
+$amps service ls
+echo
+
+# sanity service lookup and ping checks after starting monitoring stack
+echo "test nats availability"
+lookup nats
+checkexit $? "service lookup check failed: nats"
+ok "service lookup check succeeded: nats"
+kurl nats:8222
+checkexit $? "service ping check failed: nats"
+ok "service ping check succeeded: nats"
+
+echo "test elasticsearch availability"
+lookup elasticsearch
+checkexit $? "service lookup check failed: elasticsearch"
+ok "service lookup check succeeded: elasticsearch"
+kurl elasticsearch:9200
+checkexit $? "service ping check failed: elasticsearch"
+ok "service ping check succeeded: elasticsearch"
 
 SUCCESS=1
 

--- a/hack/servicescheck
+++ b/hack/servicescheck
@@ -40,11 +40,16 @@ dumplogs() {
 }
 
 SECONDS=0
+trace=0
 while true; do
   check
   [[ $? -eq 0 ]] && exit 0
-  [[ $(($SECONDS % 30)) -eq 0 ]] && $amps service ls
   [[ "${TIMEOUT}" -eq 0 || "${SECONDS}" -gt "${TIMEOUT}" ]] && dumplogs && exit 1
   sleep "${INTERVAL}"
+  # heartbeat trace so CI builds don't time out
+  if [ $(($SECONDS - $trace)) -gt 10 ]; then
+    trace=$SECONDS
+    $amps service ls
+  fi
 done
 

--- a/stacks/amplifier.stack.yml
+++ b/stacks/amplifier.stack.yml
@@ -15,7 +15,6 @@ services:
     image: appcelerator/amplifier:local
     networks:
       - default
-      - infrastructure
     ports:
       - "50101:50101"
     volumes:
@@ -33,15 +32,13 @@ services:
 
   etcd:
     image: appcelerator/etcd:3.1.5-1
+    networks:
+      - default
     command:
       - "--listen-client-urls"
       - "http://0.0.0.0:2379"
       - "--advertise-client-urls"
       - "http://etcd:2379"
-    networks:
-      infrastructure:
-        aliases:
-          - "etcd"
     volumes:
       - amp-etcd:/data
     labels:

--- a/stacks/monitoring-agent.stack.yml
+++ b/stacks/monitoring-agent.stack.yml
@@ -12,6 +12,8 @@ services:
 
   agent:
     image: appcelerator/agent:local
+    networks:
+      - default
     deploy:
       mode: global
       labels:
@@ -21,5 +23,3 @@ services:
     volumes:
       - ampagent:/containers
       - /var/run/docker.sock:/var/run/docker.sock
-    networks:
-      - default

--- a/stacks/monitoring-aux.stack.yml
+++ b/stacks/monitoring-aux.stack.yml
@@ -9,6 +9,8 @@ services:
 
   ampbeat:
     image: appcelerator/ampbeat:local
+    networks:
+      - default
     deploy:
       mode: replicated
       replicas: 1
@@ -16,11 +18,11 @@ services:
         io.amp.role: "infrastructure"
     labels:
       io.amp.role: "infrastructure"
-    networks:
-      - default
 
   kibana:
     image: appcelerator/kibana:5.3.0-1
+    networks:
+      - default
     deploy:
       mode: replicated
       replicas: 1
@@ -34,5 +36,3 @@ services:
     ]
     ports:
       - "5601:5601"
-    networks:
-      - default

--- a/stacks/monitoring-core.stack.yml
+++ b/stacks/monitoring-core.stack.yml
@@ -9,6 +9,8 @@ services:
 
   elasticsearch:
     image: appcelerator/elasticsearch-amp:5.3.0
+    networks:
+      - default
     deploy:
       mode: replicated
       replicas: 1
@@ -16,11 +18,11 @@ services:
         io.amp.role: "infrastructure"
     labels:
       io.amp.role: "infrastructure"
-    networks:
-      - default
 
   nats:
     image: appcelerator/amp-nats-streaming:v0.3.8
+    networks:
+      - default
     deploy:
       mode: replicated
       replicas: 1
@@ -28,7 +30,5 @@ services:
         io.amp.role: "infrastructure"
     labels:
       io.amp.role: "infrastructure"
-    networks:
-      - default
     ports:
       - "4222:4222"


### PR DESCRIPTION
This PR enhances the service lookup and ping checks/output. It passes consistently on a Mac, but continues to fail on linux / travis due to service connectivity issues, despite dns lookups succeeding.