### PR TITLE
false positive in versioncheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - ampmake clean buildall
   - ls -la bin/linux/amd64
   - hack/deploy -T local
-  - hack/versioncheck 10
+  - hack/versioncheck 15
   - # TODO: amp cluster destroy
   - ampmake lint
 

--- a/hack/versioncheck
+++ b/hack/versioncheck
@@ -18,7 +18,9 @@ while true; do
     $AMP version
     docker run -it --rm --network=hostnet -v $PWD/stacks:/stacks docker --host=m1 service ls
     echo "-------------------------------"
-    v=$($AMP version | grep 'not connected' | wc -l)
-    [[ $v -eq 0 ]] && [[ $SECONDS -lt $TIMEOUT ]] && $AMP version && break
+    # looking for the server information line
+    output=$($AMP version | grep '^Server:')
+    # try again if the text "not connected" appears
+    [[ -n "$output" ]] && echo "$output" | grep -qv "not connected" && [[ $SECONDS -lt $TIMEOUT ]] && $AMP version && break
     [[ $SECONDS -gt $TIMEOUT ]] && echo "version check timed out" && exit 1
 done


### PR DESCRIPTION
fix #1116 

the original test was just looking for the absence of "not connected"
But sometimes, the output does not even contain the "Server:" bloc, which result in a false positive.
This PR looks specifically for this line and makes sure the not connected message is not there.