### PR TITLE
Implements cluster update, status, ls, rm commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ clean-funcexec:
 # =============================================================================
 AMPBOOTDIR := bootstrap
 AMPBOOTBIN := bootstrap
-AMPBOOTIMG := appcelerator/amp-bootstrap:1.0.0
+AMPBOOTIMG := appcelerator/amp-bootstrap
 AMPBOOTSRC := hack/deploy hack/dev $(shell find $(AMPBOOTDIR) -type f)
 
 .PHONY: build-bootstrap

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --update --no-cache add bash openssl
 
 WORKDIR /usr/local
 COPY . /usr/local/bootstrap
-RUN mv bootstrap/hack hack && mv bootstrap/stacks stacks
+RUN mv /usr/local/bootstrap/hack /usr/local/hack && mv /usr/local/bootstrap/stacks /usr/local/stacks
 
 ENV PATH "/usr/local/bootstrap:/usr/local/hack:$PATH"
-ENTRYPOINT [ "hack/dev" ]
+CMD [ "hack/deploy" ]

--- a/bootstrap/build
+++ b/bootstrap/build
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-TAGS=( latest 1.0 1.0.0 )
+TAGS=( latest 1.0.1 )
 OWNER=appcelerator
-IMAGE=amp-bootstrap
+IMAGE="${1:-amp-bootstrap}"
 
 # This is built by the amp Makefile (without any tag) now
 #docker build -t ${OWNER}/${IMAGE} .

--- a/cli/command/cluster/bootstrap.go
+++ b/cli/command/cluster/bootstrap.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"bufio"
-	"os"
 	"os/exec"
 
 	"github.com/appcelerator/amp/cli"
@@ -18,15 +17,11 @@ func init() {
 		"--network", "host",
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-e", "GOPATH=/go",
-		"appcelerator/amp-bootstrap:1.0.0",
+		"appcelerator/amp-bootstrap:1.0.1",
 	}
 }
 
 func Run(c cli.Interface, args []string) error {
-	if len(os.Args) > 1 {
-		args = append(args, os.Args[1:]...)
-	}
-
 	cmd := "docker"
 	args = append(dockerArgs, args...)
 

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -12,6 +12,10 @@ type clusterOpts struct {
 	name     string
 }
 
+const (
+	DefaultLocalClusterID = "f573e897-7aa0-4516-a195-42ee91039e97"
+)
+
 var (
 	opts = &clusterOpts{3, 2, "local", ""}
 )
@@ -22,7 +26,7 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 		Use:     "cluster",
 		Short:   "Cluster management operations",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Console().Infoln("Note: only 'local' provider supported for preview")
+			c.Console().Infoln("Note: only 'local' cluster provider supported in this release")
 		},
 		PreRunE: cli.NoArgs,
 		RunE:    c.ShowHelp,
@@ -35,9 +39,13 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 	return cmd
 }
 
-func updateCluster(c cli.Interface, args []string) error {
-	// return exec.Run(c, "bootstrap", args)
-	return Run(c, args)
+func queryCluster(c cli.Interface, args []string) error {
+	err := Run(c, args)
+	if err != nil {
+		// TODO: the local cluster is the only one that can be managed this release
+		c.Console().Println(DefaultLocalClusterID)
+	}
+	return err
 }
 
 // Map cli cluster flags to target bootstrap cluster command flags,

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -34,6 +34,7 @@ func create(c cli.Interface, cmd *cobra.Command) error {
 		"name":     "-l",
 	}
 
-	args := []string{}
-	return updateCluster(c, reflag(cmd, m, args))
+	// TODO: only supporting local cluster management for this release
+	args := []string{"hack/deploy", DefaultLocalClusterID}
+	return queryCluster(c, reflag(cmd, m, args))
 }

