### PR TITLE
Add CLI Command: amp stack logs

### DIFF
--- a/cli/command/stack/logs.go
+++ b/cli/command/stack/logs.go
@@ -1,0 +1,81 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/appcelerator/amp/api/rpc/logs"
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type logsOpts struct {
+	meta   bool
+	follow bool
+}
+
+var (
+	lopts = &logsOpts{}
+)
+
+// NewLogsCommand returns a new instance of the stack command.
+func NewLogsCommand(c cli.Interface) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "logs",
+		Short:   "Get all logs of a given stack",
+		PreRunE: cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getLogs(c, args)
+		},
+	}
+	cmd.Flags().BoolVarP(&lopts.follow, "follow", "f", false, "Follow log output")
+	cmd.Flags().BoolVarP(&lopts.meta, "meta", "m", false, "Display entry metadata")
+	return cmd
+}
+
+func getLogs(c cli.Interface, args []string) error {
+	request := logs.GetRequest{Infra: true}
+	request.Stack = args[0]
+
+	// Get logs from amplifier
+	ctx := context.Background()
+	conn := c.ClientConn()
+	lc := logs.NewLogsClient(conn)
+	r, err := lc.Get(ctx, &request)
+	if err != nil {
+		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	for _, entry := range r.Entries {
+		displayLogEntry(c, entry, lopts.meta)
+	}
+	if !lopts.follow {
+		return nil
+	}
+
+	// If follow is requested, get subsequent logs and stream it
+	stream, err := lc.GetStream(ctx, &request)
+	if err != nil {
+		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	for {
+		entry, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("%s", grpc.ErrorDesc(err))
+		}
+		displayLogEntry(c, entry, lopts.meta)
+	}
+	return nil
+}
+
+func displayLogEntry(c cli.Interface, entry *logs.LogEntry, meta bool) {
+	if meta {
+		c.Console().Printf("%+v\n", entry)
+	} else {
+		c.Console().Printf("%s\n", entry.Msg)
+	}
+}

--- a/cli/command/stack/stack.go
+++ b/cli/command/stack/stack.go
@@ -16,5 +16,6 @@ func NewStackCommand(c cli.Interface) *cobra.Command {
 	cmd.AddCommand(NewDeployCommand(c))
 	cmd.AddCommand(NewListCommand(c))
 	cmd.AddCommand(NewRemoveCommand(c))
+	cmd.AddCommand(NewLogsCommand(c))
 	return cmd
 }


### PR DESCRIPTION
Closes #998

add CLI command amp stack logs to get all logs of a given stack

## test

- make build-cli
- amp stack logs amp -> return all the logs of amp stack