### PR TITLE
Update version template, normal color

### DIFF
--- a/cli/command/version/version.go
+++ b/cli/command/version/version.go
@@ -2,9 +2,8 @@ package version
 
 import (
 	"bytes"
-	"runtime"
-
 	"fmt"
+	"runtime"
 
 	"github.com/appcelerator/amp/api/rpc/version"
 	"github.com/appcelerator/amp/cli"
@@ -33,14 +32,14 @@ type ClientVersionInfo struct {
 	Arch      string
 }
 
-var versionTemplate = `amp:
+var template = `Client:
  Version:       {{.Client.Version}}
  Build:         {{.Client.Build}}
  Address:       {{.Client.Address}}
  Go version:    {{.Client.GoVersion}}
  OS/Arch:       {{.Client.Os}}/{{.Client.Arch}}
 
-amplifier:      {{if .IsConnected}}
+Server:      {{if .IsConnected}}
  Version:       {{.Server.Version}}
  Build:         {{.Server.Build}}
  Go version:    {{.Server.GoVersion}}
@@ -60,7 +59,7 @@ func NewVersionCommand(c cli.Interface) *cobra.Command {
 
 // Print version info of client and server (if connected).
 func showVersion(c cli.Interface) error {
-	tmpl, err := templates.Parse(versionTemplate)
+	tmpl, err := templates.Parse(template)
 	if err != nil {
 		return fmt.Errorf("template parsing error: %v\n", err)
 	}

--- a/cli/console.go
+++ b/cli/console.go
@@ -26,7 +26,7 @@ const (
 var (
 	// DarkTheme defines colors appropriate for a dark terminal
 	DarkTheme = &Theme{
-		Normal:  color.New(color.FgWhite),
+		Normal:  color.New(),
 		Info:    color.New(color.FgHiBlack),
 		Warn:    color.New(color.FgYellow),
 		Error:   color.New(color.FgRed),
@@ -35,7 +35,7 @@ var (
 
 	// LightTheme defines colors appropriate for a light terminal
 	LightTheme = &Theme{
-		Normal:  color.New(color.FgBlue),
+		Normal:  color.New(),
 		Info:    color.New(color.FgBlack),
 		Warn:    color.New(color.FgYellow),
 		Error:   color.New(color.FgRed),


### PR DESCRIPTION
Normal color should be the terminal default color.
Version command updated to display "Client" and "Server" sections.

## Verification

```
$ amp version
Client:
 Version:       v0.6.0-dev
 Build:         0768dadf
 Address:       localhost:50101
 Go version:    go1.8
 OS/Arch:       darwin/amd64

Server:      
 Version:       v0.6.0-dev
 Build:         b485f3c7
 Go version:    go1.8.1
 OS/Arch:       linux/amd64
```

Output should be in default terminal color and now says `Client` (instead of `amp`) and `Server` (instead of `amplifier`).
