### PR TITLE
Add first level of service mapping

### DIFF
--- a/bootstrap/build
+++ b/bootstrap/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TAGS=( latest 1.0.1 )
+TAGS=( latest 1.0.2 )
 OWNER=appcelerator
 IMAGE="${1:-amp-bootstrap}"
 
@@ -13,4 +13,3 @@ do
   docker tag ${OWNER}/${IMAGE} ${OWNER}/${IMAGE}:${tag}
   docker push ${OWNER}/${IMAGE}:${tag}
 done
-

--- a/cli/command/cluster/bootstrap.go
+++ b/cli/command/cluster/bootstrap.go
@@ -17,7 +17,7 @@ func init() {
 		"--network", "host",
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-e", "GOPATH=/go",
-		"appcelerator/amp-bootstrap:1.0.1",
+		"appcelerator/amp-bootstrap:1.0.2",
 	}
 }
 

--- a/cmd/amphaproxy/core/api.go
+++ b/cmd/amphaproxy/core/api.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const port = "8090"
+
+//Start API server
+func initAPI() {
+	fmt.Println("Start API server on port " + port)
+	go func() {
+		http.HandleFunc("/", receivedURL)
+		http.ListenAndServe(":"+port, nil)
+	}()
+}
+
+//for HEALTHCHECK Dockerfile instruction
+func receivedURL(resp http.ResponseWriter, req *http.Request) {
+	resp.WriteHeader(404)
+	// is this an IP or a hostname?
+	matched, err := regexp.MatchString(`([:digit:]+\.){4}`, req.Host)
+	if err != nil {
+		fmt.Printf("receivedURL: Failed to parse hostname: %v\n", err)
+		return
+	}
+	if matched {
+		fmt.Fprintln(resp, "Sorry, you can't access this service through an IP, please use a FQDN")
+		return
+	}
+	list := strings.Split(req.Host, ".")
+	if len(list) >= 2 {
+		fmt.Fprintf(resp, "no server found for stack=%s service=%s\n", list[1], list[0])
+		return
+	}
+	fmt.Fprintf(resp, "no server found for host: %s\n", req.Host)
+}

--- a/cmd/amphaproxy/core/config.go
+++ b/cmd/amphaproxy/core/config.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+//ControllerConfig Json format of conffile
+type ControllerConfig struct {
+	haproxyPort       int
+	haProxyConffile   string
+	dockerWatchPeriod int
+	ampStackName      string
+	debug             bool
+}
+
+var conf ControllerConfig
+
+//Load Json conffile and instanciate new Config
+func (config *ControllerConfig) load(version string, build string) {
+	config.setDefault()
+	config.loadConfigUsingEnvVariable()
+	config.display(version, build)
+}
+
+//Set default value of configuration
+func (config *ControllerConfig) setDefault() {
+	config.haproxyPort = 80
+	config.debug = false
+	config.dockerWatchPeriod = 10
+	config.ampStackName = "amp"
+}
+
+//Update config with env variables
+func (config *ControllerConfig) loadConfigUsingEnvVariable() {
+	config.haproxyPort = getIntParameter("PORT", config.haproxyPort)
+	config.debug = getBoolParameter("DEBUG", config.debug)
+	config.dockerWatchPeriod = getIntParameter("WATCH_PERIOD", config.dockerWatchPeriod)
+	config.ampStackName = getStringParameter("AMP_STACK_NAME", config.ampStackName)
+}
+
+func (config *ControllerConfig) display(version string, build string) {
+	fmt.Printf("HAProxy controller version %s  (build:%s)\n", version, build)
+	fmt.Printf("Port: %d\n", config.haproxyPort)
+	fmt.Printf("DockerWatchPeriod: %d s\n", config.dockerWatchPeriod)
+	fmt.Printf("AMP stack name: %s\n", config.ampStackName)
+}
+
+//return env variable value, if empty return default value
+func getStringParameter(envVariableName string, def string) string {
+	value := os.Getenv(envVariableName)
+	if value == "" {
+		return def
+	}
+	return value
+}
+
+//return env variable value, if empty return default value
+func getBoolParameter(envVariableName string, def bool) bool {
+	value := os.Getenv(envVariableName)
+	if value == "" {
+		return def
+	}
+	if strings.ToLower(value) == "true" {
+		return true
+	}
+	return false
+}
+
+//return env variable value convert to int, if empty return default value
+func getIntParameter(envVariableName string, def int) int {
+	value := os.Getenv(envVariableName)
+	if value != "" {
+		ivalue, err := strconv.Atoi(value)
+		if err != nil {
+			return def
+		}
+		return ivalue
+	}
+	return def
+}
+
+//return env variable value, if empty return default value
+func getStringArrayParameter(envVariableName string, def []string) []string {
+	value := os.Getenv(envVariableName)
+	if value == "" {
+		return def
+	}
+	list := strings.Split(strings.Replace(value, " ", "", -1), ",")
+	return list
+}

