### PR TITLE
[CLI Refactor] Update rm commands to accept multiple args

### DIFF
--- a/cli/command/org/member/remove.go
+++ b/cli/command/org/member/remove.go
@@ -1,7 +1,8 @@
 package member
 
 import (
-	"fmt"
+	"errors"
+	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/account"
 	"github.com/appcelerator/amp/cli"
@@ -10,49 +11,46 @@ import (
 	"google.golang.org/grpc"
 )
 
-type remMemOrgOpts struct {
-	name   string
-	member string
+type remMemOrgOptions struct {
+	name string
 }
-
-var (
-	remMemOrgOptions = &remMemOrgOpts{}
-)
 
 // NewOrgRemoveMemCommand returns a new instance of the remove organization member command.
 func NewOrgRemoveMemCommand(c cli.Interface) *cobra.Command {
+	opts := remMemOrgOptions{}
 	cmd := &cobra.Command{
-		Use:     "rm [OPTIONS]",
+		Use:     "rm [OPTIONS] MEMBER(S)",
 		Short:   "Remove member from organization",
 		Aliases: []string{"remove"},
-		PreRunE: cli.NoArgs,
+		PreRunE: cli.AtLeastArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return removeOrgMem(c, cmd)
+			return removeOrgMem(c, cmd, args, opts)
 		},
 	}
-	flags := cmd.Flags()
-	flags.StringVar(&remMemOrgOptions.name, "org", "", "Organization name")
-	flags.StringVar(&remMemOrgOptions.member, "member", "", "Member name")
+	cmd.Flags().StringVar(&opts.name, "org", "", "Organization name")
 	return cmd
 }
 
-func removeOrgMem(c cli.Interface, cmd *cobra.Command) error {
+func removeOrgMem(c cli.Interface, cmd *cobra.Command, args []string, opts remMemOrgOptions) error {
+	var errs []string
 	if !cmd.Flag("org").Changed {
-		remMemOrgOptions.name = c.Console().GetInput("organization name")
+		opts.name = c.Console().GetInput("organization name")
 	}
-	if !cmd.Flag("member").Changed {
-		remMemOrgOptions.member = c.Console().GetInput("member name")
-	}
-
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
-	request := &account.RemoveUserFromOrganizationRequest{
-		OrganizationName: remMemOrgOptions.name,
-		UserName:         remMemOrgOptions.member,
+	for _, member := range args {
+		request := &account.RemoveUserFromOrganizationRequest{
+			OrganizationName: opts.name,
+			UserName:         member,
+		}
+		if _, err := client.RemoveUserFromOrganization(context.Background(), request); err != nil {
+			errs = append(errs, grpc.ErrorDesc(err))
+			continue
+		}
+		c.Console().Println(member)
 	}
-	if _, err := client.RemoveUserFromOrganization(context.Background(), request); err != nil {
-		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
 	}
-	c.Console().Println("Member has been removed from organization.")
 	return nil
 }

--- a/cli/command/user/remove.go
+++ b/cli/command/user/remove.go
@@ -2,7 +2,7 @@ package user
 
 import (
 	"errors"
-	"fmt"
+	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/account"
 	"github.com/appcelerator/amp/cli"
@@ -11,43 +11,38 @@ import (
 	"google.golang.org/grpc"
 )
 
-type removeUserOpts struct {
-	username string
-}
-
-var (
-	rmOptions = &removeUserOpts{}
-)
-
 // NewRemoveUserCommand returns a new instance of the remove user command.
 func NewRemoveUserCommand(c cli.Interface) *cobra.Command {
 	return &cobra.Command{
-		Use:     "rm USERNAME",
+		Use:     "rm USERNAME(S)",
 		Short:   "Remove user",
 		Aliases: []string{"remove"},
-		PreRunE: cli.ExactArgs(1),
+		PreRunE: cli.AtLeastArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if args[0] == "" {
-				return errors.New("username cannot be empty")
-			}
-			rmOptions.username = args[0]
-			return removeUser(c, rmOptions)
+			return removeUser(c, args)
 		},
 	}
 }
 
-func removeUser(c cli.Interface, opt *removeUserOpts) error {
+func removeUser(c cli.Interface, args []string) error {
+	var errs []string
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
-	request := &account.DeleteUserRequest{
-		Name: opt.username,
-	}
-	if _, err := client.DeleteUser(context.Background(), request); err != nil {
-		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	for _, name := range args {
+		request := &account.DeleteUserRequest{
+			Name: name,
+		}
+		if _, err := client.DeleteUser(context.Background(), request); err != nil {
+			errs = append(errs, grpc.ErrorDesc(err))
+			continue
+		}
+		c.Console().Println(name)
 	}
 	if err := cli.RemoveToken(); err != nil {
-		return err
+		errs = append(errs, err.Error())
 	}
-	c.Console().Println("User removed.")
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
 	return nil
 }

--- a/cli/required.go
+++ b/cli/required.go
@@ -38,3 +38,18 @@ func ExactArgs(num int) func(cmd *cobra.Command, args []string) error {
 		)
 	}
 }
+
+// AtLeastArgs returns an error if the min number of args are not passed
+func AtLeastArgs(min int) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) >= min {
+			return nil
+		}
+		return fmt.Errorf(
+			"\"%s\" requires at least %d argument(s).\nSee '%s --help'",
+			cmd.CommandPath(),
+			min,
+			cmd.CommandPath(),
+		)
+	}
+}

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
-	//"github.com/appcelerator/amp/api/auth"
 	"github.com/appcelerator/amp/cli"
 	"github.com/appcelerator/amp/cli/command/cluster"
 	"github.com/appcelerator/amp/cli/command/function"
