### PR TITLE
Remove --time-zone and --task-id options from stats

### DIFF
--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -128,9 +128,6 @@ func (s *Stats) createBoolQuery(req *StatsRequest, period string) *elastic.BoolQ
 	if req.FilterServiceId != "" {
 		filters = append(filters, elastic.NewWildcardQuery("service_id", getWildcardValue(req.FilterServiceId)))
 	}
-	if req.FilterTaskId != "" {
-		filters = append(filters, elastic.NewWildcardQuery("task_id", getWildcardValue(req.FilterTaskId)))
-	}
 	if req.FilterStackName != "" {
 		filters = append(filters, elastic.NewWildcardQuery("stack_name", getWildcardValue(req.FilterStackName)))
 	}
@@ -186,9 +183,6 @@ func (s *Stats) createTermAggreggation(req *StatsRequest) *elastic.TermsAggregat
 // create the aggregation query on the main group (container, service, stacks. ...) and each sub aggregations related to the metrics
 func (s *Stats) createHistoAggreggation(req *StatsRequest) *elastic.DateHistogramAggregation {
 	agg := elastic.NewDateHistogramAggregation().Field("@timestamp").Interval(req.TimeGroup)
-	if req.TimeZone != "" {
-		agg = agg.TimeZone(req.TimeZone)
-	}
 	if req.StatsCpu {
 		agg = agg.SubAggregation("avgCPU", elastic.NewAvgAggregation().Field("cpu.total_usage"))
 		agg = agg.SubAggregation("avgCPUKernel", elastic.NewAvgAggregation().Field("cpu.usage_in_kernel_mode"))

--- a/cli/command/stats/stats.go
+++ b/cli/command/stats/stats.go
@@ -26,12 +26,10 @@ type statsOpts struct {
 	net            bool
 	period         string
 	timeGroup      string
-	timeZone       string
 	containerID    string
 	containerName  string
 	containerState string
 	serviceID      string
-	taskID         string
 	stackName      string
 	nodeID         string
 	follow         bool
@@ -70,14 +68,12 @@ func NewStatsCommand(c cli.Interface) *cobra.Command {
 	//historic
 	flags.StringVar(&opts.period, "period", "", `Historic period of metrics extraction, for instance: "now-1d", "now-10h", with y=year, M=month, w=week, d=day, h=hour, m=minute, s=second`)
 	flags.StringVar(&opts.timeGroup, "time-group", "", `Historic extraction by time group, for instance: "1d", "3h", , with y=year, M=month, w=week, d=day, h=hour, m=minute, s=second`)
-	flags.StringVar(&opts.timeZone, "time-zone", "", `Historic timeshift: "-01:00", "+03:00", ...`)
 	//filters
 	flags.StringVar(&opts.containerID, "container-id", "", "Filter on container id")
 	flags.StringVar(&opts.containerName, "container-name", "", "Filter on container name")
 	flags.StringVar(&opts.containerState, "container-state", "", "Filter on container state")
 	flags.StringVar(&opts.serviceID, "service-id", "", "Filter on service id")
 	flags.StringVar(&opts.stackName, "stack-name", "", "Filter on stack name")
-	flags.StringVar(&opts.taskID, "task-id", "", "Filter on task id")
 	flags.StringVar(&opts.nodeID, "node-id", "", "Filter on node id")
 	//Stream flag
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow stats output")
@@ -93,7 +89,6 @@ func getStats(c cli.Interface, args []string) error {
 	query.FilterContainerName = opts.containerName
 	query.FilterContainerState = opts.containerState
 	query.FilterServiceId = opts.serviceID
-	query.FilterTaskId = opts.taskID
 	query.FilterStackName = opts.stackName
 	query.FilterNodeId = opts.nodeID
 
@@ -128,7 +123,6 @@ func getStats(c cli.Interface, args []string) error {
 	//Set historic parameters
 	query.Period = opts.period
 	query.TimeGroup = opts.timeGroup
-	query.TimeZone = opts.timeZone
 
 	//set default for period only for current statistics
 	if query.TimeGroup == "" && query.Period == "" {

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -31,7 +31,6 @@ The `amp stats` command is used to query or stream statistics. It provides group
            --container-state string  select only the container having their state starting by the given value
            --service-id string       select only the services having their id starting by the given value
            --stack-name string       select only the stacks having their name starting by the given value
-           --task-id string          select only the task having their id starting by the given value
            --node-id string          select only the node having their name starting by the given value
            if several filters are used they are considered linked by a logical AND
 


### PR DESCRIPTION
Closes #985 
Closes #984

task-id and time-zone options have being deprioritized for now to simplify the CLI and will be revisited later.

## test

- ampmake build
- make build-cli
- hack/deploy
- amp stats --time-zone 01:00 -> error
- amp stats --task-id xxx -> error
- amp stats --help -> no mension of time-zone or task-id anymore
- /docs/stats.md  is up to date
