### PR TITLE
Update CLI output when not logged in 

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -12,6 +12,7 @@ const (
 	TokenKey              = "amp.token"
 	UserKey               = "amp.user"
 	ActiveOrganizationKey = "amp.organization"
+	CredentialsRequired   = "credentials required"
 )
 
 var (
@@ -69,19 +70,19 @@ func Interceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInf
 func authorize(ctx context.Context) (context.Context, error) {
 	md, ok := metadata.FromContext(ctx)
 	if !ok {
-		return nil, grpc.Errorf(codes.Unauthenticated, "credentials required")
+		return nil, grpc.Errorf(codes.Unauthenticated, CredentialsRequired)
 	}
 	tokens := md[TokenKey]
 	if len(tokens) == 0 {
-		return nil, grpc.Errorf(codes.Unauthenticated, "credentials required")
+		return nil, grpc.Errorf(codes.Unauthenticated, CredentialsRequired)
 	}
 	token := tokens[0]
 	if token == "" {
-		return nil, grpc.Errorf(codes.Unauthenticated, "credentials required")
+		return nil, grpc.Errorf(codes.Unauthenticated, CredentialsRequired)
 	}
 	claims, err := ValidateToken(token, TokenTypeLogin)
 	if err != nil {
-		return nil, grpc.Errorf(codes.Unauthenticated, "invalid credentials")
+		return nil, grpc.Errorf(codes.Unauthenticated, "invalid credentials. Please log in again.")
 	}
 	// Enrich the context
 	ctx = metadata.NewContext(ctx, metadata.Pairs(UserKey, claims.AccountName, ActiveOrganizationKey, claims.ActiveOrganization))

--- a/cli/command/logs/logs.go
+++ b/cli/command/logs/logs.go
@@ -2,9 +2,8 @@ package logs
 
 import (
 	"context"
-	"io"
-
 	"fmt"
+	"io"
 
 	"github.com/appcelerator/amp/api/rpc/logs"
 	"github.com/appcelerator/amp/cli"

--- a/cli/command/whoami/whoami.go
+++ b/cli/command/whoami/whoami.go
@@ -24,7 +24,7 @@ func NewWhoAmICommand(c cli.Interface) *cobra.Command {
 func whoami(c cli.Interface) error {
 	token, err := cli.ReadToken()
 	if err != nil {
-		return errors.New("you are not logged in")
+		return errors.New("you are not logged in. Use `amp login` or `amp user signup`.")
 	}
 	pToken, _ := jwt.ParseWithClaims(token, &auth.AccountClaims{}, func(t *jwt.Token) (interface{}, error) {
 		return []byte{}, nil


### PR DESCRIPTION
Update CLI output with a clear message when not logged in for the following commands (fixes #959 )
` amp whoami`, `amp logs` and `amp stats`

This PR also updates the error messages in cli/command/stats/stats.go