### PR TITLE
Append default port if not specified in --server flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -39,6 +40,11 @@ type cli struct {
 	clientConn *grpc.ClientConn
 }
 
+const (
+	//DefaultPort for server address
+	DefaultPort = ":50101"
+)
+
 // NewCLI returns a new CLI instance.
 func NewCLI(in io.ReadCloser, out, err io.Writer, config *Configuration) Interface {
 	c := &cli{
@@ -68,6 +74,9 @@ func (c *cli) Server() string {
 
 // SetServer sets the address of the grpc api (host:port) used for the client connection.
 func (c *cli) SetServer(server string) {
+	if !strings.Contains(server, ":") {
+		server += DefaultPort
+	}
 	c.Configuration.Server = server
 	c.clientConn = nil
 }

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -27,7 +27,6 @@ type opts struct {
 // newRootCommand returns a new instance of the amp cli root command.
 func newRootCommand(c cli.Interface) *cobra.Command {
 	opts := &opts{}
-
 	cmd := &cobra.Command{
 		Use:           "amp [OPTIONS] COMMAND [ARG...]",
 		Short:         "Deploy, manage, and monitor container stacks and functions.",


### PR DESCRIPTION
adds default port to --server option

### To test
```
$ amp -s localhost version

Client:
 Version:       v0.6.0-dev
 Build:         e75f63c5
 Server:        localhost:50101
 Go version:    go1.8
 OS/Arch:       darwin/amd64

Server:         
 Version:       v0.6.0-dev
 Build:         33dca96f
 Go version:    go1.8.1
 OS/Arch:       linux/amd64
```