### PR TITLE
certificates should be excluded from the bootstrap image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,7 @@ AMPBOOTSRC := hack/deploy hack/dev $(shell find $(AMPBOOTDIR) -type f)
 build-bootstrap:
 	@echo "Building $(AMPBOOTIMG):$(AMPBOOTVER)"
 	@cp -r hack stacks $(AMPBOOTDIR)
+	@rm -f $(AMPBOOTDIR)/stacks/*.pem
 	@$(DOCKER_CMD) build -t $(AMPBOOTIMG):$(AMPBOOTVER) $(AMPBOOTDIR) >/dev/null
 	@rm -rf $(AMPBOOTDIR)/hack $(AMPBOOTDIR)/stacks
 

--- a/hack/deploy
+++ b/hack/deploy
@@ -178,6 +178,11 @@ prepare_certificates() {
     echo "can't find certificate $certfile" >&2
     return 1
   fi
+  # copy the certificate in the amp-stacks volume
+  cid=$(docker run -d --rm -v amp-stacks:/stacks alpine:3.5 sleep 15)
+  if [[ $? -ne 0 || -z "$cid" ]]; then return 1; fi
+  docker cp $certfile $cid:/stacks/$name.pem
+  docker kill $cid
   echo "checking if the certificate secret is already defined"
   $amps secret ls | grep -q "certificate_atomiq" && return 0
   echo "creating the certificate secret"


### PR DESCRIPTION
fix #1137

- remove the certificates from the amp-bootstrap image at build time.
- add the certificate in the amp-stacks volume at run time.

how to test:
```
make build-bootstrap
amp -s localhost cluster create -t local
```
it should generate the certificate and deploy the amp_proxy service.