### PR TITLE
Cluster create local

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.03.1-ce
+FROM docker:17.05.0-ce-rc1
 
 RUN apk --update --no-cache add bash openssl
 

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -44,8 +44,8 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 	return cmd
 }
 
-func queryCluster(c cli.Interface, args []string) error {
-	err := Run(c, args)
+func queryCluster(c cli.Interface, args []string, env map[string]string) error {
+	err := Run(c, args, env)
 	if err != nil {
 		// TODO: the local cluster is the only one that can be managed this release
 		c.Console().Println(DefaultLocalClusterID)

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -42,5 +42,6 @@ func create(c cli.Interface, cmd *cobra.Command) error {
 	args := []string{"hack/deploy"}
 	args = reflag(cmd, m, args)
 	args = append(args, DefaultLocalClusterID)
-	return queryCluster(c, args)
+	env := map[string]string{"TAG": opts.tag}
+	return queryCluster(c, args, env)
 }

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -21,7 +21,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.IntVarP(&opts.managers, "managers", "m", 3, "Intial number of manager nodes")
 	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
-	flags.StringVar(&opts.tag, "tag", "latest", "Specify tag for cluster images (default is 'latest', use 'local' for development)")
+	flags.StringVarP(&opts.tag, "tag","t","latest", "Specify tag for cluster images (default is 'latest', use 'local' for development)")
 	return cmd
 }
 

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -21,5 +21,5 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 func remove(c cli.Interface) error {
 	// TODO: only supporting local cluster management for this release
 	args := []string{"bootstrap/bootstrap", "-d", DefaultLocalClusterID}
-	return queryCluster(c, args)
+	return queryCluster(c, args, nil)
 }

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -20,7 +20,7 @@ func NewStatusCommand(c cli.Interface) *cobra.Command {
 func status(c cli.Interface, cmd *cobra.Command) error {
 	// TODO call api to get status
 	args := []string{"bootstrap/bootstrap", "-s", DefaultLocalClusterID}
-	status := queryCluster(c, args)
+	status := queryCluster(c, args, nil)
 	if status != nil {
 		c.Console().Println("cluster status: not running")
 	} else {

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -31,5 +31,5 @@ func update(c cli.Interface, cmd *cobra.Command) error {
 
 	// TODO: only supporting local cluster management for this release
 	args := []string{"bootstrap/bootstrap", DefaultLocalClusterID}
-	return queryCluster(c, reflag(cmd, m, args))
+	return queryCluster(c, reflag(cmd, m, args), nil)
 }


### PR DESCRIPTION
Implements partial support for #1079 and complements #1129 to allow specifying the tag for the bootstrap image for local `cluster create`. It also allow environment variables to be supplied to the bootstrap container.

    $ amp buildall
    $ amp -s localhost cluster create -t local

This tells amp (on localhost) to build a cluster using images tagged with `local` -- which now also includes the bootstrap image (thanks to #1129)