### PR TITLE
Ensure cluster commands only used on local cluster for now

### DIFF
--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -1,6 +1,9 @@
 package cluster
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/appcelerator/amp/cli"
 	"github.com/spf13/cobra"
 )
@@ -23,19 +26,25 @@ var (
 // NewClusterCommand returns a new instance of the cluster command.
 func NewClusterCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "cluster",
-		Short:   "Cluster management operations",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			c.Console().Infoln("Note: only 'local' cluster provider supported in this release")
+		Use:   "cluster",
+		Short: "Cluster management operations",
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// TODO special case handling for cluster this release
+			local := strings.HasPrefix(c.Server(), "127.0.0.1") ||
+				strings.HasPrefix(c.Server(), "localhost")
+			if !local {
+				return errors.New("Note: only cluster operations with '--server=localhost' supported in this release")
+			}
+			return nil
 		},
 		PreRunE: cli.NoArgs,
 		RunE:    c.ShowHelp,
 	}
 	cmd.AddCommand(NewCreateCommand(c))
-	cmd.AddCommand(NewRemoveCommand(c))
-	cmd.AddCommand(NewUpdateCommand(c))
-	cmd.AddCommand(NewStatusCommand(c))
 	cmd.AddCommand(NewListCommand(c))
+	cmd.AddCommand(NewRemoveCommand(c))
+	cmd.AddCommand(NewStatusCommand(c))
+	cmd.AddCommand(NewUpdateCommand(c))
 	return cmd
 }
 

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -21,7 +21,7 @@ import (
 
 type opts struct {
 	version bool
-	addr    string
+	server  string
 }
 
 // newRootCommand returns a new instance of the amp cli root command.
@@ -34,8 +34,8 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 		SilenceErrors: true,
 		Example:       "amp version",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if opts.addr != "" {
-				c.SetServer(opts.addr)
+			if opts.server != "" {
+				c.SetServer(opts.server)
 			}
 			return nil
 		},
@@ -52,7 +52,7 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 	cli.SetupRootCommand(cmd)
 
 	cmd.Flags().BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
-	cmd.PersistentFlags().StringVarP(&opts.addr, "server", "s", "", "Specify server (host:port)")
+	cmd.PersistentFlags().StringVarP(&opts.server, "server", "s", "", "Specify server (host:port)")
 
 	cmd.SetOutput(c.Out())
 	addCommands(cmd, c)


### PR DESCRIPTION
This release only supports the local cluster provider.

## Verification

    # any cluster command should fail with an error
    $ amp cluster ls

    # any cluster command should succeed
    $ amp --server=localhost cluster ls

