### PR TITLE
enable http and forward to https

### DIFF
--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -39,10 +39,10 @@ services:
         constraints: [node.role == worker]
     labels:
       io.amp.role: "infrastructure"
-    environment: [
-      "ELASTICSEARCH_URL=http://elasticsearch:9200",
-      "SERVICE_PORTS=5601",
-      "VIRTUAL_HOST=https://dashboard.*"
-    ]
+    environment:
+      ELASTICSEARCH_URL: "http://elasticsearch:9200"
+      SERVICE_PORTS: 5601
+      VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
+      FORCE_SSL: 1
     ports:
       - "50106:5601"

--- a/platform/stacks/ampproxy.stack.yml
+++ b/platform/stacks/ampproxy.stack.yml
@@ -23,7 +23,6 @@ services:
         constraints: [node.role == manager]
     environment:
       CERT_FOLDER: "/run/secrets"
-      EXTRA_FRONTEND_SETTINGS_80: redirect scheme https code 301 if !{ ssl_fc }
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:

--- a/platform/stacks/ampui.stack.yml
+++ b/platform/stacks/ampui.stack.yml
@@ -43,7 +43,8 @@ services:
         io.amp.role: "infrastructure"
     environment:
       SERVICE_PORTS: "3333"
-      VIRTUAL_HOST: "https://ui.*"
+      VIRTUAL_HOST: "http://ui.*,https://ui.*"
+      FORCE_SSL: 1
       LOCAL_ENDPOINT: "true"
       ENDPOINTS: "cloud.atomiq.io"
     labels:

--- a/platform/stacks/visualizer.stack.yml
+++ b/platform/stacks/visualizer.stack.yml
@@ -13,7 +13,8 @@ services:
       - default
     environment:
       SERVICE_PORTS: "8080"
-      VIRTUAL_HOST: "https://visualizer.*"
+      VIRTUAL_HOST: "http://visualizer,https://visualizer.*"
+      FORCE_SSL: 1
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     deploy:
@@ -26,7 +27,8 @@ services:
       - default
     environment:
       SERVICE_PORTS: "9000"
-      VIRTUAL_HOST: "https://portainer.*"
+      VIRTUAL_HOST: "http://portainer.*,https://portainer.*"
+      FORCE_SSL: 1
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:


### PR DESCRIPTION
The proxy now accepts http connection (port 80) and forwards to https.
The configuration is not global, it has to be set on each service.

```
$ make build-bootstrap
$ amp -s localhost cluster create
```
connect to http://dashboard.local.atomiq.io, it should redirect to https://dashboard.local.atomiq.io