### PR TITLE
Default stack name

### DIFF
--- a/cli/required.go
+++ b/cli/required.go
@@ -53,3 +53,19 @@ func AtLeastArgs(min int) func(cmd *cobra.Command, args []string) error {
 		)
 	}
 }
+
+// RangeArgs returns an error if the min and max number of args are not passed
+func RangeArgs(min int, max int) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) >= min && len(args) <= max {
+			return nil
+		}
+		return fmt.Errorf(
+			"\"%s\" requires at least %d argument(s) and at most %d argument(s).\nSee '%s --help'",
+			cmd.CommandPath(),
+			min,
+			max,
+			cmd.CommandPath(),
+		)
+	}
+}


### PR DESCRIPTION
Closes #1081 

If no stack name is provided during stack creation, a default stack name is assigned. 
For example: 
`amp -s localhost stack start -c examples/stacks/pinger/pinger.yml` creates a stack with a default stack name `pinger`

### To test
`$ amp -s localhost stack start -c examples/stacks/pinger/pinger.yml`
or
`$ amp -s localhost stack start -c stacks/visualizer.stack.yml`


