### PR TITLE
Revert "dind 17.05-rc2": connection from outside the swarm was broken

### DIFF
--- a/bootstrap/config.docker-local.tpl
+++ b/bootstrap/config.docker-local.tpl
@@ -16,7 +16,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind:17.05-rc2"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
               "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
@@ -84,7 +84,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind:17.05-rc2"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
               "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
@@ -152,7 +152,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind:17.05-rc2"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
               "Cmd": "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"{{ end }} {{ if var "/docker/ports/exposed" }},
               "ExposedPorts": {{ var "/docker/ports/exposed" | jsonEncode }} {{ end }}
             },


### PR DESCRIPTION
This reverts commit 9882bfe02d8fb477691f97c070c9026a41e9e729.

how to check:

$ hack/dev
$ amp -s localhost version # no connection error

check the haproxy page on your browser: http://proxy.local.atomiq.io:1936/