### PR TITLE
Remove not used code

### DIFF
--- a/api/rpc/logs/logs.go
+++ b/api/rpc/logs/logs.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appcelerator/amp/pkg/docker"
 	"github.com/appcelerator/amp/pkg/elasticsearch"
 	"github.com/appcelerator/amp/pkg/labels"
 	"github.com/appcelerator/amp/pkg/nats-streaming"
@@ -21,7 +20,6 @@ import (
 
 // Server is used to implement log.LogServer
 type Server struct {
-	Docker        *docker.Docker
 	Es            *elasticsearch.Elasticsearch
 	NatsStreaming *ns.NatsStreaming
 }

--- a/api/rpc/stats/stats.go
+++ b/api/rpc/stats/stats.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/appcelerator/amp/pkg/docker"
 	"github.com/appcelerator/amp/pkg/elasticsearch"
 	"golang.org/x/net/context"
 	"gopkg.in/olivere/elastic.v5"
@@ -14,8 +13,7 @@ import (
 
 // Stats structure to implement StatsServer interface
 type Stats struct {
-	Docker *docker.Docker
-	Es     *elasticsearch.Elasticsearch
+	Es *elasticsearch.Elasticsearch
 }
 
 const (

--- a/cmd/amplifier/server/server.go
+++ b/cmd/amplifier/server/server.go
@@ -158,7 +158,6 @@ func registerVersionServer(c *Configuration, s *grpc.Server) {
 
 func registerLogsServer(c *Configuration, s *grpc.Server) {
 	logs.RegisterLogsServer(s, &logs.Server{
-		Docker:        runtime.Docker,
 		Es:            runtime.Elasticsearch,
 		NatsStreaming: runtime.NatsStreaming,
 	})
@@ -172,8 +171,7 @@ func registerStorageServer(c *Configuration, s *grpc.Server) {
 
 func registerStatsServer(c *Configuration, s *grpc.Server) {
 	stats.RegisterStatsServer(s, &stats.Stats{
-		Docker: runtime.Docker,
-		Es:     runtime.Elasticsearch,
+		Es: runtime.Elasticsearch,
 	})
 }
 


### PR DESCRIPTION
Remove not used Docker instances in logs and stats rpc api

## test

- ampmake build
- amp cluster create --server localhost
- signup/login if needed
- amp logs -i --server localhost
- amp stats --server localhost
