### PR TITLE
Fix issue on stack rm with no argument

### DIFF
--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -24,6 +24,7 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 		Use:     "remove STACKNAME",
 		Aliases: []string{"rm", "down", "stop"},
 		Short:   "Remove a deployed stack",
+		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ropts.name = args[0]
 			return remove(c)


### PR DESCRIPTION

Closes #1003 

## test

- make build-cli
- amp stack rm -> regular error on argument missing