### PR TITLE
fix commands in generated emails

### DIFF
--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -33,7 +33,6 @@ func main() {
 		Version:          Version,
 		Build:            Build,
 		Port:             server.DefaultPort,
-		PublicAddress:    server.DefaultPublicAddress,
 		EmailSender:      mail.DefaultSender,
 		SmsSender:        sms.DefaultSender,
 		EtcdEndpoints:    []string{etcd.DefaultEndpoint},

--- a/cmd/amplifier/server/configuration.go
+++ b/cmd/amplifier/server/configuration.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	DefaultPort          = ":50101"
-	DefaultPublicAddress = "local.appcelerator.io"
-	DefaultTimeout       = time.Minute
+	DefaultPort    = ":50101"
+	DefaultTimeout = time.Minute
 )
 
 // Config is used for amplifier configuration settings
@@ -20,7 +19,6 @@ type Configuration struct {
 	Version          string
 	Build            string
 	Port             string
-	PublicAddress    string
 	EtcdEndpoints    []string
 	ElasticsearchURL string
 	NatsURL          string

--- a/cmd/amplifier/server/server.go
+++ b/cmd/amplifier/server/server.go
@@ -126,7 +126,7 @@ func initDocker(config *Configuration) error {
 }
 
 func initMailer(config *Configuration) error {
-	runtime.Mailer = mail.NewMailer(config.EmailKey, config.EmailSender, config.PublicAddress)
+	runtime.Mailer = mail.NewMailer(config.EmailKey, config.EmailSender)
 	return nil
 }
 

--- a/pkg/mail/accountResetPassword.go
+++ b/pkg/mail/accountResetPassword.go
@@ -7,11 +7,11 @@ var accountResetPasswordEmailBody = `
         <div style="color:#404040;">
          	<h2>Hi <b style="color:red">{accountName}</b>!</h2>
             <h3>If you requested a new password for your AMP account, please use the following command line:</h4>
-            <h4>amp password --set {token}</h4>
+            <h4>amp -s {ampAddress} password set --token {token}</h4>
         <div style="height:20px"></div>
         <div style="color:#404040;">
             <h4>If you didn't make this request, you can safely ignore this email</h4>
-            <h4>This link is good for one hour only</h4>
+            <h4>This token is valid for one hour only</h4>
         </div>
     </body>
 </html>

--- a/pkg/mail/accountVerification.go
+++ b/pkg/mail/accountVerification.go
@@ -8,7 +8,11 @@ var accountVerificationBody = `
             <h2>Hi <b style="color:red">{accountName}</b>, thanks for joining AMP!</h2>
             <h3>You have successfully created an AMP account.</h3>
             <h3>Please validate your AMP account using the following command line:</h4>
-            <h4>amp user verify {token}</h4>
+            <h4>amp -s {ampAddress} user verify {token}</h4>
+        </div>
+        <div style="color:#404040;">
+            <h4>If you didn't make this request, you can safely ignore this email</h4>
+            <h4>This token is valid for one hour only</h4>
         </div>
     </body>
 </html>

--- a/pkg/mail/mailer.go
+++ b/pkg/mail/mailer.go
@@ -21,15 +21,13 @@ type emailTemplate struct {
 type Mailer struct {
 	apiKey           string
 	emailSender      string
-	publicAddress    string
 	emailTemplateMap map[string]*emailTemplate
 }
 
-func NewMailer(apiKey string, emailSender string, publicAddress string) *Mailer {
+func NewMailer(apiKey string, emailSender string) *Mailer {
 	mailer := &Mailer{
 		apiKey:           apiKey,
 		emailSender:      emailSender,
-		publicAddress:    publicAddress,
 		emailTemplateMap: make(map[string]*emailTemplate),
 	}
 
@@ -55,12 +53,12 @@ func NewMailer(apiKey string, emailSender string, publicAddress string) *Mailer 
 }
 
 // SendAccountVerificationEmail send mail
-func (m *Mailer) SendAccountVerificationEmail(to string, accountName string, token string) error {
+func (m *Mailer) SendAccountVerificationEmail(to string, accountName string, token string, address string) error {
 	//config := conf.GetRegularConfig(false)
 	variables := map[string]string{
 		"accountName": accountName,
 		"token":       token,
-		"ampAddress":  m.publicAddress,
+		"ampAddress":  address,
 	}
 	if err := m.SendTemplateEmail(to, "AccountVerification", variables); err != nil {
 		return err
@@ -185,12 +183,12 @@ func (m *Mailer) SendTeamRemovedEmail(to string, team string) error {
 }
 
 // SendAccountResetPasswordEmail send a AccountResetPassword email template
-func (m *Mailer) SendAccountResetPasswordEmail(to string, accountName string, token string) error {
+func (m *Mailer) SendAccountResetPasswordEmail(to string, accountName string, token string, address string) error {
 	//config := conf.GetRegularConfig(false)
 	variables := map[string]string{
 		"accountName": accountName,
 		"token":       token,
-		"ampAddress":  m.publicAddress,
+		"ampAddress":  address,
 	}
 	if err := m.SendTemplateEmail(to, "AccountResetPassword", variables); err != nil {
 		return err


### PR DESCRIPTION
Fixes #1018 

Relying on gRPC over HTTP2 specification (https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests) to determine the server address used by the client.

## How to test
```
ampmake clean build
alias amp='amp -s localhost'
amp cluster create --tag=local
amp user signup --user user
[Make sure you received an email with a valid command line for verification]
[After verification]
amp password reset user
[Make sure you received an email with a valid command line for password reset]
```