### PR TITLE
Move switch command under org command

### DIFF
--- a/cli/command/org/org.go
+++ b/cli/command/org/org.go
@@ -19,5 +19,6 @@ func NewOrgCommand(c cli.Interface) *cobra.Command {
 	cmd.AddCommand(NewOrgRemoveCommand(c))
 	cmd.AddCommand(NewOrgGetCommand(c))
 	cmd.AddCommand(member.NewOrgMemCommand(c))
+	cmd.AddCommand(NewSwitchCommand(c))
 	return cmd
 }

--- a/cli/command/org/switch.go
+++ b/cli/command/org/switch.go
@@ -1,4 +1,4 @@
-package switch_
+package org
 
 import (
 	"errors"
@@ -25,7 +25,7 @@ func NewSwitchCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:     "switch ACCOUNT",
 		Short:   "Switch account",
-		PreRunE: cli.NoArgs,
+		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {
 				return errors.New("account name cannot be empty")

--- a/cli/command/team/list.go
+++ b/cli/command/team/list.go
@@ -27,7 +27,7 @@ func NewTeamListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS] ORGANIZATION",
 		Short:   "List team",
-		PreRunE: cli.NoArgs,
+		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {
 				return errors.New("organization name cannot be empty")

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/appcelerator/amp/cli/command/org"
 	"github.com/appcelerator/amp/cli/command/password"
 	"github.com/appcelerator/amp/cli/command/stats"
-	"github.com/appcelerator/amp/cli/command/switch"
 	"github.com/appcelerator/amp/cli/command/team"
 	"github.com/appcelerator/amp/cli/command/user"
 	"github.com/appcelerator/amp/cli/command/version"
@@ -78,9 +77,6 @@ func addCommands(cmd *cobra.Command, c cli.Interface) {
 
 		//password
 		password.NewPasswordCommand(c),
-
-		//switch
-		switch_.NewSwitchCommand(c),
 
 		//team
 		team.NewTeamCommand(c),


### PR DESCRIPTION
Earlier, `switch` command was part of `amp` root command. It has now been moved as part of `amp org` command. 
```
$ amp org

Usage:	amp org [OPTIONS] COMMAND [ARGS...]

Organization management operations

Options:
  -h, --help            Print usage
  -s, --server string   Specify server (host:port)

Management Commands:
  member      Manage organization members

Commands:
  create      Create organization
  get         Get organization
  ls          List organization
  rm          Remove organization
  switch      Switch account

Run 'amp org COMMAND --help' for more information on a command.
```
This PR also fixes arg check for `amp team ls` cmd