### PR TITLE
[new monitoring] add stats cli

### DIFF
--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -75,10 +75,7 @@ func (s *Stats) statsCurrentQuery(ctx context.Context, req *StatsRequest) (*Stat
 // execute a historic stats request
 func (s *Stats) statsHistoricQuery(ctx context.Context, req *StatsRequest) (*StatsReply, error) {
 	if req.Period == "" {
-		req.Period = "now-10m"
-	}
-	if req.TimeGroup == "" {
-		req.Period = "1m"
+		return nil, fmt.Errorf("Historical statistics (using --time-group option) should set --period option explicitelly")
 	}
 	boolQuery := s.createBoolQuery(req, req.Period)
 	agg := s.createHistoAggreggation(req)
@@ -347,8 +344,12 @@ func (s *Stats) validateTimeGroup(rg string) error {
 		return fmt.Errorf("time-group last digit should be in [y,M,w,d,h,m,s]")
 	}
 	mid := rg[0 : len(rg)-1]
-	if _, err := strconv.Atoi(mid); err != nil {
+	num, err := strconv.Atoi(mid)
+	if err != nil {
 		return fmt.Errorf("the time-group doesn't start by a number")
+	}
+	if last == "s" && num < 3 {
+		return fmt.Errorf("to short time-group, it should be upper than 2s")
 	}
 	return nil
 }

--- a/cli/command/stats/stats.go
+++ b/cli/command/stats/stats.go
@@ -1,0 +1,363 @@
+package stats
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/appcelerator/amp/api/rpc/stats"
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+)
+
+type statsOpts struct {
+	container      bool
+	service        bool
+	node           bool
+	stack          bool
+	cpu            bool
+	mem            bool
+	io             bool
+	net            bool
+	period         string
+	timeGroup      string
+	timeZone       string
+	containerID    string
+	containerName  string
+	containerState string
+	serviceID      string
+	taskID         string
+	stackName      string
+	nodeID         string
+	follow         bool
+}
+
+var (
+	opts = &statsOpts{}
+)
+
+var displayGroupMap = map[string]string{
+	"container_short_name": "container",
+	"service_name":         "service",
+	"node_id":              "node",
+	"stack_name":           "stack",
+}
+
+// NewStatsCommand returns a new instance of the stats command.
+func NewStatsCommand(c cli.Interface) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats SERVICE",
+		Short: "Display amp statistics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getStats(c, args)
+		},
+	}
+	flags := cmd.Flags()
+	flags.BoolVar(&opts.container, "container", false, "Display stats on containers")
+	flags.BoolVar(&opts.service, "service", true, "Display stats on services")
+	flags.BoolVar(&opts.node, "node", false, "Display stats on nodes")
+	flags.BoolVar(&opts.stack, "stack", false, "Display stats on stacks")
+	//metrics
+	flags.BoolVar(&opts.cpu, "cpu", false, "Display cpu stats")
+	flags.BoolVar(&opts.mem, "mem", false, "Display memory stats")
+	flags.BoolVar(&opts.io, "io", false, "Display disk io stats")
+	flags.BoolVar(&opts.net, "net", false, "Display net rx/tx stats")
+	//historic
+	flags.StringVar(&opts.period, "period", "", `Historic period of metrics extraction, for instance: "now-1d", "now-10h", with y=year, M=month, w=week, d=day, h=hour, m=minute, s=second`)
+	flags.StringVar(&opts.timeGroup, "time-group", "", `Historic extraction by time group, for instance: "1d", "3h", , with y=year, M=month, w=week, d=day, h=hour, m=minute, s=second`)
+	flags.StringVar(&opts.timeZone, "time-zone", "", `Historic timeshift: "-01:00", "+03:00", ...`)
+	//filters
+	flags.StringVar(&opts.containerID, "container-id", "", "Filter on container id")
+	flags.StringVar(&opts.containerName, "container-name", "", "Filter on container name")
+	flags.StringVar(&opts.containerState, "container-state", "", "Filter on container state")
+	flags.StringVar(&opts.serviceID, "service-id", "", "Filter on service id")
+	flags.StringVar(&opts.stackName, "stack-name", "", "Filter on stack name")
+	flags.StringVar(&opts.taskID, "task-id", "", "Filter on task id")
+	flags.StringVar(&opts.nodeID, "node-id", "", "Filter on node id")
+	//Stream flag
+	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow stats output")
+	return cmd
+}
+
+// Stats displays resource usage statistcs
+func getStats(c cli.Interface, args []string) error {
+	var query = &stats.StatsRequest{}
+
+	//Set filters
+	query.FilterContainerId = opts.containerID
+	query.FilterContainerName = opts.containerName
+	query.FilterContainerState = opts.containerState
+	query.FilterServiceId = opts.serviceID
+	query.FilterTaskId = opts.taskID
+	query.FilterStackName = opts.stackName
+	query.FilterNodeId = opts.nodeID
+
+	//set main group
+	if len(args) > 0 {
+		query.Group = "service_name"
+		query.FilterServiceName = args[0]
+	} else {
+		if opts.container {
+			query.Group = "container_short_name"
+		} else if opts.node {
+			query.Group = "node_id"
+		} else if opts.stack {
+			query.Group = "stack_name"
+		} else {
+			query.Group = "service_name"
+		}
+	}
+
+	//set metrics
+	query.StatsCpu = opts.cpu
+	query.StatsMem = opts.mem
+	query.StatsIo = opts.io
+	query.StatsNet = opts.net
+	if !opts.cpu && !opts.mem && !opts.io && !opts.net {
+		query.StatsCpu = true
+		query.StatsMem = true
+		query.StatsIo = true
+		query.StatsNet = true
+	}
+
+	//Set historic parameters
+	query.Period = opts.period
+	query.TimeGroup = opts.timeGroup
+	query.TimeZone = opts.timeZone
+
+	//set default for period only for current statistics
+	if query.TimeGroup == "" && query.Period == "" {
+		query.Period = "now-10s"
+	}
+
+	// Execute query regarding discriminator
+	ctx := context.Background()
+	conn, err := c.ClientConn()
+	if err != nil {
+		return err
+	}
+	client := stats.NewStatsClient(conn)
+	r, err := client.StatsQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	if r.Entries == nil {
+		fmt.Println("No result found")
+		return nil
+	}
+	if query.TimeGroup != "" {
+		displayHistoricResult(query, r, c, true)
+	} else {
+		displayCurrentResult(query, r, c)
+	}
+	if opts.follow {
+		if query.TimeGroup == "" {
+			if err := continueCurrentExecution(ctx, c, client, query); err != nil {
+				return err
+			}
+		} else {
+			if err := continueHistoricExecution(ctx, c, client, query, r); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Display current stats
+func displayCurrentResult(query *stats.StatsRequest, result *stats.StatsReply, c cli.Interface) {
+	if opts.follow {
+		c.Console().Printf("\033[2J\033[0;0H")
+	}
+	w := tabwriter.NewWriter(c.Out(), 0, 8, 2, ' ', 0)
+	c.Console().Println(getGroupByFilterText(query))
+	fmt.Fprintln(w, getStatTitle(query))
+	for _, entry := range result.Entries {
+		fmt.Fprintln(w, getOneStatLine(query, entry))
+	}
+	w.Flush()
+}
+
+// Display historic stats
+func displayHistoricResult(query *stats.StatsRequest, result *stats.StatsReply, c cli.Interface, displayTitle bool) {
+	w := tabwriter.NewWriter(c.Out(), 0, 8, 2, ' ', 0)
+	if displayTitle {
+		c.Console().Println(getGroupByFilterText(query))
+		fmt.Fprintln(w, getStatTitle(query))
+	}
+	for _, entry := range result.Entries {
+		fmt.Fprintln(w, getOneStatLine(query, entry))
+	}
+	w.Flush()
+}
+
+// get one line of the stat table
+func getOneStatLine(query *stats.StatsRequest, entry *stats.MetricsEntry) string {
+	line := entry.Group
+	if query.StatsCpu {
+		line = fmt.Sprintf("%s\t%.2f%%", line, entry.Cpu.TotalUsage)
+	}
+	if query.StatsMem {
+		line = fmt.Sprintf("%s\t%s\t%s\t%.1f%%", line, formatBytes(entry.Mem.Usage), formatBytes(entry.Mem.Limit), entry.Mem.UsageP)
+	}
+	if query.StatsIo {
+		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Io.Read), formatBytes(entry.Io.Write))
+	}
+	if query.StatsNet {
+		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Net.RxBytes), formatBytes(entry.Net.TxBytes))
+	}
+	return line
+}
+
+// get The title of the table to display
+func getStatTitle(query *stats.StatsRequest) string {
+	title := strings.ToUpper(getDisplayedGroup(query.Group))
+	if query.TimeGroup != "" {
+		title = "Date"
+	}
+	if query.StatsCpu {
+		title = fmt.Sprintf("%s\tCPU %%", title)
+	}
+	if query.StatsMem {
+		title = fmt.Sprintf("%s\tMEM USAGE\tLIMIT\tMEM %%", title)
+	}
+	if query.StatsIo {
+		title = fmt.Sprintf("%s\tIO READ\tIO WRITE", title)
+	}
+	if query.StatsNet {
+		title = fmt.Sprintf("%s\tNET RX\t NET TX", title)
+	}
+	return title
+}
+
+func getDisplayedGroup(group string) string {
+	val, ok := displayGroupMap[group]
+	if !ok {
+		return "unknow"
+	}
+	return val
+}
+
+// get request explaination text to display at fist
+func getGroupByFilterText(query *stats.StatsRequest) string {
+	text := fmt.Sprintf("Stats on %ss period=%s", getDisplayedGroup(query.Group), query.Period)
+	if query.TimeGroup != "" {
+		text = fmt.Sprintf("Stats historic period=%s timeGroup=%s", query.Period, query.TimeGroup)
+	}
+	filters := []string{}
+	if query.FilterContainerId != "" {
+		filters = append(filters, fmt.Sprintf("ContainerId=%s", query.FilterContainerId))
+	}
+	if query.FilterContainerName != "" {
+		filters = append(filters, fmt.Sprintf("ContainerName=%s", query.FilterContainerName))
+	}
+	if query.FilterContainerState != "" {
+		filters = append(filters, fmt.Sprintf("ContainerState=%s", query.FilterContainerState))
+	}
+	if query.FilterServiceName != "" {
+		filters = append(filters, fmt.Sprintf("ServiceName=%s", query.FilterServiceName))
+	}
+	if query.FilterServiceId != "" {
+		filters = append(filters, fmt.Sprintf("ServiceId=%s", query.FilterServiceId))
+	}
+	if query.FilterStackName != "" {
+		filters = append(filters, fmt.Sprintf("StackName=%s", query.FilterStackName))
+	}
+	if query.FilterTaskId != "" {
+		filters = append(filters, fmt.Sprintf("TaskId=%s", query.FilterTaskId))
+	}
+	if query.FilterNodeId != "" {
+		filters = append(filters, fmt.Sprintf("NodeId=%s", query.FilterNodeId))
+	}
+	if len(filters) == 0 {
+		return fmt.Sprintf("%s, No filter", text)
+	}
+	for i, filter := range filters {
+		if i == 0 {
+			if len(filters) > 1 {
+				text = fmt.Sprintf("%s, Filters: %s", text, filter)
+			} else {
+				text = fmt.Sprintf("%s, Filter: %s", text, filter)
+			}
+		} else {
+			text = fmt.Sprintf("%s and %s", text, filter)
+		}
+	}
+	return text
+}
+
+// format the number of bytes into number of Kb, Mb, Gb, ...
+func formatBytes(vali int64) string {
+	val := float64(vali)
+	if val == 0 {
+		return "0"
+	} else if val < 1 {
+		return "0.0"
+	} else if val < 1024 {
+		return fmt.Sprintf("%.1f B", val)
+	} else if val < 1048576 {
+		return fmt.Sprintf("%.1f KB", val/1024)
+	} else if val < 1073741824 {
+		return fmt.Sprintf("%.1f MB", val/1048576)
+	}
+	return fmt.Sprintf("%.1f GB", val/1073741824)
+}
+
+func continueCurrentExecution(ctx context.Context, c cli.Interface, client stats.StatsClient, query *stats.StatsRequest) error {
+	for {
+		time.Sleep(2 * time.Second)
+		r, err := client.StatsQuery(ctx, query)
+		if err != nil {
+			return err
+		}
+		displayCurrentResult(query, r, c)
+	}
+}
+
+func continueHistoricExecution(ctx context.Context, c cli.Interface, client stats.StatsClient, query *stats.StatsRequest, result *stats.StatsReply) error {
+	sleepTime, err := getHistoricSleepDuration(query.TimeGroup)
+	if err != nil {
+		return fmt.Errorf("Internal error: following is broken")
+	}
+	if sleepTime < 0 {
+		c.Console().Println("Too long time-groupd to way for the next line: following aborted")
+	}
+	lastDate := result.Entries[len(result.Entries)-1].Group
+	currentDate, err := time.Parse("2006-01-02T15:04:05", lastDate)
+	if err != nil {
+		return fmt.Errorf("Get a bad date format: %v", err)
+	}
+	for {
+		time.Sleep(sleepTime)
+		r, err := client.StatsQuery(ctx, query)
+		if err != nil {
+			return err
+		}
+		currentDate = currentDate.Add(sleepTime)
+		if len(r.Entries) > 1 {
+			r.Entries = r.Entries[len(r.Entries)-1 : len(r.Entries)]
+			r.Entries[0].Group = currentDate.Format("2006-01-02T15:04:05")
+		}
+		displayHistoricResult(query, r, c, false)
+	}
+}
+
+func getHistoricSleepDuration(timeGroup string) (time.Duration, error) {
+	last := timeGroup[len(timeGroup)-1 : len(timeGroup)]
+	num, err := strconv.Atoi(timeGroup[0 : len(timeGroup)-1])
+	if err != nil {
+		return 0, err
+	}
+	if last == "y" || last == "M" || last == "w" || last == "d" {
+		return -1, nil
+	}
+	if last == "h" {
+		return time.Hour * time.Duration(num), nil
+	} else if last == "m" {
+		return time.Minute * time.Duration(num), nil
+	}
+	return time.Second * time.Duration(num), nil
+}

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -7,6 +7,7 @@ import (
 	"github.com/appcelerator/amp/cli/command/logs"
 	"github.com/appcelerator/amp/cli/command/org"
 	"github.com/appcelerator/amp/cli/command/password"
+	"github.com/appcelerator/amp/cli/command/stats"
 	"github.com/appcelerator/amp/cli/command/team"
 	"github.com/appcelerator/amp/cli/command/user"
 	"github.com/appcelerator/amp/cli/command/version"
@@ -69,6 +70,9 @@ func addCommands(cmd *cobra.Command, c cli.Interface) {
 
 		// user
 		user.NewUserCommand(c),
+
+		// Stats
+		stats.NewStatsCommand(c),
 
 		// version
 		version.NewVersionCommand(c),

--- a/docs/latest/stats.md
+++ b/docs/latest/stats.md
@@ -1,0 +1,104 @@
+
+### Stats
+
+The `amp stats` command is used to query or stream statistics. It provides group, filtering and historic options to manage what is presented.
+
+    $ amp stats --help
+
+    Usage:	amp stats SERVICE
+
+    Compute statistics for the service name SERVICE
+    Without SERVICE name, display the statistics of all available services
+    Options:
+
+      type of statistics:
+          --cpu                     display cpu statistics
+          --mem                     display memory statistics
+          --net                     display net tx/rx statistics
+          --io                      display disk io statistics
+          if no one of the options above is set then display all statistics, cpu, meme, net, io
+
+      statistics group:
+          --container               present a list all available containers with their statistics
+          --node                    present a list all available nodes with their statistics
+          --service                 present a list all available services with their statistics
+          --stack                   present a list all available stacks with their statistics
+          default is service
+
+      filters:
+           --container-id string     select only the container having their id starting by the given value
+           --container-name string   select only the container having their name starting by the given value
+           --container-state string  select only the container having their state starting by the given value
+           --service-id string       select only the services having their id starting by the given value
+           --stack-name string       select only the stacks having their name starting by the given value
+           --task-id string          select only the task having their id starting by the given value
+           --node-id string          select only the node having their name starting by the given value
+           if several filters are used they are considered linked by a logical AND
+
+      period of computing:
+          --period string            define the period of time inside which statistics are computed     
+
+          the given value should have the following format: now-xt
+          where:
+            - x is a number
+            - t is a time unit amount: y=year, M=month, w=week, d=day, h=hour, m=minute, s=second
+          for instance, now-10h means that the period starts from 10 hours in the past until now
+          By default, the period is "now-10s"
+
+      historic statistics:
+          historic statistics display statistics by time period,
+          where current statistic displays the last available statistics in the period one shot.
+
+          --time-group string       define the period of time use to group statistics
+
+          the given value should have the following format: xt
+          where:
+            - x is a number
+            - t is a time unit amount: y=year, M=month, w=week, d=day, h=hour, m=minute, s=second
+          for instance, 10s means 10 seconds, 3d means 3 days, ...
+          there is no default for time-group and no default for period if time-group is set
+          then for historic stats time-group and period should be set all together
+
+     -other options
+         -f --follow                if set the statistics are continually computed
+
+         Current statistics are recomputed every 2 seconds
+         Historic statistics add new lines depending of the time group.            
+
+
+A few useful examples:
+
+* To compute and follow stats by services:
+```
+  $ amp stats -f
+```
+
+* To compute and follow the stats for a specific service:
+```
+  $ amp stats -f etcd
+```
+
+* To compute only cpu and mem statistics for all stakcs
+```
+  $ amp stats --stack --cpu --mem
+```
+
+* To compute stats by node
+```
+  $ amp stats --node
+```
+
+* To compute stats for a stack on a specific node
+```
+  $ amp stats --stack-name monitoring --node-id aNodeId
+```
+
+* To compute historic stats for a service
+```
+  $ amp stats --period now-1m --time-group=10s elasticsearch
+```
+
+* To compute historic stats for a stack and follow to see a new line every 3 seconds
+```
+  $ amp stats --stack-name monitoring --period now-30s --time-group=3s -f
+```


### PR DESCRIPTION

see: docs/latest/stats.md

## How to test
    $ ampmake clean build
    $ hack/deploy

Then test `amp stats` commands, for instances:

* To compute and follow stats by services:
```
  $ amp stats -f
```

* To compute and follow the stats for a specific service:
```
  $ amp stats -f etcd
```

* To compute only cpu and mem statistics for all stakcs
```
  $ amp stats --stack --cpu --mem
```

* To compute stats by node
```
  $ amp stats --node
```

* To compute stats for a stack on a specific node
```
  $ amp stats --stack-name monitoring --node-id aNodeId
```

* To compute historic stats for a service
```
  $ amp stats --period now-1m --time-group=10s elasticsearch
```

* To compute historic stats for a stack and follow to see a new line every 3 seconds
```
  $ amp stats --stack-name monitoring --period now-30s --time-group=3s -f
```
 
 