### PR TITLE
[CLI] Certain amp commands take a flag whereas they should take an argument

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -8,7 +8,7 @@ import (
 // NewCreateCommand returns a new instance of the create command for bootstrapping a local development cluster.
 func NewCreateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
+		Use:     "create [OPTIONS]",
 		Short:   "Create a local amp cluster",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -8,7 +8,7 @@ import (
 // NewUpdateCommand returns a new instance of the update command for updating local development cluster.
 func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "update",
+		Use:     "update [OPTIONS]",
 		Short:   "Update a local amp cluster",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/login/login.go
+++ b/cli/command/login/login.go
@@ -24,7 +24,7 @@ var (
 // NewLoginCommand returns a new instance of the login command.
 func NewLoginCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "login",
+		Use:     "login [OPTIONS]",
 		Short:   "Login to account",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/logs/logs.go
+++ b/cli/command/logs/logs.go
@@ -30,7 +30,7 @@ var (
 // NewLogsCommand returns a new instance of the logs command.
 func NewLogsCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logs SERVICE",
+		Use:   "logs [OPTIONS] SERVICE",
 		Short: "Fetch log entries matching provided criteria",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return getLogs(c, args)

--- a/cli/command/org/create.go
+++ b/cli/command/org/create.go
@@ -22,7 +22,7 @@ var (
 // NewOrgCreateCommand returns a new instance of the create organization command.
 func NewOrgCreateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
+		Use:     "create [OPTIONS]",
 		Short:   "Create organization",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/org/list.go
+++ b/cli/command/org/list.go
@@ -23,18 +23,18 @@ var (
 // NewOrgListCommand returns a new instance of the list organization command.
 func NewOrgListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Short:   "List organization",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listOrg(c, cmd)
+			return listOrg(c)
 		},
 	}
 	cmd.Flags().BoolVarP(&listOrgOptions.quiet, "quiet", "q", false, "Only display organization name")
 	return cmd
 }
 
-func listOrg(c cli.Interface, cmd *cobra.Command) error {
+func listOrg(c cli.Interface) error {
 	conn, err := c.ClientConn()
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))

--- a/cli/command/org/member/add.go
+++ b/cli/command/org/member/add.go
@@ -22,7 +22,7 @@ var (
 // NewOrgAddMemCommand returns a new instance of the add organization member command.
 func NewOrgAddMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add",
+		Use:     "add [OPTIONS]",
 		Short:   "Add member to organization",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/org/member/remove.go
+++ b/cli/command/org/member/remove.go
@@ -22,7 +22,7 @@ var (
 // NewOrgRemoveMemCommand returns a new instance of the remove organization member command.
 func NewOrgRemoveMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "rm",
+		Use:     "rm [OPTIONS]",
 		Short:   "Remove member from organization",
 		Aliases: []string{"del"},
 		PreRunE: cli.NoArgs,

--- a/cli/command/org/member/role.go
+++ b/cli/command/org/member/role.go
@@ -24,7 +24,7 @@ var (
 // NewOrgChangeMemRoleCommand returns a new instance of the organization member role change command.
 func NewOrgChangeMemRoleCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "role",
+		Use:     "role [OPTIONS]",
 		Short:   "Change member role",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/password/change.go
+++ b/cli/command/password/change.go
@@ -22,7 +22,7 @@ var (
 // NewChangeCommand returns a new instance of the change command.
 func NewChangeCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "change",
+		Use:     "change [OPTIONS]",
 		Short:   "Change password",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/password/set.go
+++ b/cli/command/password/set.go
@@ -22,7 +22,7 @@ var (
 // NewSetCommand returns a new instance of the set command.
 func NewSetCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "set",
+		Use:     "set [OPTIONS]",
 		Short:   "Set password",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/stats/stats.go
+++ b/cli/command/stats/stats.go
@@ -49,7 +49,7 @@ var displayGroupMap = map[string]string{
 // NewStatsCommand returns a new instance of the stats command.
 func NewStatsCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stats SERVICE",
+		Use:   "stats [OPTIONS] SERVICE",
 		Short: "Display amp statistics",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return getStats(c, args)
@@ -82,7 +82,7 @@ func NewStatsCommand(c cli.Interface) *cobra.Command {
 	return cmd
 }
 
-// Stats displays resource usage statistcs
+// Stats displays resource usage statistics
 func getStats(c cli.Interface, args []string) error {
 	var query = &stats.StatsRequest{}
 

--- a/cli/command/team/create.go
+++ b/cli/command/team/create.go
@@ -22,7 +22,7 @@ var (
 // NewTeamCreateCommand returns a new instance of the team create command.
 func NewTeamCreateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
+		Use:     "create [OPTIONS]",
 		Short:   "Create team",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/get.go
+++ b/cli/command/team/get.go
@@ -23,7 +23,7 @@ var (
 // NewTeamGetCommand returns a new instance of the get team command.
 func NewTeamGetCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "get",
+		Use:     "get [OPTIONS]",
 		Short:   "Get team",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/member/add.go
+++ b/cli/command/team/member/add.go
@@ -23,7 +23,7 @@ var (
 // NewAddTeamMemCommand returns a new instance of the add team member command.
 func NewAddTeamMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add",
+		Use:     "add [OPTIONS]",
 		Short:   "Add member to team",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/member/list.go
+++ b/cli/command/team/member/list.go
@@ -24,7 +24,7 @@ var (
 // NewListTeamMemCommand returns a new instance of the list team member command.
 func NewListTeamMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Short:   "List members",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/member/remove.go
+++ b/cli/command/team/member/remove.go
@@ -23,7 +23,7 @@ var (
 // NewRemoveTeamMemCommand returns a new instance of the remove team member command.
 func NewRemoveTeamMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "rm",
+		Use:     "rm [OPTIONS]",
 		Short:   "Remove member from team",
 		Aliases: []string{"del"},
 		PreRunE: cli.NoArgs,

--- a/cli/command/team/member/role.go
+++ b/cli/command/team/member/role.go
@@ -25,7 +25,7 @@ var (
 // NewTeamChangeMemRoleCommand returns a new instance of the team member role change command.
 func NewTeamChangeMemRoleCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "role",
+		Use:     "role [OPTIONS]",
 		Short:   "Change member role",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/remove.go
+++ b/cli/command/team/remove.go
@@ -22,7 +22,7 @@ var (
 // NewTeamRemoveCommand returns a new instance of the team remove command.
 func NewTeamRemoveCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "rm",
+		Use:     "rm [OPTIONS]",
 		Short:   "Remove team",
 		Aliases: []string{"del"},
 		PreRunE: cli.NoArgs,

--- a/cli/command/user/list.go
+++ b/cli/command/user/list.go
@@ -22,18 +22,18 @@ var (
 // NewListUserCommand returns a new instance of the list user command.
 func NewListUserCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Short:   "List users",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listUser(c, cmd)
+			return listUser(c)
 		},
 	}
 	cmd.Flags().BoolVarP(&listUserOptions.quiet, "quiet", "q", false, "Only display user names")
 	return cmd
 }
 
-func listUser(c cli.Interface, cmd *cobra.Command) error {
+func listUser(c cli.Interface) error {
 	request := &account.ListUsersRequest{}
 	conn, err := c.ClientConn()
 	if err != nil {

--- a/cli/command/user/signup.go
+++ b/cli/command/user/signup.go
@@ -23,7 +23,7 @@ var (
 // NewSignUpCommand returns a new instance of the signup command.
 func NewSignUpCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "signup",
+		Use:     "signup [OPTIONS]",
 		Short:   "Signup for a new account",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/required.go
+++ b/cli/required.go
@@ -23,3 +23,18 @@ func NoArgsCustom(errstr string) func(*cobra.Command, []string) error {
 		return fmt.Errorf(errstr, args[0])
 	}
 }
+
+// ExactArgs returns an error if the exact number of args are not passed
+func ExactArgs(num int) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == num {
+			return nil
+		}
+		return fmt.Errorf(
+			"\"%s\" requires exactly %d argument(s).\nSee '%s --help'",
+			cmd.CommandPath(),
+			num,
+			cmd.CommandPath(),
+		)
+	}
+}

--- a/docs/current/cluster.md
+++ b/docs/current/cluster.md
@@ -1,4 +1,4 @@
-### Cluster Management Operations
+### Cluster Management
 
 The `amp cluster` command manages all cluster-related operations for AMP.
 
@@ -27,13 +27,13 @@ The `amp cluster` command manages all cluster-related operations for AMP.
 ```
     $ amp cluster create
 ```
-    [_if no flags are passed to the command, a cluster with default number of worker and manager nodes is created. See `amp cluster create --help` for more options._]
+    [If no flags are passed to the command, a cluster with default number of worker and manager nodes is created. See `amp cluster create --help` for more options.]
 
 * To update a cluster with specific number of worker and manager nodes:
 ```
     $ amp cluster update
 ```
-    [_See `amp cluster update --help` for options._]
+    [See `amp cluster update --help` for options.]
 
 * To retrieve details about a cluster:
 ```

--- a/docs/current/logs.md
+++ b/docs/current/logs.md
@@ -21,7 +21,7 @@ The `amp logs` command is used to query or stream logs. It provides useful filte
           --stack string       Filter by the given stack
 
 
-A few useful examples:
+### Examples
 
 * To fetch and follow all the logs:
 ```

--- a/docs/current/org.md
+++ b/docs/current/org.md
@@ -1,4 +1,4 @@
-### Organization Management Commands
+### Organization Management
 
 The `amp org` command manages all organization related operations for AMP.
 
@@ -70,6 +70,8 @@ To be able to perform any organization related operations, you must be logged in
 
     Run 'amp org member COMMAND --help' for more information on a command.
 ```
+
+#### Examples
 
 * To add a member to an organization:
 ```

--- a/docs/current/password.md
+++ b/docs/current/password.md
@@ -1,4 +1,4 @@
-### Password management
+### Password Management
 
 The `amp password` command manages password-related operations for any AMP account.
 
@@ -22,18 +22,19 @@ The `amp password` command manages password-related operations for any AMP accou
 
 ### Examples
 
-* To update current password -
+* To update current password:
 ```
     $ amp password change
 ```
 
-* To reset password -
+* To reset password:
 ```
     $ amp password reset
-    [an email with instructions to reset password will be sent]
 ```
+    [An email with instructions to reset password will be sent to the registered email address.]
 
-* To set a new password -
+
+* To set a new password:
 ```
     $ amp password set
 ```

--- a/docs/current/stats.md
+++ b/docs/current/stats.md
@@ -66,7 +66,7 @@ The `amp stats` command is used to query or stream statistics. It provides group
          Historic statistics add new lines depending of the time group.            
 
 
-A few useful examples:
+### Examples
 
 * To compute and follow stats by services:
 ```
@@ -78,27 +78,27 @@ A few useful examples:
   $ amp stats -f etcd
 ```
 
-* To compute only cpu and mem statistics for all stakcs
+* To compute only cpu and mem statistics for all stacks:
 ```
   $ amp stats --stack --cpu --mem
 ```
 
-* To compute stats by node
+* To compute stats by node:
 ```
   $ amp stats --node
 ```
 
-* To compute stats for a stack on a specific node
+* To compute stats for a stack on a specific node:
 ```
   $ amp stats --stack-name monitoring --node-id aNodeId
 ```
 
-* To compute historic stats for a service
+* To compute historic stats for a service:
 ```
   $ amp stats --period now-1m --time-group=10s elasticsearch
 ```
 
-* To compute historic stats for a stack and follow to see a new line every 3 seconds
+* To compute historic stats for a stack and follow to see a new line every 3 seconds:
 ```
   $ amp stats --stack-name monitoring --period now-30s --time-group=3s -f
 ```

--- a/docs/current/team.md
+++ b/docs/current/team.md
@@ -1,4 +1,4 @@
-### Team Management Commands
+### Team Management
 
 The `amp team` command manages all team related operations for AMP.
 
@@ -70,6 +70,8 @@ To be able to perform any team related operations, you must be logged in to AMP 
     Run 'amp team member COMMAND --help' for more information on a command.
 ```
 
+#### Examples
+
 * To add a member to a team:
 ```
     $ amp team member add
@@ -78,6 +80,11 @@ To be able to perform any team related operations, you must be logged in to AMP 
 * To list members in a team:
 ```
     $ amp team member ls
+```
+
+* To change role of a member in a team:
+```
+    $ amp team member role
 ```
 
 * To remove a member from a team:

--- a/docs/current/user.md
+++ b/docs/current/user.md
@@ -1,4 +1,4 @@
-### User Management Commands
+### User Management
 
 The `amp user` command manages all user related operations for AMP.
 
@@ -25,41 +25,41 @@ The `amp user` command manages all user related operations for AMP.
 
 ### Examples
 
-* To create a user -
+* To create a user:
 ```
     $ amp user signup
 ```
-    [_an email with a verification token will be sent to the given email address_]
+    [An email with a verification token will be sent to the given email address.]
 
-* To verify newly created account -
+* To verify newly created account:
 ```
     $ amp user verify
 ```
 
-* To retrieve account name -
+* To retrieve account name:
 ```
     $ amp user forgot-login
 ```
-    [_an email with the username will be sent to the registered email address_]
+    [An email with the username will be sent to the registered email address.]
 
-* To retrieve a list of users -
+* To retrieve a list of users:
 ```
     $ amp user ls
 ```
 
-* To retrieve details of a specific user -
+* To retrieve details of a specific user:
 ```
     $ amp user get
 ```
 
-* To remove of a user -
+* To remove of a user:
 ```
     $ amp user rm
     [or]
     $ amp user del
 ```
 
-* To login to AMP -
+* To login to AMP:
 ```
     $ amp login
 ```

--- a/docs/current/version.md
+++ b/docs/current/version.md
@@ -1,4 +1,4 @@
-# version
+# Version
 
 The `amp version` command displays the current version of AMP.
 

--- a/pkg/mail/accountVerification.go
+++ b/pkg/mail/accountVerification.go
@@ -8,7 +8,7 @@ var accountVerificationBody = `
             <h2>Hi <b style="color:red">{accountName}</b>, thanks for joining AMP!</h2>
             <h3>You have successfully created an AMP account.</h3>
             <h3>Please validate your AMP account using the following command line:</h4>
-            <h4>amp user verify --token {token}</h4>
+            <h4>amp user verify {token}</h4>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Resolves #940 
This PR also contains minor updates to the docs and improved command usage as seen on the command help.