### PR TITLE
Fix lint warnings

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,7 +47,7 @@ func AgentInit(version, build string) error {
 		log.Fatalln("Unable to get hostname: ", err)
 	}
 	agent.natsStreaming = ns.NewClient(ns.DefaultURL, ns.ClusterID, os.Args[0]+"-"+hostname, time.Minute)
-	if err := agent.natsStreaming.Connect(); err != nil {
+	if err = agent.natsStreaming.Connect(); err != nil {
 		return err
 	}
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -27,8 +27,9 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
 	rootCmd.SetHelpCommand(helpCommand)
 
-	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+	// error can be safely ignored since we're only setting up and haven't yet added all expected flags
 	_ = rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 }
 
 // FlagErrorFunc prints an error message which matches the format of the

--- a/cli/in.go
+++ b/cli/in.go
@@ -53,7 +53,7 @@ func (i *InStream) SetRawTerminal() (err error) {
 // RestoreTerminal restores normal mode to the terminal
 func (i *InStream) RestoreTerminal() {
 	if i.state != nil {
-		_ = term.RestoreTerminal(i.fd, i.state) // nolint:
+		_ = term.RestoreTerminal(i.fd, i.state)
 	}
 }
 


### PR DESCRIPTION
Fixes a few lint warnings that only show up when running `make lint-fast`, not `ampmake lint-fast`. The reason for the discrepancy isn't clear and needs to be investigated (see #942); nevertheless, I decided to fix them.

```
$ make lint-fast
running subset of lint checks in fast mode
cli/cobra.go:31::warning: Errors unhandled.,LOW,HIGH (gas)
cli/in.go:56::warning: Errors unhandled.,LOW,HIGH (gas)
agent/agent.go:50::warning: declaration of "err" shadows declaration at agent.go:39 (vetshadow)
```

The two cli warnings remain after fixing. `ampmake lint-fast` shows no warnings.