### PR TITLE
Add visualizer stack

### DIFF
--- a/stacks/visualizer.stack.yml
+++ b/stacks/visualizer.stack.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  visualizer:
+    image: manomarks/visualizer
+    networks:
+      - default
+    environment:
+      SERVICE_PORTS: "8080"
+      VIRTUAL_HOST: "https://visualizer.*"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+
+  portainer:
+    image: portainer/portainer
+    networks:
+      - default
+    environment:
+      SERVICE_PORTS: "9000"
+      VIRTUAL_HOST: "https://portainer.*"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    deploy:
+      placement:
+        constraints: [node.role == manager]


### PR DESCRIPTION
Adds stack for visualization / demo purposes (includes manomarks/visualizer and portainer/portainer)

    $ amp -s=localhost stack deploy -c stacks/visualizer.stack.yml visualizer
 
The first time takes a short while since the images will need to be pulled. Once the services are running, you can visit the web pages at:

https://visualizer.local.atomiq.io

https://portainer.local.atomiq.io