--- a/cmd/amphaproxy/core/coremain.go
+++ b/cmd/amphaproxy/core/coremain.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"fmt"
+	"time"
+)
+
+//Run launch main loop
+func Run(version string, build string) {
+	//ampHAProxyControllerVersion = version
+	conf.load(version, build)
+	haproxy.init()
+	haproxy.trapSignal()
+	initAPI()
+	haproxy.waitForAmplifier()
+	haproxy.start()
+}
+
+func (app *HAProxy) waitForAmplifier() {
+	amplifierName := fmt.Sprintf("%s_amplifier", conf.ampStackName)
+	fmt.Printf("Waiting for %s\n", amplifierName)
+	for !app.tryToResolvDNS(amplifierName) {
+		time.Sleep(3 * time.Second)
+	}
+	fmt.Printf("%s is ready\n", amplifierName)
+}

--- a/cmd/amphaproxy/core/haproxy.go
+++ b/cmd/amphaproxy/core/haproxy.go
@@ -1,0 +1,426 @@
+package core
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/appcelerator/amp/pkg/docker"
+	"github.com/appcelerator/amp/pkg/labels"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+const (
+	dockerStackLabelName = "com.docker.stack.namespace"
+)
+
+//HAProxy haproxy struct
+type HAProxy struct {
+	docker             *client.Client
+	mappingMap         map[string]*publicMapping
+	exec               *exec.Cmd
+	isLoadingConf      bool
+	dnsRetryLoopID     int
+	dnsNotResolvedList []string
+	updateID           int
+	updateChannel      chan int
+	iterationNumber    int
+}
+
+type publicMapping struct {
+	iterationNumber int    //internal counter to detect removed mapping
+	account         string //Account or stack owner namem used in the url host part
+	stack           string //Stack name, used in the url host part
+	service         string //service to reach
+	label           string //label used in the url host part
+	port            string //internal service port
+}
+
+var (
+	haproxy HAProxy
+	ctx     context.Context
+)
+
+//Set app mate initial values
+func (app *HAProxy) init() {
+	app.mappingMap = make(map[string]*publicMapping)
+	ctx = context.Background()
+	if err := dockerInit(); err != nil {
+		fmt.Printf("Init error: %v\n", err)
+		os.Exit(1)
+	}
+	app.updateChannel = make(chan int)
+	app.isLoadingConf = false
+	haproxy.updateConfiguration(true)
+}
+
+func dockerInit() error {
+	// Connection to Docker
+	defaultHeaders := map[string]string{"User-Agent": "haproxy"}
+	cli, err := client.NewClient(docker.DefaultURL, docker.DefaultVersion, nil, defaultHeaders)
+	if err != nil {
+		return err
+	}
+	haproxy.docker = cli
+	fmt.Println("Connected to Docker-engine")
+	return nil
+}
+
+//Launch a routine to catch SIGTERM Signal
+func (app *HAProxy) trapSignal() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	signal.Notify(ch, syscall.SIGTERM)
+	go func() {
+		<-ch
+		fmt.Println("\namp-haproxy-controller received SIGTERM signal")
+		app.docker.Close()
+		os.Exit(1)
+	}()
+}
+
+//Launch HAProxy using cmd command
+func (app *HAProxy) start() {
+	//launch HAPRoxy
+	go func() {
+		fmt.Println("launching HAProxy on initial configuration")
+		app.exec = exec.Command("haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg")
+		app.exec.Stdout = os.Stdout
+		app.exec.Stderr = os.Stderr
+		err := app.exec.Run()
+		if err != nil {
+			fmt.Printf("HAProxy exit with error: %v\n", err)
+			app.docker.Close()
+			os.Exit(1)
+		}
+	}()
+	//Launch main docker watch loop
+	fmt.Println("launching Docker watch")
+	app.dockerWatch()
+	//Launch main haproxy update loop
+	for {
+		uid := <-app.updateChannel
+		if uid == app.updateID {
+			app.updateConfiguration(true)
+		}
+	}
+}
+
+//Stop HAProxy
+func (app *HAProxy) stop() {
+	fmt.Println("Send SIGTERM signal to HAProxy")
+	if app.exec != nil {
+		app.exec.Process.Kill()
+	}
+}
+
+func (app *HAProxy) dockerWatch() {
+	go func() {
+		for {
+			time.Sleep(time.Duration(conf.dockerWatchPeriod) * time.Second)
+			if app.updateServiceMap() {
+				app.updateID++
+				app.updateChannel <- app.updateID
+			}
+		}
+	}()
+}
+
+func (app *HAProxy) updateServiceMap() bool {
+	list, err := app.docker.ServiceList(ctx, types.ServiceListOptions{})
+	if err != nil || len(list) == 0 {
+		fmt.Printf("Error reading docker service list: %v\n", err)
+		return false
+	}
+	isItemUpdated := false
+	for _, serv := range list {
+		if serv.Spec.Labels != nil {
+			stackName, exist := serv.Spec.Labels[dockerStackLabelName]
+			if exist {
+				serviceName := serv.Spec.Annotations.Name
+				mappings, ok := serv.Spec.Labels[labels.LabelsNameMapping]
+				if ok {
+					if app.addMappings(stackName, serviceName, mappings) {
+						isItemUpdated = true
+					}
+				}
+			}
+		}
+
+	}
+	return isItemUpdated
+}
+
+func (app *HAProxy) addMappings(stackName string, serviceName string, mappings string) bool {
+	isItemUpdated := false
+	app.iterationNumber++
+	mappingList := strings.Split(mappings, ",")
+	tmpMap := make(map[string]*publicMapping)
+	for _, value := range mappingList {
+		data, err := app.evalMappingString(stackName, serviceName, strings.TrimSpace(value))
+		if err != nil {
+			fmt.Printf("Mapping error for service %s: %v\n", serviceName, err)
+			return false
+		}
+		fmt.Printf("Found mapping %s: %v\n", value, data)
+		data.iterationNumber = app.iterationNumber
+		mappingID := fmt.Sprintf("%s-%s-%s:%s", data.account, data.stack, data.label, data.port)
+		mapping, exist := app.mappingMap[mappingID]
+		if !exist {
+			isItemUpdated = true
+			tmpMap[mappingID] = data
+		} else {
+			mapping.iterationNumber = app.iterationNumber
+		}
+	}
+	for id, item := range app.mappingMap {
+		if item.iterationNumber == app.iterationNumber {
+			tmpMap[id] = item
+		} else {
+			isItemUpdated = true
+		}
+	}
+	app.mappingMap = tmpMap
+	return isItemUpdated
+}
+
+//Launch HAProxy using cmd command
+func (app *HAProxy) reloadConfiguration() {
+	app.isLoadingConf = true
+	fmt.Println("reloading HAProxy configuration")
+	if app.exec == nil {
+		fmt.Printf("HAProxy is not started yet, waiting for it\n")
+		return
+	}
+	pid := app.exec.Process.Pid
+	fmt.Printf("Execute: %s %s %s %s %d\n", "haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg", "-sf", pid)
+	app.exec = exec.Command("haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg", "-sf", fmt.Sprintf("%d", pid))
+	app.exec.Stdout = os.Stdout
+	app.exec.Stderr = os.Stderr
+	go func() {
+		err := app.exec.Run()
+		app.isLoadingConf = false
+		if err == nil {
+			fmt.Println("HAProxy configuration reloaded")
+			return
+		}
+		fmt.Printf("HAProxy reload configuration error: %v\n", err)
+		os.Exit(1)
+	}()
+}
+
+// update configuration managing the isUpdatingConf flag
+func (app *HAProxy) updateConfiguration(reload bool) error {
+	app.dnsRetryLoopID++
+	app.dnsNotResolvedList = []string{}
+	err := app.updateConfigurationEff(reload)
+	if err == nil {
+		app.startDNSRevolverLoop(app.dnsRetryLoopID)
+	}
+	return err
+}
+
+//update HAProxy configuration for master regarding ETCD keys values and make HAProxy reload its configuration if reload is true
+func (app *HAProxy) updateConfigurationEff(reload bool) error {
+	fmt.Printf("update HAProxy configuration, mapping len=%d\n", len(app.mappingMap))
+	fileNameTarget := "/usr/local/etc/haproxy/haproxy.cfg"
+	fileNameTpt := "/usr/local/etc/haproxy/haproxy.cfg.tpt"
+	file, err := os.Create(fileNameTarget + ".new")
+	if err != nil {
+		fmt.Printf("Error creating new haproxy conffile for creation: %v\n", err)
+		return err
+	}
+	filetpt, err := os.Open(fileNameTpt)
+	if err != nil {
+		fmt.Printf("Error opening conffile template: %s : %v\n", fileNameTpt, err)
+		return err
+	}
+	scanner := bufio.NewScanner(filetpt)
+	if conf.debug {
+		fmt.Printf("Updating with mappings: %v\n", app.mappingMap)
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if conf.debug {
+			fmt.Printf("line: %s\n", line)
+		}
+		if strings.HasPrefix(strings.Trim(line, " "), "[frontendInline]") {
+			app.writeFrontendInline(file)
+		} else if strings.HasPrefix(strings.Trim(line, " "), "[backends]") {
+			app.writeBackend(file)
+		} else {
+			file.WriteString(line + "\n")
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		fmt.Printf("Error reading haproxy conffile template: %s %v\n", fileNameTpt, err)
+		file.Close()
+		return err
+	}
+	file.Close()
+	os.Remove(fileNameTarget)
+	err2 := os.Rename(fileNameTarget+".new", fileNameTarget)
+	if err2 != nil {
+		fmt.Printf("Error renaming haproxy conffile .new: %v\n", err)
+		return err
+	}
+	fmt.Println("HAProxy configuration updated")
+	if reload {
+		app.reloadConfiguration()
+	}
+	return nil
+}
+
+// write backends for main service configuration
+func (app *HAProxy) writeFrontendInline(file *os.File) error {
+	for _, mapping := range app.mappingMap {
+		if mapping.account != "" {
+			line := fmt.Sprintf("    use_backend bk_%s-%s-%s if { hdr_beg(host) -i %s.%s.%s }\n", mapping.account, mapping.service, mapping.port, mapping.label, mapping.stack, mapping.account)
+			file.WriteString(line)
+			fmt.Printf(line)
+		} else {
+			line := fmt.Sprintf("    use_backend bk_-%s-%s if { hdr_beg(host) -i %s.%s }\n", mapping.service, mapping.port, mapping.label, mapping.stack)
+			file.WriteString(line)
+			fmt.Printf(line)
+		}
+	}
+	return nil
+}
+
+// write backends for stack haproxy configuration
+func (app *HAProxy) writeBackend(file *os.File) error {
+	for _, mapping := range app.mappingMap {
+		dnsResolved := app.tryToResolvDNS(mapping.service)
+		line := fmt.Sprintf("\nbackend bk_%s-%s-%s\n", mapping.account, mapping.service, mapping.port)
+		file.WriteString(line)
+		fmt.Printf(line)
+		//if dns name is not resolved haproxy (v1.6) won't start or accept the new configuration so server is disabled
+		//to be removed when haproxy will fixe this bug
+		if dnsResolved {
+			line1 := fmt.Sprintf("    server %s_1 %s:%s resolvers docker resolve-prefer ipv4\n", mapping.service, mapping.service, mapping.port)
+			file.WriteString(line1)
+			fmt.Printf(line1)
+		} else {
+			line1 := fmt.Sprintf("    #dns name %s not resolved\n", mapping.service)
+			file.WriteString(line1)
+			fmt.Printf(line1)
+			line2 := fmt.Sprintf("    #server %s_1 %s:%s resolvers docker resolve-prefer ipv4\n", mapping.service, mapping.service, mapping.port)
+			file.WriteString(line2)
+			fmt.Printf(line2)
+			app.addDNSNameInRetryList(mapping.service)
+		}
+	}
+	return nil
+}
+
+// test if a dns name is resolved or not
+func (app *HAProxy) tryToResolvDNS(name string) bool {
+	_, err := net.LookupIP(name)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// add unresolved dns name in list to be retested later
+func (app *HAProxy) addDNSNameInRetryList(name string) {
+	app.dnsNotResolvedList = append(app.dnsNotResolvedList, name)
+}
+
+// on regular basis try to see if one of the unresolved dns become resolved, if so execute a configuration update.
+// need to have only one loop at a time, if the id change then the current loop should stop
+// id is incremented at each configuration update which can be trigger by ETCD wash also
+func (app *HAProxy) startDNSRevolverLoop(loopID int) {
+	//if no unresolved DNS name then not needed to start the loop
+	if len(haproxy.dnsNotResolvedList) == 0 {
+		return
+	}
+	fmt.Printf("Start DNS resolver id: %d\n", loopID)
+	go func() {
+		for {
+			for _, name := range haproxy.dnsNotResolvedList {
+				if app.tryToResolvDNS(name) {
+					if haproxy.dnsRetryLoopID == loopID {
+						fmt.Printf("DNS %s resolved, update configuration\n", name)
+						app.updateConfiguration(true)
+					}
+					fmt.Printf("Stop DNS resolver id: %d\n", loopID)
+					return
+				}
+			}
+			time.Sleep(10)
+			if haproxy.dnsRetryLoopID != loopID {
+				fmt.Printf("Stop DNS resolver id: %d\n", loopID)
+				return
+			}
+		}
+	}()
+}
+
+// parse a value of io.amp.mapping label
+func (app *HAProxy) evalMappingString(stack string, service string, labelValue string) (*publicMapping, error) {
+	mapping := &publicMapping{
+		stack:   app.getSimpleName(stack),
+		service: service,
+		label:   app.getDefaultName(service),
+	}
+	if labelValue == "" {
+		return mapping, nil
+	}
+	items := strings.Split(labelValue, " ")
+	for _, item := range items {
+		param := strings.Split(item, "=")
+		if len(param) == 0 {
+			param = strings.Split(item, ":")
+		}
+		if len(param) != 2 {
+			return nil, fmt.Errorf("Error in label %s: parameter %s should have '=' or ':' separator", labelValue, item)
+		}
+		name := strings.TrimSpace(param[0])
+		value := strings.TrimSpace(param[1])
+		if name == "account" {
+			mapping.account = value
+		} else if name == "name" {
+			mapping.label = value
+		} else if name == "port" {
+			mapping.port = value
+		}
+	}
+	if mapping.port == "" {
+		return nil, fmt.Errorf("Error in label %s: need to define the targetted port (port=xxx)", labelValue)
+	}
+	return mapping, nil
+}
+
+func (app *HAProxy) getDefaultName(name string) string {
+	list := strings.Split(name, "_")
+	if len(list) == 1 {
+		return name
+	}
+	ret := list[1]
+	if len(list) > 2 {
+		for _, item := range list[2:len(list)] {
+			ret = fmt.Sprintf("%s_%s", ret, item)
+		}
+	}
+	return ret
+}
+
+func (app *HAProxy) getSimpleName(name string) string {
+	list := strings.Split(name, "-")
+	ret := list[0]
+	if len(list) > 2 {
+		for _, item := range list[1 : len(list)-1] {
+			ret = fmt.Sprintf("%s-%s", ret, item)
+		}
+	}
+	return ret
+}

--- a/cmd/amphaproxy/main.go
+++ b/cmd/amphaproxy/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/appcelerator/amp/cmd/amphaproxy/core"
+)
+
+// build vars
+var (
+	// Version is set with a linker flag (see Makefile)
+	Version string
+
+	// Build is set with a linker flag (see Makefile)
+	Build string
+)
+
+func main() {
+	core.Run(Version, Build)
+}

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -38,3 +38,29 @@ List the deployed stacks and give the following information:
 optionally -q can be used to display only the stack id
 
 Note that this command display only the amp stacks, all other stacks created out of amp are not displayed, infrastructure stacks are not displayed either.
+
+# amp dedicated labels
+
+## io.amp.mapping
+
+When this label is added as a service label in a stack file, amp create a mapping to reverse proxy the service.
+
+the label format is:
+
+io.amp.mapping = " account=[myAccount] name=[aName] port=[internalServicePort]"
+
+then the following urls can be used to request the service
+
+http://[aName].[stackName].[myAccount].local.appcelerator.io
+or
+http://[aName].[stackName].[myAccount].cluster.atomiq.io
+depending on your environment
+
+without account=..., the url become:
+http://[aName].[stackName].local.appcelerator.io
+or
+http://[aName].[stackName].cluster.atomiq.io
+
+if name=... doesn't exist then name is set as the service name
+
+[port] is mandatory

--- a/images/amphaproxy/Dockerfile
+++ b/images/amphaproxy/Dockerfile
@@ -1,0 +1,19 @@
+FROM haproxy:1.7-alpine
+
+ENV GOPATH /go
+ENV PATH $PATH:/go/bin
+
+RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    echo "@community http://nl.alpinelinux.org/alpine/v3.5/community" >> /etc/apk/repositories
+RUN apk update && apk upgrade && \
+    apk -v add curl && \
+    cd / && rm -rf /go/src /go/pkg /var/cache/apk/* /root/.cache /root/.glide
+
+COPY haproxy.cfg.tpt /usr/local/etc/haproxy/haproxy.cfg.tpt
+# amp-haproxy should be built outside from this Dockerfile, see ../build-images.sh
+COPY amphaproxy.alpine /go/bin/amphaproxy
+
+HEALTHCHECK --interval=5s --timeout=10s --retries=12 CMD curl http://127.0.0.1/healthcheck
+
+CMD ["/go/bin/amphaproxy"]

--- a/images/amphaproxy/README.md
+++ b/images/amphaproxy/README.md
@@ -1,0 +1,8 @@
+### amphaproxy
+
+
+HAProxy image including a controller for HAProxy configuration updates on docker service labels
+
+# tags
+
+- 1.0.0

--- a/images/amphaproxy/docker-compose.test.yml
+++ b/images/amphaproxy/docker-compose.test.yml
@@ -1,0 +1,23 @@
+version: "2"
+services:
+  sut:
+    image: appcelerator/sut
+    build:
+      context: ./sut
+      dockerfile: Dockerfile
+    depends_on:
+      - haproxy
+
+  amplifier:
+    image: alpine
+    command: ["nc", "-l", "50101"]
+
+  haproxy:
+    image: appcelerator/amphaproxy
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      NO_DEFAULT_BACKEND: 'true'
+    depends_on:
+      - amplifier

--- a/images/amphaproxy/haproxy.cfg.tpt
+++ b/images/amphaproxy/haproxy.cfg.tpt
@@ -1,0 +1,29 @@
+global
+    maxconn 256
+    stats socket /var/run/haproxy.sock mode 600 level admin
+    stats timeout 2m
+
+resolvers docker
+    nameserver dnsmasq 127.0.0.1:53
+    resolve_retries      6
+    timeout retry        3s
+    hold valid           10s
+
+defaults
+    mode http
+    option dontlog-normal
+    option dontlognull
+    timeout connect 50000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend main_http-in
+    bind *:80
+    monitor-uri /healthcheck
+[frontendInline]
+    default_backend controler_api
+
+backend controler_api
+    server controler_api1 localhost:8090
+
+[backends]

--- a/images/amphaproxy/sut/Dockerfile
+++ b/images/amphaproxy/sut/Dockerfile
@@ -1,0 +1,3 @@
+From appcelerator/alpine:3.4.0
+COPY ./sut.sh /bin
+CMD ["/bin/sut.sh"]

--- a/images/amphaproxy/sut/sut.sh
+++ b/images/amphaproxy/sut/sut.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+HAPROXY_HOST=${HAPROXY_HOST:-haproxy}
+STATS_PORT=8082
+STATS_URL="admin?stats"
+
+echo -n "test Haproxy Availability... "
+r=1
+i=0
+while [[ $r -ne 0 ]]; do
+  sleep 1
+  timeout -t 2 curl -I "$HAPROXY_HOST:$STATS_PORT/$STATS_URL" 2>/dev/null | grep -q "HTTP/1.1 200 OK"
+  r=$?
+  ((i++))
+  if [[ $i -gt 12 ]]; then break; fi
+  echo -n "+"
+done
+if [[ $r -ne 0 ]]; then
+  echo
+  echo "$HAPROXY_HOST:$STATS_PORT failed"
+  curl -I "$HAPROXY_HOST:$STATS_PORT"
+  exit 1
+fi
+echo " [OK]"
+
+echo -n "test Haproxy stats... "
+r=1
+timeout -t 2 curl "$HAPROXY_HOST:$STATS_PORT/$STATS_URL;csv" 2>/dev/null | grep -q "http-in"
+r=$?
+if [[ $r -ne 0 ]]; then
+  echo
+  echo "can't find http-in in $HAPROXY_HOST:$STATS_PORT"
+  curl "$HAPROXY_HOST:$STATS_PORT;csv"
+  exit 1
+fi
+echo " [OK]"
+
+echo "all tests passed successfully"

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -4,6 +4,11 @@ package labels
 const (
 	// LabelsNameRole describe the role of the container/service in amp context
 	LabelsNameRole = "io.amp.role"
+
+	// LabelsMapping set a maaping between a logical host name and a service port
+	// format "name=myName account=myAccount port=myPort" -> will create a reverse proxy on http://myName.stackName.myAccount.local.appcelerator.io -> service:port
+	// by default name is the service name
+	LabelsNameMapping = "io.amp.mapping"
 )
 
 //Amp label values

--- a/stacks/amp.stack.yml
+++ b/stacks/amp.stack.yml
@@ -46,3 +46,21 @@ services:
     volumes:
       - ampagent:/containers
       - /var/run/docker.sock:/var/run/docker.sock
+
+  haproxy:
+    image: appcelerator/amphaproxy:1.0.0
+    networks:
+      - default
+    ports:
+      - "50180:80"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints: [node.role == manager]
+    labels:
+      io.amp.role: "infrastructure"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/stacks/ampmon.2.stack.yml
+++ b/stacks/ampmon.2.stack.yml
@@ -34,7 +34,6 @@ services:
       replicas: 1
       labels:
         io.amp.role: "infrastructure"
-        io.amp.mapping: "kibana:5601"
       placement:
         constraints: [node.role == worker]
     labels:

--- a/stacks/pinger.yml
+++ b/stacks/pinger.yml
@@ -6,7 +6,6 @@ networks:
       name: ampnet
 
 services:
-
   pinger:
     image: subfuzion/pinger
     networks:
@@ -19,6 +18,6 @@ services:
       replicas: 3
       labels:
         io.amp.role: "pinger"
+        io.amp.mapping: "account=tony name=mypinger port=3000"
       restart_policy:
         condition: on-failure
-


### PR DESCRIPTION
Have first level of HAproxy reverse-proxy mapping regarding amp label set in services
**see documentation: docs/stacks.md**

## test

- make build-cli
- ampmake clean build
- amp cluster create --127.0.0.1:50101

Once the cluster is up, we have for now to update manually the infrastructure amp.stack.yml stack (this is a temporary step):
- docker run --rm -v $PWD/stacks:/stacks:ro --network hostnet  docker -H m1 stack deploy -c stacks/amp.stack.yml amp

Then, we can test as usual with user stack having for instance the label: 
**io.amp.mapping: "account=tony name=mypinger port=3000"** 
for now the stack should use ampnet network to be able to be reverse-proxied.
for instance, `stacks/pinger.yml`:
```
version: "3"

networks:
  default:
    external:
      name: ampnet

services:
  pinger:
    image: subfuzion/pinger
    networks:
      default:
        aliases:
          - pinger
    ports:
      - "50105:3000"
    deploy:
      replicas: 3
      labels:
        io.amp.role: "pinger"
        io.amp.mapping: "account=tony name=mypinger port=3000"
      restart_policy:
        condition: on-failure
```

- amp signup/login if needed
- amp stack deploy -c stacks/pinger.yml test
- wait few seconds the time to HAProy to have its conf updated
- **curl mypinger.test.tony.local.appcelerator.io:50180/ping -> pong**

