### PR TITLE
version of images in core stacks default to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - set -e
   - ampmake clean buildall
   - ls -la bin/linux/amd64
-  - hack/deploy
+  - hack/deploy -T local
   - hack/versioncheck 10
   - # TODO: amp cluster destroy
   - ampmake lint

--- a/bootstrap/build
+++ b/bootstrap/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TAGS=( latest 1.0.1 )
+TAGS=( latest 1.1.0 )
 OWNER=appcelerator
 IMAGE="${1:-amp-bootstrap}"
 

--- a/cli/command/cluster/bootstrap.go
+++ b/cli/command/cluster/bootstrap.go
@@ -17,7 +17,7 @@ func init() {
 		"--network", "host",
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-e", "GOPATH=/go",
-		"appcelerator/amp-bootstrap:1.0.1",
+		"appcelerator/amp-bootstrap:1.1.0",
 	}
 }
 

--- a/hack/deploy
+++ b/hack/deploy
@@ -2,8 +2,6 @@
 
 SUCCESS=0
 
-CID=$1
-
 # This script uses other scripts expected to be in the same directory
 # This gets absolute path to script (resolving symlinks)
 readonly SP="$(cd "$(dirname "$0")"; pwd -P)"
@@ -39,9 +37,9 @@ cluster_create() {
   local)
     # async
     if [ $# -eq 0 ]; then
-      $bootstrap -f
+      $bootstrap $BOOTSTRAP_OPTIONS -f
     else
-      $bootstrap -fi $1
+      $bootstrap $BOOTSTRAP_OPTIONS -fi $1
     fi ;;
   aws)
     # sync (modulo user data execution)
@@ -102,7 +100,7 @@ set_deployment_variables(){
     dockerhost=m1
     registryhost=127.0.0.1
     create_amp_stacks_volume
-    amps="docker run -t --rm --network=hostnet -v amp-stacks:/stacks docker --host=$dockerhost"
+    amps="docker run -t --rm --network=hostnet -e TAG=$TAG -v amp-stacks:/stacks docker --host=$dockerhost"
     stacks_path=/stacks
     domainname=$localdomainname
     ;;
@@ -110,7 +108,7 @@ set_deployment_variables(){
     # todo: use a secured remote API
     dockerhost=$($terraform output -state=/data/terraform.tfstate leader_ip)
     registryhost=$dockerhost
-    amps="docker -H $dockerhost"
+    amps="TAG=$TAG docker -H $dockerhost"
     stacks_path=stacks
     domainname=$clouddomainname
     # variable used in sub scripts
@@ -185,6 +183,20 @@ prepare_certificates() {
   $amps secret create "certificate_atomiq" /stacks/$name.pem
 }
 
+while getopts ":w:m:t:l:T:" opt; do
+  case $opt in
+  w|m|t|l) # just pass it to the bootstrap script
+    BOOTSTRAP_OPTIONS="$BOOTSTRAP_OPTIONS -${opt} $OPTARG"
+    ;;
+  T) # tag for images to deploy
+    export TAG=$OPTARG
+    ;;
+  esac
+done
+shift "$((OPTIND-1))"
+
+CID=$1
+
 trap cleanup EXIT
 
 echo "$(deployment_target) deployment"
@@ -233,10 +245,14 @@ $curlcheck "${registryhost}:5000/v2/" 200 180
 checkexit $? "registry timed out"
 ok
 
-echo "push images to cluster"
-for image in amplifier ampbeat agent funcexec funchttp; do
-  pushimage ${registryhost}:5000 appcelerator/${image}:local
-done
+if [[ "x$TAG" = "xlocal" ]]; then
+  echo "push images to cluster"
+  for image in amplifier ampbeat agent funcexec funchttp; do
+    pushimage ${registryhost}:5000 appcelerator/${image}:${TAG:-local}
+  done
+else
+  echo "image push to cluster is ignored (tag=${TAG:-latest})"
+fi
 
 maxwait=580
 echo "deploy amp monitoring stack to cluster - stage 1"

--- a/hack/dev
+++ b/hack/dev
@@ -2,7 +2,7 @@
 
 readonly CID="f573e897-7aa0-4516-a195-42ee91039e97"
 readonly SP="$(cd "$(dirname "$0")"; pwd -P)"
-readonly deploy="$SP/deploy"
+readonly deploy="$SP/deploy -T ${TAG:-local}"
 
 $deploy $CID
 status=$?

--- a/stacks/amp.stack.yml
+++ b/stacks/amp.stack.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   amplifier:
-    image: appcelerator/amplifier:local
+    image: appcelerator/amplifier:${TAG-latest}
     networks:
       default:
         aliases:
@@ -32,7 +32,7 @@ services:
         constraints: [node.role == manager]
 
   agent:
-    image: appcelerator/agent:local
+    image: appcelerator/agent:${TAG-latest}
     networks:
       default:
         aliases:

--- a/stacks/ampmon.2.stack.yml
+++ b/stacks/ampmon.2.stack.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   ampbeat:
-    image: appcelerator/ampbeat:local
+    image: appcelerator/ampbeat:${TAG-latest}
     networks:
       default:
         aliases:

