### PR TITLE
Updated ls, rm aliases

### DIFF
--- a/cli/command/function/list.go
+++ b/cli/command/function/list.go
@@ -25,6 +25,7 @@ func NewFunctionListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List function",
+		Aliases: []string{"list"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listFunction(c)

--- a/cli/command/function/remove.go
+++ b/cli/command/function/remove.go
@@ -21,7 +21,7 @@ func NewFunctionRemoveCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm FUNCTION",
 		Short:   "Remove function",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {

--- a/cli/command/org/list.go
+++ b/cli/command/org/list.go
@@ -25,6 +25,7 @@ func NewOrgListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List organization",
+		Aliases: []string{"list"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOrg(c)

--- a/cli/command/org/member/list.go
+++ b/cli/command/org/member/list.go
@@ -26,6 +26,7 @@ func NewOrgListMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS] ORGANIZATION",
 		Short:   "List members",
+		Aliases: []string{"list"},
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {

--- a/cli/command/org/member/remove.go
+++ b/cli/command/org/member/remove.go
@@ -24,7 +24,7 @@ func NewOrgRemoveMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rm [OPTIONS]",
 		Short:   "Remove member from organization",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeOrgMem(c, cmd)

--- a/cli/command/org/remove.go
+++ b/cli/command/org/remove.go
@@ -24,7 +24,7 @@ func NewOrgRemoveCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm ORGANIZATION",
 		Short:   "Remove organization",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -26,9 +26,9 @@ var (
 // NewListCommand returns a new instance of the stack command.
 func NewListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
+		Use:     "ls",
 		Short:   "List deployed stacks",
+		Aliases: []string{"list"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return list(c)

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -21,8 +21,8 @@ var (
 // NewRemoveCommand returns a new instance of the stack command.
 func NewRemoveCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "remove STACKNAME",
-		Aliases: []string{"rm", "down", "stop"},
+		Use:     "rm STACKNAME",
+		Aliases: []string{"remove", "down", "stop"},
 		Short:   "Remove a deployed stack",
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/team/list.go
+++ b/cli/command/team/list.go
@@ -27,6 +27,7 @@ func NewTeamListCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS] ORGANIZATION",
 		Short:   "List team",
+		Aliases: []string{"list"},
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {

--- a/cli/command/team/member/list.go
+++ b/cli/command/team/member/list.go
@@ -26,6 +26,7 @@ func NewListTeamMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List members",
+		Aliases: []string{"list"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listTeamMem(c, cmd)

--- a/cli/command/team/member/remove.go
+++ b/cli/command/team/member/remove.go
@@ -25,7 +25,7 @@ func NewRemoveTeamMemCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rm [OPTIONS]",
 		Short:   "Remove member from team",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return remTeamMem(c, cmd)

--- a/cli/command/team/remove.go
+++ b/cli/command/team/remove.go
@@ -24,7 +24,7 @@ func NewTeamRemoveCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rm [OPTIONS]",
 		Short:   "Remove team",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeTeam(c, cmd)

--- a/cli/command/user/list.go
+++ b/cli/command/user/list.go
@@ -5,8 +5,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/appcelerator/amp/api/rpc/account"
-	"github.com/appcelerator/amp/pkg/time"
 	"github.com/appcelerator/amp/cli"
+	"github.com/appcelerator/amp/pkg/time"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -25,6 +25,7 @@ func NewListUserCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List users",
+		Aliases: []string{"list"},
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listUser(c)

--- a/cli/command/user/remove.go
+++ b/cli/command/user/remove.go
@@ -24,7 +24,7 @@ func NewRemoveUserCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm USERNAME",
 		Short:   "Remove user",
-		Aliases: []string{"del"},
+		Aliases: []string{"remove"},
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {


### PR DESCRIPTION
Updated `ls, list` and `rm, remove` aliases for the following commands:
- function
- org, org member
- stack
- team, team member
- user