### PR TITLE
Add CLI Command: amp service logs

### DIFF
--- a/agent/container.go
+++ b/agent/container.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -106,8 +105,8 @@ func (a *Agent) addContainer(ID string) {
 				logsReadError: false,
 			}
 			labels := inspect.Config.Labels
-			// data.serviceName = a.getMapValue(labels, "com.docker.swarm.service.name")
-			data.serviceName = strings.TrimPrefix(labels["com.docker.swarm.service.name"], labels["com.docker.stack.namespace"]+"_")
+			data.serviceName = a.getMapValue(labels, "com.docker.swarm.service.name")
+			//data.serviceName = strings.TrimPrefix(labels["com.docker.swarm.service.name"], labels["com.docker.stack.namespace"]+"_")
 			if data.serviceName == "" {
 				data.serviceName = "noService"
 			}

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/appcelerator/amp/api/rpc/logs"
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type logsOpts struct {
+	meta   bool
+	follow bool
+}
+
+var (
+	opts = &logsOpts{}
+)
+
+// NewServiceLogsCommand returns a new instance of the stack command.
+func NewServiceLogsCommand(c cli.Interface) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "logs",
+		Short:   "Get all logs of a given service",
+		PreRunE: cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getLogs(c, args)
+		},
+	}
+	cmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
+	cmd.Flags().BoolVarP(&opts.meta, "meta", "m", false, "Display entry metadata")
+	return cmd
+}
+
+func getLogs(c cli.Interface, args []string) error {
+	request := logs.GetRequest{Infra: true}
+	request.Service = args[0]
+
+	// Get logs from amplifier
+	ctx := context.Background()
+	conn := c.ClientConn()
+	lc := logs.NewLogsClient(conn)
+	r, err := lc.Get(ctx, &request)
+	if err != nil {
+		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	for _, entry := range r.Entries {
+		displayLogEntry(c, entry, opts.meta)
+	}
+	if !opts.follow {
+		return nil
+	}
+
+	// If follow is requested, get subsequent logs and stream it
+	stream, err := lc.GetStream(ctx, &request)
+	if err != nil {
+		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	for {
+		entry, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("%s", grpc.ErrorDesc(err))
+		}
+		displayLogEntry(c, entry, opts.meta)
+	}
+	return nil
+}
+
+func displayLogEntry(c cli.Interface, entry *logs.LogEntry, meta bool) {
+	if meta {
+		c.Console().Printf("%+v\n", entry)
+	} else {
+		c.Console().Printf("%s\n", entry.Msg)
+	}
+}

--- a/cli/command/service/service.go
+++ b/cli/command/service/service.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+)
+
+// NewServiceCommand returns a new instance of the service command.
+func NewServiceCommand(c cli.Interface) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "service",
+		Short:   "Service management operations",
+		PreRunE: cli.NoArgs,
+		RunE:    c.ShowHelp,
+	}
+	cmd.AddCommand(NewServiceLogsCommand(c))
+	return cmd
+}

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -8,6 +8,7 @@ import (
 	"github.com/appcelerator/amp/cli/command/logs"
 	"github.com/appcelerator/amp/cli/command/org"
 	"github.com/appcelerator/amp/cli/command/password"
+	"github.com/appcelerator/amp/cli/command/service"
 	"github.com/appcelerator/amp/cli/command/stack"
 	"github.com/appcelerator/amp/cli/command/stats"
 	"github.com/appcelerator/amp/cli/command/team"
@@ -78,6 +79,9 @@ func addCommands(cmd *cobra.Command, c cli.Interface) {
 
 		// password
 		password.NewPasswordCommand(c),
+
+		// service
+		service.NewServiceCommand(c),
 
 		// stack
 		stack.NewStackCommand(c),


### PR DESCRIPTION

Closes #999

add CLI command amp service logs to get all logs of a given service

## test

- ampmake build
- make build-cli
- amp service logs amp_amplifier -> return all the logs of amp_amplifier