--- a/stacks/function.stack.yml
+++ b/stacks/function.stack.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   funchttp:
-    image: appcelerator/funchttp:local
+    image: appcelerator/funchttp:${TAG-latest}
     networks:
       default:
         aliases:
@@ -25,7 +25,7 @@ services:
       - "VIRTUAL_HOST=https://faas.*"
 
   funcexec:
-    image: appcelerator/funcexec:local
+    image: appcelerator/funcexec:${TAG-latest}
     networks:
       default:
         aliases:


### PR DESCRIPTION
partial fix for #1067 

amplifier, agent, ampbeat, httpfunc and httpexec image versions are now variables, defaulting to `latest`

Since AMP v0.9.0, `amp cluster create -s localhost` will deploy the `latest` tag of these images instead of `local`.
After v0.9.0, to install another tag the hack/dev script will force the tag `local`, unless you use it with the environment variable TAG set to a different value.

## How to test

First, let's make sure the amp CLI 0.9.0 is working as expected
```
# download amp CLI 0.9.0
$ docker rmi appcelerator/amp-bootstrap:1.0.1
$ amp cluster create -s localhost
$ docker exec m1 docker service ls
ID            NAME               MODE        REPLICAS  IMAGE
8vkwk5am0ef5  amp_agent          global      3/3       appcelerator/agent:latest
95ov13bxxsnw  amp_funcexec       replicated  1/1       appcelerator/funcexec:latest
endc6e5r87v4  amp_ampbeat        replicated  1/1       appcelerator/ampbeat:latest
gytupvt3g9ir  amp_kibana         replicated  1/1       appcelerator/kibana:5.3.0-3
hk44erxnvtvn  amp_proxy          global      1/1       dockercloud/haproxy
pf1i9bnq519a  amp_amplifier      global      1/1       appcelerator/amplifier:latest
pwv5jfb31qrq  amp_elasticsearch  replicated  1/1       appcelerator/elasticsearch-amp:5.3.0
v7r0m6qm26io  amp_nats           replicated  1/1       appcelerator/amp-nats-streaming:v0.3.8
w1yr2lhmrvec  amp_etcd           replicated  1/1       appcelerator/etcd:3.1.5-1
yb3yfggp72ix  amp_funchttp       replicated  1/1       appcelerator/funchttp:latest
```
Notice the `latest` tag for these five services

Then, make sure the development workflow is also working as expected (forcing tag)
For this checkout this branch and check the following use cases.
```
$ hack/dev
$ docker exec m1 docker service ls
ID            NAME               MODE        REPLICAS  IMAGE
8vkwk5am0ef5  amp_agent          global      3/3       appcelerator/agent:local
95ov13bxxsnw  amp_funcexec       replicated  1/1       appcelerator/funcexec:local
endc6e5r87v4  amp_ampbeat        replicated  1/1       appcelerator/ampbeat:local
gytupvt3g9ir  amp_kibana         replicated  1/1       appcelerator/kibana:5.3.0-3
hk44erxnvtvn  amp_proxy          global      1/1       dockercloud/haproxy
pf1i9bnq519a  amp_amplifier      global      1/1       appcelerator/amplifier:local
pwv5jfb31qrq  amp_elasticsearch  replicated  1/1       appcelerator/elasticsearch-amp:5.3.0
v7r0m6qm26io  amp_nats           replicated  1/1       appcelerator/amp-nats-streaming:v0.3.8
w1yr2lhmrvec  amp_etcd           replicated  1/1       appcelerator/etcd:3.1.5-1
yb3yfggp72ix  amp_funchttp       replicated  1/1       appcelerator/funchttp:local
```
Notice the `local` tag for these five services
```
$ TAG=0.9.0 hack/dev
$ docker exec m1 docker service ls
ID            NAME               MODE        REPLICAS  IMAGE
8vkwk5am0ef5  amp_agent          global      3/3       appcelerator/agent:0.9.0
95ov13bxxsnw  amp_funcexec       replicated  1/1       appcelerator/funcexec:0.9.0
endc6e5r87v4  amp_ampbeat        replicated  1/1       appcelerator/ampbeat:0.9.0
gytupvt3g9ir  amp_kibana         replicated  1/1       appcelerator/kibana:5.3.0-3
hk44erxnvtvn  amp_proxy          global      1/1       dockercloud/haproxy
pf1i9bnq519a  amp_amplifier      global      1/1       appcelerator/amplifier:0.9.0
pwv5jfb31qrq  amp_elasticsearch  replicated  1/1       appcelerator/elasticsearch-amp:5.3.0
v7r0m6qm26io  amp_nats           replicated  1/1       appcelerator/amp-nats-streaming:v0.3.8
w1yr2lhmrvec  amp_etcd           replicated  1/1       appcelerator/etcd:3.1.5-1
yb3yfggp72ix  amp_funchttp       replicated  1/1       appcelerator/funchttp:0.9.0
```
Notice the `0.9.0` tag for these five services