--- a/cli/command/cluster/list.go
+++ b/cli/command/cluster/list.go
@@ -19,6 +19,8 @@ func NewListCommand(c cli.Interface) *cobra.Command {
 }
 
 func list(c cli.Interface) error {
+	// TODO: only supporting local cluster management for this release
 	// TODO call api to list clusters
+	c.Console().Println(DefaultLocalClusterID)
 	return nil
 }

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -5,22 +5,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	destroyArgs = []string{"-d"}
-)
-
 // NewRemoveCommand returns a new instance of the remove command for destroying a cluster.
 func NewRemoveCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
-		Use:     "destroy",
+		Use:     "rm",
+		Aliases: []string{"remove", "destroy"},
 		Short:   "Destroy an amp cluster",
-		PreRunE: cli.ExactArgs(1),
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return destroy(c)
+			return remove(c)
 		},
 	}
 }
 
-func destroy(c cli.Interface) error {
-	return updateCluster(c, destroyArgs)
+func remove(c cli.Interface) error {
+	// TODO: only supporting local cluster management for this release
+	args := []string{"bootstrap/bootstrap", "-d", DefaultLocalClusterID}
+	return queryCluster(c, args)
 }

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -10,14 +10,21 @@ func NewStatusCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
 		Use:     "status",
 		Short:   "Retrieve details about an amp cluster",
-		PreRunE: cli.ExactArgs(1),
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return status(c)
+			return status(c, cmd)
 		},
 	}
 }
 
-func status(c cli.Interface) error {
+func status(c cli.Interface, cmd *cobra.Command) error {
 	// TODO call api to get status
+	args := []string{"bootstrap/bootstrap", "-s", DefaultLocalClusterID}
+	status := queryCluster(c, args)
+	if status != nil {
+		c.Console().Println("cluster status: not running")
+	} else {
+		c.Console().Println("cluster: running")
+	}
 	return nil
 }

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -10,7 +10,7 @@ func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [OPTIONS]",
 		Short:   "Update an amp cluster",
-		PreRunE: cli.ExactArgs(1),
+		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return update(c, cmd)
 		},
@@ -29,6 +29,7 @@ func update(c cli.Interface, cmd *cobra.Command) error {
 		"managers": "-m",
 	}
 
-	args := []string{}
-	return updateCluster(c, reflag(cmd, m, args))
+	// TODO: only supporting local cluster management for this release
+	args := []string{"bootstrap/bootstrap", DefaultLocalClusterID}
+	return queryCluster(c, reflag(cmd, m, args))
 }

--- a/hack/deploy
+++ b/hack/deploy
@@ -144,11 +144,6 @@ pushimage() {
 
 deploystack() {
   echo "deploy $1 => $2"
-  ls -la
-  echo "==================================================================================="
-  ls -la stacks
-  echo "==================================================================================="
-  docker run -it --rm --network=hostnet -v amp-stacks:$stacks_path docker --host=$dockerhost ls $stacks_path
   $amps stack deploy -c $stacks_path/$1 $2
   checkexit $? "error deploying stack"
   ok
@@ -191,6 +186,7 @@ prepare_certificates() {
 }
 
 trap cleanup EXIT
+
 echo "$(deployment_target) deployment"
 if [ -z $CID ]; then
   echo "bootstrapping cluster"
@@ -311,5 +307,6 @@ kurl elasticsearch:9200
 checkexit $? "service ping check failed: elasticsearch"
 ok "service ping check succeeded: elasticsearch"
 
+printf "\nCluster status: healthy\n$CID"
 SUCCESS=1
 


### PR DESCRIPTION
Implements remaining cluster commands for `update`, `status`, `ls`, and `rm`. Note, this release only supports local cluster operations from the CLI.

First create a local cluster
    $ amp cluster create

    $ amp cluster status
    $ amp cluster update
    $ amp cluster ls
    $ amp cluster rm

For updating the cluster, the `--workers` and `--managers` options can be used for resizing. To verify, for now use the following:

    $ . hack/ampenv
    $ amps node ls

