### PR TITLE
amp-bootstrap 1.2.0

### DIFF
--- a/bootstrap/build
+++ b/bootstrap/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TAGS=( latest 1.1.0 )
+TAGS=( latest 1.2.0 )
 OWNER=appcelerator
 IMAGE="${1:-amp-bootstrap}"
 
@@ -10,7 +10,7 @@ IMAGE="${1:-amp-bootstrap}"
 
 for tag in "${TAGS[@]}"
 do
-  docker tag ${OWNER}/${IMAGE} ${OWNER}/${IMAGE}:${tag}
+  docker tag ${OWNER}/${IMAGE}:local ${OWNER}/${IMAGE}:${tag}
   docker push ${OWNER}/${IMAGE}:${tag}
 done
 

--- a/cli/command/cluster/bootstrap.go
+++ b/cli/command/cluster/bootstrap.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	bootstrapImg = "appcelerator/amp-bootstrap:%s"
-	bootstrapTag = "1.1.0"
+	bootstrapTag = "1.2.0"
 )
 
 var (


### PR DESCRIPTION
- build appcelerator/amp-bootstrap 1.2.0 (already pushed on DockerHub)
- use it by default in the CLI

$ make build-cli
$ amp -s localhost cluster create
