### PR TITLE
local tag in Makefile bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(AMPTARGET): $(GLIDETARGETS) $(PROTOTARGETS) $(AMPSRC)
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) hack/lbuild $(REPO)/bin $(AMP) $(AMPPKG) $(LDFLAGS)
 	@echo "bin/$(GOOS)/$(GOARCH)/$(AMP)"
 
-build-cli: $(AMPTARGET)
+build-cli: $(AMPTARGET) build-bootstrap
 
 .PHONY: rebuild-cli
 rebuild-cli: clean-cli build-cli
@@ -339,13 +339,14 @@ clean-ui:
 AMPBOOTDIR := bootstrap
 AMPBOOTBIN := bootstrap
 AMPBOOTIMG := appcelerator/amp-bootstrap
+AMPBOOTVER ?= local
 AMPBOOTSRC := hack/deploy hack/dev $(shell find $(AMPBOOTDIR) -type f)
 
 .PHONY: build-bootstrap
 build-bootstrap:
-	@echo "Building $(AMPBOOTIMG)"
+	@echo "Building $(AMPBOOTIMG):$(AMPBOOTVER)"
 	@cp -r hack stacks $(AMPBOOTDIR)
-	@$(DOCKER_CMD) build --no-cache -t $(AMPBOOTIMG) $(AMPBOOTDIR)
+	@$(DOCKER_CMD) build -t $(AMPBOOTIMG):$(AMPBOOTVER) $(AMPBOOTDIR) >/dev/null
 	@rm -rf $(AMPBOOTDIR)/hack $(AMPBOOTDIR)/stacks
 
 .PHONY: push-bootstrap

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.03
+FROM docker:17.03.1-ce
 
 RUN apk --update --no-cache add bash openssl
 


### PR DESCRIPTION
this PR depends on another PR that will make sure the CLI uses the amp-bootstrap:local image.

- the build-cli target depends on the build-bootstrap target
- the build-bootstrap target builds the amp-bootstrap image with tag _local_

how to test:
Build the CLI
```
$ make build-cli
...
```

remove the amp-bootstrap image from your Docker cache.
```
$ docker image rm appcelerator/amp-bootstrap:local
Untagged: appcelerator/amp-bootstrap:local
Deleted: sha256:7867389cc14f67fbc9fba02e10bd8f8f5db8c848e1eea64a7650b5e1866ee6ae
Deleted: sha256:b3c655a646c5db69d1cb953452540703c50092ac65161375fa972df2e4052f02
Deleted: sha256:68f86920afbd56b6e407bf74cb317893e030167f696da1109475b2bd19fe5bc1
Deleted: sha256:cdb45ee3367d4282ed7ad1412c07c8507c1579e60edca22bd07478e5ae7ab4c4
Deleted: sha256:55886cbfd82c785a3124426f09118d0f2961c37ebf9b9e738376df2099bbfab1
Deleted: sha256:4ec5ecfa5bc1003e0617760aa3a92c0d64abb1b90b6b791e2f2429ec478d6913
Deleted: sha256:320f1839d1e9ab395db95af5da3f88fc12c665f50d897175317bed140639fde7
Deleted: sha256:70486266adde7c40537d784b766735c725ba353487d4fd5b7a2a9942565a1076
Deleted: sha256:c18e8fd169706eb129c839a9a4d3f9605f6c301a975ea1a25214e5dada455a42
```
Build the CLI, it should take a significant time to build the bootstrap image.
```
~/Development/src/github.com/appcelerator/amp(makefile-bootstrap ✗) make build-cli
Building appcelerator/amp-bootstrap:local
```
Build again, it should be instantaneous.
```
~/Development/src/github.com/appcelerator/amp(makefile-bootstrap ✗) make build-cli
Building appcelerator/amp-bootstrap:local
```