### PR TITLE
etcd cluster

### DIFF
--- a/stacks/ampmon.1.stack.yml
+++ b/stacks/ampmon.1.stack.yml
@@ -5,9 +5,6 @@ networks:
     external:
       name: ampnet
 
-volumes:
-  amp-etcd:
-
 services:
 
   elasticsearch:
@@ -46,11 +43,9 @@ services:
       default:
         aliases:
           - etcd
-    volumes:
-      - amp-etcd:/data
     environment:
       SERVICE_NAME: "etcd"
-      MIN_SEEDS_COUNT: 2
+      MIN_SEEDS_COUNT: 3
     command:
       - "--advertise-client-urls"
       - "http://etcd:2379"
@@ -58,7 +53,7 @@ services:
       io.amp.role: "infrastructure"
     deploy:
       mode: replicated
-      replicas: 2
+      replicas: 3
       labels:
         io.amp.role: "infrastructure"
       placement:

--- a/stacks/ampmon.1.stack.yml
+++ b/stacks/ampmon.1.stack.yml
@@ -41,7 +41,7 @@ services:
         constraints: [node.role == worker]
 
   etcd:
-    image: appcelerator/etcd:3.1.5-1
+    image: appcelerator/etcd:3.1.6
     networks:
       default:
         aliases:

--- a/stacks/ampmon.1.stack.yml
+++ b/stacks/ampmon.1.stack.yml
@@ -46,16 +46,19 @@ services:
       default:
         aliases:
           - etcd
-    command:
-      - "--listen-client-urls"
-      - "http://0.0.0.0:2379"
-      - "--advertise-client-urls"
-      - "http://etcd:2379"
     volumes:
       - amp-etcd:/data
+    environment:
+      SERVICE_NAME: "etcd"
+      MIN_SEEDS_COUNT: 2
+    command:
+      - "--advertise-client-urls"
+      - "http://etcd:2379"
     labels:
       io.amp.role: "infrastructure"
     deploy:
+      mode: replicated
+      replicas: 2
       labels:
         io.amp.role: "infrastructure"
       placement:


### PR DESCRIPTION
ref #1063 

- bump etcd to 3.1.6
- cluster

how to test:
```
$ hack/dev
...
$ docker exec m1 docker run --rm -e ETCDCTL_API=3 --network ampnet appcelerator/etcd:3.1.6 /bin/etcdctl --endpoints=etcd:2379 member list
9e71dd434f8d295f, started, etcd-9, http://10.0.0.9:2380, http://0.0.0.0:2379,http://0.0.0.0:4001
c257cd058ed71587, started, etcd-10, http://10.0.0.10:2380, http://0.0.0.0:2379,http://0.0.0.0:4001
# 2 members are listed
```