@@ -20,7 +20,6 @@ import (
 	"github.com/appcelerator/amp/cli/command/user"
 	"github.com/appcelerator/amp/cli/command/version"
 	"github.com/appcelerator/amp/cli/command/whoami"
-	//"github.com/dgrijalva/jwt-go"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +42,8 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 				c.SetServer(opts.server)
 			}
 
-			err := info(c)
-			if err != nil {
-				return err
-			}
+			//print current context
+			info(c)
 
 			if cmd.Parent() != nil && cmd.Parent().Use == "cluster" {
 				// TODO special case handling for cluster this release
@@ -126,26 +123,7 @@ func addCommands(cmd *cobra.Command, c cli.Interface) {
 	)
 }
 
-func info(c cli.Interface) error {
+func info(c cli.Interface) {
 	s := c.Server()
-	c.Console().Infof("[%s]\n", s)
-
-	//// TODO: pToken.Claims panics
-	//token, err := cli.ReadToken()
-	//if err != nil {
-	//	c.Console().Infof("[%s] Not logged in. Use `amp login` or `amp user signup`\n.", s)
-	//}
-
-	//pToken, _ := jwt.ParseWithClaims(token, &auth.AccountClaims{}, func(t *jwt.Token) (interface{}, error) {
-	//	return []byte{}, nil
-	//})
-
-	//if claims, ok := pToken.Claims.(*auth.AccountClaims); ok {
-	//	if claims.ActiveOrganization != "" {
-	//		c.Console().Infof("[%s] user: %s (organization: %s)\n", s, claims.AccountName, claims.ActiveOrganization)
-	//	} else {
-	//		c.Console().Infof("[%s] user: %s\n", s, claims.AccountName)
-	//	}
-	//}
-	return nil
+	fmt.Fprintf(c.Err(), "[%s]\n", s)
 }


### PR DESCRIPTION
Resolves #1102 
Fixes #1113 

Updated `remove` sub-commands for the following commands to accept more than one argument (or even the output of a list command) -
```
- function
- org, org member
- team, team member, team resource
- user
```

### To test

#### Build and deploy
```
$ ampmake build
$ alias amp='amp -s localhost'
$ amp cluster create --tag=local
$ rm ~/.config/amp/token
```
#### Create user, verify and login
```
$ amp user signup
$ amp user verify eyJhbGc....
$ amp login
```
#### Create different organizations
```
$ amp org create --org=org1 --email=org1@xmail.com 
$ amp org create --org=org2 --email=org2@xmail.com 
$ amp org create --org=org3 --email=org3@xmail.com 
```
#### List organizations
```
$ amp org ls -q
[localhost:50101]
org1
org2
org3
```
#### Add members to organizations
```
$ amp org member add --org=org1 --member=foo
$ amp org member add --org=org1 --member=bar
```
#### List organization members
```
$ amp org member ls --org=org1 -q
[localhost:50101]
foo
bar
```
#### Remove one or more members in an organization
`$ amp org member rm --org=org1 foo`
or
`$ amp org member rm --org=org1 foo bar`
or
`$ amp org member rm --org=org1 $(amp org member ls --org=org1 -q)`
#### Remove one or more organizations
`$ amp org rm org1`
or
`$ amp org rm org3 org2`
or
`$ amp org rm $(amp org ls -q)`