### PR TITLE
default server is now cloud.appcelerator.io

### DIFF
--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -24,7 +24,7 @@ func main() {
 	config = &cli.Configuration{
 		Version: Version,
 		Build:   Build,
-		Server:  "cloud.atomiq.io:50101",
+		Server:  "cloud.appcelerator.io:50101",
 	}
 
 	// Set terminal emulation based on platform as required.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ ATOMIQ
 
 ## Getting started
 
-> NOTE: by default, the CLI will connect to `cloud.atomiq.io:50101`.
+> NOTE: by default, the CLI will connect to `cloud.appcelerator.io:50101`.
 This is currently for testing and evaluation only and anything you
 create will be deleted periodically over the next few weeks.
 
@@ -52,7 +52,7 @@ Versions of Docker for Mac v.17.03 and higher work with the default settings.
 
 The `amp stats` and `amp logs` commands provide rich filtered
 query support for both realtime feeds and historical queries.
-You can connect to the hosted dashboard at https://dashboard.cloud.atomiq.io/.
+You can connect to the hosted dashboard at https://dashboard.cloud.appcelerator.io/.
 If you create a local cluster, you can connect to it at:
 http://localhost:50106.
 

--- a/docs/version.md
+++ b/docs/version.md
@@ -8,14 +8,14 @@ The `amp version` command displays the current version of AMP.
     $ amp version
 
     Client:
-     Version:       v0.6.0-dev
+     Version:       v0.10.0-dev
      Build:         6f590348
-     Server:        cloud.atomiq.io:50101
+     Server:        cloud.appcelerator.io:50101
      Go version:    go1.8
      OS/Arch:       darwin/amd64
 
     Server:
-     Version:       v0.6.0-dev
+     Version:       v0.10.0-dev
      Build:         04daab98
      Go version:    go1.8.1
      OS/Arch:       linux/amd64


### PR DESCRIPTION
the CLI will now default to cloud.appcelerator.io:50101