### PR TITLE
Server option

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -18,8 +18,8 @@ type Interface interface {
 	Err() io.Writer
 	ShowHelp(cmd *cobra.Command, args []string) error
 
-	Address() string
-	SetAddress(addr string)
+	Server() string
+	SetServer(server string)
 	ClientConn() (*grpc.ClientConn, error)
 
 	OnInitialize(initializers ...func())
@@ -59,14 +59,14 @@ func (c *cli) Build() string {
 	return c.Configuration.Build
 }
 
-// Address returns the address of the grpc api (host:port) used for the client connection.
-func (c *cli) Address() string {
-	return c.Configuration.Address
+// Server returns the address of the grpc api (host:port) used for the client connection.
+func (c *cli) Server() string {
+	return c.Configuration.Server
 }
 
-// SetAddress sets the address of the grpc api (host:port) used for the client connection.
-func (c *cli) SetAddress(addr string) {
-	c.Configuration.Address = addr
+// SetServer sets the address of the grpc api (host:port) used for the client connection.
+func (c *cli) SetServer(server string) {
+	c.Configuration.Server = server
 	c.clientConn = nil
 }
 
@@ -99,7 +99,7 @@ func (c *cli) OnInitialize(initializers ...func()) {
 func (c *cli) ClientConn() (*grpc.ClientConn, error) {
 	if c.clientConn == nil {
 		var err error
-		c.clientConn, err = NewClientConn(c.Address(), GetToken())
+		c.clientConn, err = NewClientConn(c.Server(), GetToken())
 		if err != nil {
 			return nil, err
 		}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,6 +19,7 @@ type Interface interface {
 	ShowHelp(cmd *cobra.Command, args []string) error
 
 	Address() string
+	SetAddress(addr string)
 	ClientConn() (*grpc.ClientConn, error)
 
 	OnInitialize(initializers ...func())
@@ -49,47 +50,53 @@ func NewCLI(in io.ReadCloser, out, err io.Writer, config *Configuration) Interfa
 }
 
 // Version returns the version of the CLI process that supplied this value at initialization.
-func (c cli) Version() string {
+func (c *cli) Version() string {
 	return c.Configuration.Version
 }
 
 // Build returns the build of the CLI process that supplied this value at initialization.
-func (c cli) Build() string {
+func (c *cli) Build() string {
 	return c.Configuration.Build
 }
 
 // Address returns the address of the grpc api (host:port) used for the client connection.
-func (c cli) Address() string {
+func (c *cli) Address() string {
 	return c.Configuration.Address
 }
 
+// SetAddress sets the address of the grpc api (host:port) used for the client connection.
+func (c *cli) SetAddress(addr string) {
+	c.Configuration.Address = addr
+	c.clientConn = nil
+}
+
 // In returns the reader used for stdin.
-func (c cli) In() *InStream {
+func (c *cli) In() *InStream {
 	return c.in
 }
 
 // Out returns the writer used for stdout.
-func (c cli) Out() *OutStream {
+func (c *cli) Out() *OutStream {
 	return c.out
 }
 
 // Err returns the writer used for stderr.
-func (c cli) Err() io.Writer {
+func (c *cli) Err() io.Writer {
 	return c.err
 }
 
 // Console returns the console for formatted printing.
-func (c cli) Console() *Console {
+func (c *cli) Console() *Console {
 	return c.console
 }
 
 // OnInitialize runs initializer functions before executing the command.
-func (c cli) OnInitialize(initializers ...func()) {
+func (c *cli) OnInitialize(initializers ...func()) {
 	cobra.OnInitialize(initializers...)
 }
 
 // ClientConn returns the grpc connection to the API.
-func (c cli) ClientConn() (*grpc.ClientConn, error) {
+func (c *cli) ClientConn() (*grpc.ClientConn, error) {
 	if c.clientConn == nil {
 		var err error
 		c.clientConn, err = NewClientConn(c.Address(), GetToken())
@@ -100,7 +107,7 @@ func (c cli) ClientConn() (*grpc.ClientConn, error) {
 	return c.clientConn, nil
 }
 
-func (c cli) ShowHelp(cmd *cobra.Command, args []string) error {
+func (c *cli) ShowHelp(cmd *cobra.Command, args []string) error {
 	cmd.SetOutput(c.Err())
 	cmd.HelpFunc()(cmd, args)
 	return nil

--- a/cli/command/version/version.go
+++ b/cli/command/version/version.go
@@ -26,20 +26,20 @@ func (v Version) IsConnected() bool {
 type ClientVersionInfo struct {
 	Version   string
 	Build     string
-	Address   string
+	Server    string
 	GoVersion string
-	Os        string
+	OS        string
 	Arch      string
 }
 
 var template = `Client:
  Version:       {{.Client.Version}}
  Build:         {{.Client.Build}}
- Address:       {{.Client.Address}}
+ Server:        {{.Client.Server}}
  Go version:    {{.Client.GoVersion}}
- OS/Arch:       {{.Client.Os}}/{{.Client.Arch}}
+ OS/Arch:       {{.Client.OS}}/{{.Client.Arch}}
 
-Server:      {{if .IsConnected}}
+Server:         {{if .IsConnected}}
  Version:       {{.Server.Version}}
  Build:         {{.Server.Build}}
  Go version:    {{.Server.GoVersion}}
@@ -68,9 +68,9 @@ func showVersion(c cli.Interface) error {
 		Client: &ClientVersionInfo{
 			Version:   c.Version(),
 			Build:     c.Build(),
-			Address:   c.Address(),
+			Server:    c.Server(),
 			GoVersion: runtime.Version(),
-			Os:        runtime.GOOS,
+			OS:        runtime.GOOS,
 			Arch:      runtime.GOARCH,
 		},
 	}

--- a/cli/configuration.go
+++ b/cli/configuration.go
@@ -4,7 +4,7 @@ package cli
 type Configuration struct {
 	Version string
 	Build   string
-	Address string
+	Server  string
 	Verbose bool
 	Theme   string
 }

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -34,7 +34,7 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 		Example:       "amp version",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.addr != "" {
-				c.SetAddress(opts.addr)
+				c.SetServer(opts.addr)
 			}
 			return nil
 		},

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -19,6 +19,7 @@ import (
 
 type opts struct {
 	version bool
+	addr    string
 }
 
 // newRootCommand returns a new instance of the amp cli root command.
@@ -31,19 +32,26 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example:       "amp version",
-		Run: func(cmd *cobra.Command, args []string) {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.addr != "" {
+				c.SetAddress(opts.addr)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.version {
 				showVersion()
-				return
+				return nil
 			}
 			cmd.SetOutput(c.Err())
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 	cli.SetupRootCommand(cmd)
 
-	flags := cmd.Flags()
-	flags.BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
+	cmd.Flags().BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
+	cmd.PersistentFlags().StringVarP(&opts.addr, "server", "s", "", "Specify server (host:port)")
 
 	cmd.SetOutput(c.Out())
 	addCommands(cmd, c)

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -24,7 +24,7 @@ func main() {
 	config = &cli.Configuration{
 		Version: Version,
 		Build:   Build,
-		Address: "cloud.atomiq.io:50101",
+		Server:  "cloud.atomiq.io:50101",
 	}
 
 	// Set terminal emulation based on platform as required.

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -24,7 +24,7 @@ func main() {
 	config = &cli.Configuration{
 		Version: Version,
 		Build:   Build,
-		Address: "localhost:50101",
+		Address: "cloud.atomiq.io:50101",
 	}
 
 	// Set terminal emulation based on platform as required.

--- a/hack/versioncheck
+++ b/hack/versioncheck
@@ -8,15 +8,17 @@ usage() {
 
 [[ $# -eq 0 ]] && usage
 
+AMP="amp --server localhost:50101"
+
 # max script timeout, default = 300 seconds (5m)
 TIMEOUT="${1:-300}"
 
 SECONDS=0
 while true; do
-    amp version
+    $AMP version
     docker run -it --rm --network=hostnet -v $PWD/stacks:/stacks docker --host=m1 service ls
     echo "-------------------------------"
-    v=$(amp version | grep 'not connected' | wc -l)
-    [[ $v -eq 0 ]] && [[ $SECONDS -lt $TIMEOUT ]] && amp version && break
+    v=$($AMP version | grep 'not connected' | wc -l)
+    [[ $v -eq 0 ]] && [[ $SECONDS -lt $TIMEOUT ]] && $AMP version && break
     [[ $SECONDS -gt $TIMEOUT ]] && echo "version check timed out" && exit 1
 done


### PR DESCRIPTION
Closes #950

Adds the `--server` option to `amp`. The default server is `cloud.atomiq.io:50101`, but this option lets you override it (e.g., for local development).

## Verification

Use default server:

    $ amp version

Verify `cloud.atomiq.io` appears in either a success or error response.

Specify the server:

```
$ amp --server localhost:50101 version
Client:
 . . .
 Server:        localhost:50101
 . . .
```
Verify `localhost` appears in either a success or error response.
