### PR TITLE
Fix interactive execution of get team cmd

### DIFF
--- a/cli/command/team/get.go
+++ b/cli/command/team/get.go
@@ -41,7 +41,7 @@ func getTeam(c cli.Interface, cmd *cobra.Command) error {
 		getTeamOptions.org = c.Console().GetInput("organization name")
 	}
 	if !cmd.Flag("team").Changed {
-		getTeamOptions.org = c.Console().GetInput("team name")
+		getTeamOptions.team = c.Console().GetInput("team name")
 	}
 
 	conn := c.ClientConn()


### PR DESCRIPTION
Closes #981 

To test:
```
$ ampmake build
$ make build-cli
$ hack/dev
$ amp user signup
$ amp user verify <token>
$ amp login
$ amp org create
$ amp team create
$ amp team get
```