### PR TITLE
check for potential errors before running CLI cluster commands

### DIFF
--- a/cli/command/cluster/check.go
+++ b/cli/command/cluster/check.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// check if a cluster command is not already in progress, and provides hints if it's the case
+func check(provider string) error {
+	cmd := "docker"
+	switch provider {
+	case "local":
+		// check that the amp-boostrap container does not exist
+		args := []string{
+			"container", "inspect", "amp-bootstrap",
+		}
+		proc := exec.Command(cmd, args...)
+		err := proc.Run()
+		if err == nil {
+			return errors.New("A cluster operation is still in progress. Please wait for it to finish unless you want to terminate it now (docker rm -f amp-bootstrap) and try again.")
+		}
+	default:
+		// no check
+	}
+	return nil
+}

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -45,6 +45,9 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 }
 
 func queryCluster(c cli.Interface, args []string, env map[string]string) error {
+	if err := check(opts.provider); err != nil {
+		return err
+	}
 	err := Run(c, args, env)
 	if err != nil {
 		// TODO: the local cluster is the only one that can be managed this release

--- a/platform/tests/cli/pr-1148-error-hints
+++ b/platform/tests/cli/pr-1148-error-hints
@@ -1,0 +1,8 @@
+#!/bin/bash
+# simulate that a cluster creation is already in progress
+cid=$(docker run --rm -d --name amp-bootstrap alpine:3.5 sleep 3 2>/dev/null)
+# we should get a hint to terminate the container
+amp -s localhost cluster create -t local 2>&1 | grep -q terminate
+ret=$?
+docker kill $cid >/dev/null 2>&1
+exit $ret


### PR DESCRIPTION
fix #1086 

check for potential errors before running CLI cluster commands and print hints on how to fix it if it's the case
```
$ make build-cli
$ amp -s localhost cluster create
...
# in a second terminal while the first command is still processing
$ amp -s localhost cluster create
[localhost:50101]
Error: the amp-bootstrap container is already running. Another CLI is probably still running, wait for it to stop or kill it. If that's not the case, you should force remove the container with `docker rm -f amp-bootstrap` and try again.
```