### PR TITLE
UI as default virtual host

### DIFF
--- a/platform/stacks/ampui.stack.yml
+++ b/platform/stacks/ampui.stack.yml
@@ -43,7 +43,7 @@ services:
         io.amp.role: "infrastructure"
     environment:
       SERVICE_PORTS: "3333"
-      VIRTUAL_HOST: "http://ui.*,https://ui.*"
+      VIRTUAL_HOST: "http://ui.*,https://ui.*,http://cloud.*,http://local.*,https://cloud.*,https://local.*"
       FORCE_SSL: 1
       LOCAL_ENDPOINT: "true"
       ENDPOINTS: "cloud.atomiq.io"


### PR DESCRIPTION
fix #1036

cloud.appcelerator.io (or local.appcelerator.io) will route on the UI service.