### PR TITLE
forgot-login now won't run if user is logged in

### DIFF
--- a/cli/command/user/forgot-login.go
+++ b/cli/command/user/forgot-login.go
@@ -36,6 +36,9 @@ func NewForgotLoginCommand(c cli.Interface) *cobra.Command {
 }
 
 func forgotLogin(c cli.Interface, opt *forgotOpts) error {
+	if token := cli.GetToken(); token != "" {
+		return errors.New("you are already logged into an account. Use 'amp whoami' to view your username")
+	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
 	request := &account.ForgotLoginRequest{
@@ -44,6 +47,7 @@ func forgotLogin(c cli.Interface, opt *forgotOpts) error {
 	if _, err := client.ForgotLogin(context.Background(), request); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
+
 	c.Console().Printf("Your login name has been sent to the address: %s\n", opt.email)
 	return nil
 }


### PR DESCRIPTION
fixes #994 

`amp user forgot-login` will no longer run if the user is currently logged into an account. It will now error, saying that the user should use `amp whoami` to get their username instead.

to test:
```
$ ampmake build
$ make build-cli
$ hack/dev
$ amp user signup --name=user1 --email=<some email> --password=<some password>
$ amp user verify <token>
$ amp login --name=user1 --password=<some password>
$ amp user forgot-login <your email>
you are already logged into an account. Use 'amp whoami' to view your username
```