### PR TITLE
Use standard HTTP authorization header

### DIFF
--- a/amp-ui/server/core/api.go
+++ b/amp-ui/server/core/api.go
@@ -45,7 +45,7 @@ func (s *serverAPI) handleAPIFunctions(r *mux.Router) {
 }
 
 func (s *serverAPI) setToken(r *http.Request) context.Context {
-	md := metadata.Pairs(auth.TokenKey, r.Header.Get("TokenKey"))
+	md := metadata.Pairs(auth.AuthorizationHeader, r.Header.Get("AuthorizationHeader"))
 	return metadata.NewContext(context.Background(), md)
 }
 
@@ -145,7 +145,7 @@ func (s *serverAPI) login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//return token
-	tokens := header[auth.TokenKey]
+	tokens := header[auth.AuthorizationHeader]
 	if len(tokens) == 0 {
 		log.Println("invalid token.")
 		http.Error(w, "invalid token.", http.StatusInternalServerError)

--- a/cli/command/login/login.go
+++ b/cli/command/login/login.go
@@ -47,12 +47,12 @@ func login(c cli.Interface, cmd *cobra.Command, opts loginOptions) error {
 		Name:     opts.username,
 		Password: opts.password,
 	}
-	header := metadata.MD{}
-	_, err := client.Login(context.Background(), request, grpc.Header(&header))
+	headers := metadata.MD{}
+	_, err := client.Login(context.Background(), request, grpc.Header(&headers))
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
-	if err := cli.SaveToken(header); err != nil {
+	if err := cli.SaveToken(headers); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
 	c.Console().Printf("Welcome back %s!\n", opts.username)

--- a/cli/command/org/switch.go
+++ b/cli/command/org/switch.go
@@ -29,12 +29,12 @@ func switch_(c cli.Interface, args []string) error {
 	request := &account.SwitchRequest{
 		Account: args[0],
 	}
-	header := metadata.MD{}
-	_, err := client.Switch(context.Background(), request, grpc.Header(&header))
+	headers := metadata.MD{}
+	_, err := client.Switch(context.Background(), request, grpc.Header(&headers))
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
-	if err := cli.SaveToken(header); err != nil {
+	if err := cli.SaveToken(headers); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
 	c.Console().Printf("You are now logged in as: %s\n", args[0])

--- a/cli/token.go
+++ b/cli/token.go
@@ -18,9 +18,8 @@ var (
 )
 
 // SaveToken saves the authentication token to file
-func SaveToken(metadata metadata.MD) error {
-	// Extract token from header
-	tokens := metadata[auth.TokenKey]
+func SaveToken(headers metadata.MD) error {
+	tokens := headers[auth.TokenKey]
 	if len(tokens) == 0 {
 		return fmt.Errorf("invalid token")
 	}
@@ -28,7 +27,6 @@ func SaveToken(metadata metadata.MD) error {
 	if token == "" {
 		return fmt.Errorf("invalid token")
 	}
-
 	usr, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("cannot get current user: %s", err)
@@ -80,7 +78,7 @@ type LoginCredentials struct {
 // GetRequestMetadata implements credentials.PerRPCCredentials
 func (c *LoginCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
 	return map[string]string{
-		auth.TokenKey: c.Token,
+		auth.AuthorizationHeader: auth.ForgeAuthorizationHeader(c.Token),
 	}, nil
 }
 

--- a/platform/tests/gateway/http-auth
+++ b/platform/tests/gateway/http-auth
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-set -e
-
 amp="amp -s localhost"
+set -e
+function cleanup {
+  $amp user rm user
+}
+trap cleanup EXIT
 
 rm -f ~/.config/amp/token
 
@@ -23,4 +26,5 @@ sleep 15
 # TODO: use jq
 $ curl -k --header "Authorization: amp $TOKEN" https://gw.local.atomiq.io/v1/stacks | grep "{\"stacks\":"
 #  {"stacks":[{"stack":{"id":"f48137d2c207f352","name":"pinger","owner":{"name":"qube"}},"service":"1"}]}
+
 

--- a/platform/tests/gateway/http-auth
+++ b/platform/tests/gateway/http-auth
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+amp="amp -s localhost"
+
+rm -f ~/.config/amp/token
+
+$amp user signup --name user --password password --email email@user.amp
+
+$amp login --name user --password password
+TOKEN=$(cat ~/.config/amp/token)
+
+# no stacks yet
+curl -k --header "Authorization: amp $TOKEN" https://gw.local.atomiq.io/v1/stacks | grep "{}"
+
+# deploy a stack
+$amp stack deploy -c "tests/gateway/pinger.yml" pinger
+
+# TODO: need to use servicescheck or similar
+sleep 15
+
+# TODO: use jq
+$ curl -k --header "Authorization: amp $TOKEN" https://gw.local.atomiq.io/v1/stacks | grep "{\"stacks\":"
+#  {"stacks":[{"stack":{"id":"f48137d2c207f352","name":"pinger","owner":{"name":"qube"}},"service":"1"}]}
+

--- a/platform/tests/gateway/pinger.yml
+++ b/platform/tests/gateway/pinger.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  pinger:
+    image: subfuzion/pinger
+    networks:
+      default:
+        aliases:
+          - pinger
+    environment:
+      SERVICE_PORTS: "3000"
+      VIRTUAL_HOST: "https://pinger.*"
+    deploy:
+      replicas: 3
+      labels:
+        io.amp.role: "pinger"
+      restart_policy:
+        condition: on-failure

--- a/platform/tests/signup/signup
+++ b/platform/tests/signup/signup
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 amp="amp -s localhost"
+set -e
+function cleanup {
+  $amp user rm user
+}
+trap cleanup EXIT
+
 $amp user signup --name user --password password --email email@user.amp
 $amp login --name user --password password
 $amp user ls -q | wc -l | grep 1

--- a/tests/integration/rpc/main_test.go
+++ b/tests/integration/rpc/main_test.go
@@ -103,12 +103,12 @@ func createUser(t *testing.T, user *account.SignUpRequest) context.Context {
 	assert.NoError(t, err)
 
 	// Extract token from header
-	tokens := header[auth.TokenKey]
+	tokens := header[auth.AuthorizationHeader]
 	assert.NotEmpty(t, tokens)
 	token := tokens[0]
 	assert.NotEmpty(t, token)
 
-	return metadata.NewContext(ctx, metadata.Pairs(auth.TokenKey, token))
+	return metadata.NewContext(ctx, metadata.Pairs(auth.AuthorizationHeader, token))
 }
 
 func createOrganization(t *testing.T, org *account.CreateOrganizationRequest, owner *account.SignUpRequest) context.Context {
@@ -166,12 +166,12 @@ func switchAccount(userCtx context.Context, t *testing.T, accountName string) co
 	assert.NoError(t, err)
 
 	// Extract token from header
-	tokens := header[auth.TokenKey]
+	tokens := header[auth.AuthorizationHeader]
 	assert.NotEmpty(t, tokens)
 	token := tokens[0]
 	assert.NotEmpty(t, token)
 
-	return metadata.NewContext(ctx, metadata.Pairs(auth.TokenKey, token))
+	return metadata.NewContext(ctx, metadata.Pairs(auth.AuthorizationHeader, token))
 }
 
 func changeOrganizationMemberRole(userCtx context.Context, t *testing.T, org *account.CreateOrganizationRequest, user *account.SignUpRequest, role accounts.OrganizationRole) {


### PR DESCRIPTION
Fixes #1130 

## How to test
```
$ ampmake build
$ alias amp='amp -s localhost'
$ amp cluster create --tag=local --registration=none
$ rm -f ~/.config/amp/token
$ amp user signup --name user --password password --email email@user.amp
$ amp login --name user --password password
$ cat ~/.config/amp/token
TOKEN
$ curl -k --header "Authorization: amp TOKEN" https://gw.local.atomiq.io/v1/stacks
{}
$ amp stack deploy -c examples/stacks/pinger/pinger.yml pinger
$ curl -k --header "Authorization: amp TOKEN" https://gw.local.atomiq.io/v1/stacks
{"stacks":[{"stack":{"id":"f48137d2c207f352","name":"pinger","owner":{"name":"qube"}},"service":"1"}]}
```