### PR TITLE
Adding an error if the email API key has not been provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,9 @@ $(AMPLTARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(AMPLSRC)
 	@go build -ldflags $(LDFLAGS) -o $(AMPLTARGET) $(REPO)/$(CMDDIR)/$(AMPL)
 
 build-server: $(AMPLTARGET)
-	@cp -f /root/.config/amp/amplifier.yaml cmd/amplifier &> /dev/null || touch cmd/amplifier/amplifier.yaml
+	@cp -f /root/.config/amp/amplifier.y*ml cmd/amplifier &> /dev/null || (echo "!! Warning !! You have no configuration file for amplifier, emails will not work" && touch cmd/amplifier/amplifier.yml)
 	@$(DOCKER_CMD) build -t $(AMPLIMG) $(CMDDIR)/$(AMPL) || (rm -f $(AMPLTARGET); exit 1)
-	@rm -f cmd/amplifier/amplifier.yaml
+	@rm -f cmd/amplifier/amplifier.yml
 
 rebuild-server: clean-server build-server
 

--- a/cmd/amplifier/Dockerfile
+++ b/cmd/amplifier/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 RUN apk --no-cache add ca-certificates
 COPY amplifier.alpine /usr/local/bin/amplifier
-COPY amplifier.yaml /etc/atomiq/amplifier.yaml
+COPY amplifier.yml /etc/atomiq/amplifier.yml
 ENTRYPOINT [ "amplifier" ]

--- a/pkg/mail/mailer.go
+++ b/pkg/mail/mailer.go
@@ -224,6 +224,9 @@ func (m *Mailer) SendTemplateEmail(to string, templateEmailName string, variable
 
 // SendMail send an email to "to" with subject and body, use configuration
 func (m *Mailer) SendMail(to string, subject string, isHTML bool, body string) error {
+	if m.apiKey == "" {
+		return fmt.Errorf("SendGrid API key is empty")
+	}
 	from := mail.NewEmail("amp", m.emailSender)
 	target := mail.NewEmail(strings.Split(to, "@")[0], to)
 	cType := "text/plain"


### PR DESCRIPTION
Amplifier now returns a fatal error is the SendGrid key has not been set.