### PR TITLE
Logout of account after user is removed

### DIFF
--- a/cli/command/logout/logout.go
+++ b/cli/command/logout/logout.go
@@ -1,11 +1,8 @@
 package logout
 
 import (
-	"fmt"
-
 	"github.com/appcelerator/amp/cli"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 )
 
 // NewLogoutCommand returns a new instance of the logout command.
@@ -21,9 +18,8 @@ func NewLogoutCommand(c cli.Interface) *cobra.Command {
 }
 
 func logout(c cli.Interface) error {
-	err := cli.RemoveToken()
-	if err != nil {
-		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	if err := cli.RemoveToken(); err != nil {
+		return err
 	}
 	c.Console().Println("You have been logged out!")
 	return nil

--- a/cli/command/user/remove.go
+++ b/cli/command/user/remove.go
@@ -45,6 +45,9 @@ func removeUser(c cli.Interface, opt *removeUserOpts) error {
 	if _, err := client.DeleteUser(context.Background(), request); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
+	if err := cli.RemoveToken(); err != nil {
+		return err
+	}
 	c.Console().Println("User removed.")
 	return nil
 }

--- a/cli/token.go
+++ b/cli/token.go
@@ -63,7 +63,7 @@ func RemoveToken() error {
 	}
 	filePath := filepath.Join(usr.HomeDir, ampConfigFolder, ampTokenFile)
 	if _, err = os.Stat(filePath); os.IsNotExist(err) {
-		return nil
+		return fmt.Errorf("you are not logged in. Use `amp login` or `amp user signup`")
 	}
 	err = os.Remove(filePath)
 	if err != nil {


### PR DESCRIPTION
Resolves #978 
When a user logs in to AMP and tries to delete their own account, the user is logged out of the account.

### To test

```
$ ampmake build
$ make build-cli
$ hack/dev
$ amp user signup --name user1 --email <valid email> --password xxxx
$ amp user verify 7sdk3...
$ amp login --name user1 --password xxxx
$ amp whoami 
user1
$ amp user rm user1
User removed.
$ amp whoami
Error: you are not logged in. Use `amp login` or `amp user signup`.
```