### PR TITLE
Pass-through registry for local deployments

### DIFF
--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -18,7 +18,7 @@ INFRAKIT_OPTIONS="-e INFRAKIT_HOME=$INFRAKIT_HOME -v $BOOTSTRAP_VOLUME:$INFRAKIT
 INFRAKIT_PLUGINS_OPTIONS="-v /var/run/docker.sock:/var/run/docker.sock -e INFRAKIT_PLUGINS_DIR=$INFRAKIT_HOME/plugins"
 BRIDGE_NETWORK=hostnet
 CLUSTER_LABEL_NAME=${CLUSTER_LABEL_NAME:-atomiq.clusterid}
-INFRAKIT_LOG_LEVEL=3
+INFRAKIT_LOG_LEVEL=4
 #WORKER_GROUP_LIST=(data:2)
 WORKER_GROUP_LIST=()
 
@@ -527,11 +527,11 @@ _prepare_config_container() {
   local _config=$(mktemp)
   cleanup_file_list="$cleanup_file_list $_config"
   docker exec infrakit infrakit template --log $INFRAKIT_LOG_LEVEL $CONTAINER_CONFIG_TPL > $_config
-  docker cp $_config infrakit:$INFRAKIT_HOME/config.json || exit 1
   if [ $? -ne 0 ]; then
     echo "failed, template URL was $CONTAINER_CONFIG_TPL" >&2
     exit 1
   fi
+  docker cp $_config infrakit:$INFRAKIT_HOME/config.json || exit 1
 }
 
 # deploy the infrakit configuration

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -69,6 +69,8 @@ _get_dirname() {
 }
 
 # expose the Docker remote api
+# and set the registry mirrors
+# only applies to non local deployments
 _expose_remote_api() {
   local _registry_opt
   mkdir -p /etc/systemd/system/docker.service.d
@@ -497,6 +499,7 @@ _kill_ikt() {
 # kill the registry container (but keep the volume)
 _kill_registry(){
   docker container rm -f registry >/dev/null 2>&1 && echo "registry has been destroyed" >&2
+  docker container rm -f registry-cache >/dev/null 2>&1 && echo "registry-cache has been destroyed" >&2
 }
 
 # kill the infrakit plugins (container or process)
@@ -540,7 +543,7 @@ _deploy_config_container() {
   docker exec infrakit infrakit manager commit file://$INFRAKIT_HOME/config.json >&2
 }
 
-# run a registry service for Docker image availability in the cluster
+# run registry services for Docker image availability in the cluster
 _run_registry() {
   local _nwopt
   docker network inspect $BRIDGE_NETWORK >/dev/null 2>&1 && _nwopt="--network=$BRIDGE_NETWORK"
@@ -550,6 +553,15 @@ _run_registry() {
              --volume=registry:/var/lib/registry \
              --label="$CLUSTER_LABEL_NAME=$clusterid" --label="io.amp.role=$ROLE_LABEL" \
              -e REGISTRY_STORAGE_DELETE_ENABLED=true \
+             registry:2 >&2
+  # for local deployment a registry cache is also created to boost the pulls
+  [[ "$target" = "local" ]] && \
+  docker run --name=registry-cache --detach $_nwopt \
+             --restart=unless-stopped \
+             --volume=registry-cache:/var/lib/registry \
+             --label="$CLUSTER_LABEL_NAME=$clusterid" --label="io.amp.role=$ROLE_LABEL" \
+             -e REGISTRY_STORAGE_DELETE_ENABLED=true \
+             -e REGISTRY_PROXY_REMOTEURL="https://registry-1.docker.io" \
              registry:2 >&2
 }
 

--- a/platform/bootstrap/config.docker-local.tpl
+++ b/platform/bootstrap/config.docker-local.tpl
@@ -17,7 +17,7 @@
           "Properties": {
             "Config": {
               "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
-              "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
+              "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry-cache/host" }}:{{ var "/docker/registry-cache/port" }}", "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
               "AutoRemove": true,
@@ -85,7 +85,7 @@
           "Properties": {
             "Config": {
               "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
-              "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
+              "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry-cache/host" }}:{{ var "/docker/registry-cache/port" }}", "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }}
             },
             "HostConfig": {
               "AutoRemove": true,
@@ -153,7 +153,7 @@
           "Properties": {
             "Config": {
               "Image": "subfuzion/dind:17.05-ce-rc1"{{ if var "/docker/registry/host" }},
-              "Cmd": "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"{{ end }} {{ if var "/docker/ports/exposed" }},
+              "Cmd": ["--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry-cache/host" }}:{{ var "/docker/registry-cache/port" }}", "--registry-mirror={{ var "/docker/registry/scheme" }}{{ var "/docker/registry/host" }}:{{ var "/docker/registry/port" }}"]{{ end }} {{ if var "/docker/ports/exposed" }},
               "ExposedPorts": {{ var "/docker/ports/exposed" | jsonEncode }} {{ end }}
             },
             "HostConfig": {

--- a/platform/bootstrap/default.ikt
+++ b/platform/bootstrap/default.ikt
@@ -21,5 +21,7 @@
 {{ var "/docker/registry/scheme" "http://" }}
 {{ var "/docker/registry/host" "registry" }}
 {{ var "/docker/registry/port" "5000" }}
+{{ var "/docker/registry-cache/host" "registry-cache" }}
+{{ var "/docker/registry-cache/port" "5000" }}
 {{ var "/aws/stackname" "unset" }}
 {{ var "/docker/label/cluster/key" "atomiq.clusterid" }}


### PR DESCRIPTION
The deployment scripts already include a registry where we can push images not available on an official repository. This registry does not cache images from Docker Hub.
For local deployments this PR adds a second registry dedicated for image cache, boosting the deployment cache.

- bump the VERSION file
- catch infrakit template errors
- add a pass-through registry for local deployments

test with ```make build-cli && amp -s localhost cluster create -t local```