### PR TITLE
[stack] Two letter stack name

### DIFF
--- a/data/stacks/validators.go
+++ b/data/stacks/validators.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var nameFormat = regexp.MustCompile(`^[a-z0-9\-]{3,128}$`)
+var nameFormat = regexp.MustCompile(`^[a-z0-9\-]{2,128}$`)
 
 // CheckName checks name
 func CheckName(name string) (string, error) {


### PR DESCRIPTION
Fixes #1101 

At stack creation, the command accepts a two-letter stack name.

```
    $ amp stack deploy -c examples/stacks/pinger/pinger.yml p1    
```