### PR TITLE
Downgrade to 17.05-ce-rc1 due to github.com/moby/moby/issues/32916

### DIFF
--- a/bootstrap/config.docker-local.tpl
+++ b/bootstrap/config.docker-local.tpl
@@ -16,7 +16,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
               "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
@@ -84,7 +84,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
               "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
@@ -152,7 +152,7 @@
           "Plugin": "instance-docker",
           "Properties": {
             "Config": {
-              "Image": "subfuzion/dind"{{ if var "/docker/registry/host" }},
+              "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
               "Cmd": "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"{{ end }} {{ if var "/docker/ports/exposed" }},
               "ExposedPorts": {{ var "/docker/ports/exposed" | jsonEncode }} {{ end }}
             },


### PR DESCRIPTION
Due to a regression with Docker 17.05-ce-rc2 that appears related to [this issue](https://github.com/moby/moby/issues/32916), this PR downgrades the DinD version to 17.05-ce-rc1.

## Verification

    $ hack/dev
    $ amp -s localhost version # confirm server details (no connection issue)

Check haproxy page at: http://proxy.local.atomiq.io:1936/