### PR TITLE
CLI config file

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,6 +41,9 @@ type cli struct {
 }
 
 const (
+	//DefaultAddress is the default server address
+	DefaultAddress = "cloud.appcelerator.io"
+
 	//DefaultPort for server address
 	DefaultPort = ":50101"
 )
@@ -54,6 +57,7 @@ func NewCLI(in io.ReadCloser, out, err io.Writer, config *Configuration) Interfa
 		err:           err,
 	}
 	c.console = NewConsole(c.Out(), config.Verbose)
+	c.SetServer(config.Server)
 	return c
 }
 
@@ -110,7 +114,7 @@ func (c *cli) OnInitialize(initializers ...func()) {
 func (c *cli) Connect() (*grpc.ClientConn, error) {
 	if c.clientConn == nil {
 		var err error
-		c.clientConn, err = NewClientConn(c.Server(), GetToken())
+		c.clientConn, err = NewClientConn(c.Server(), GetToken(c.Server()))
 		if err != nil {
 			// extra newline helpful for grpc errors
 			return nil, fmt.Errorf("\nunable to establish grpc connection: %s", err)

--- a/cli/command/login/login.go
+++ b/cli/command/login/login.go
@@ -52,7 +52,7 @@ func login(c cli.Interface, cmd *cobra.Command, opts loginOptions) error {
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
-	if err := cli.SaveToken(headers); err != nil {
+	if err := cli.SaveToken(headers, c.Server()); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
 	c.Console().Printf("Welcome back %s!\n", opts.username)

--- a/cli/command/logout/logout.go
+++ b/cli/command/logout/logout.go
@@ -18,7 +18,7 @@ func NewLogoutCommand(c cli.Interface) *cobra.Command {
 }
 
 func logout(c cli.Interface) error {
-	if err := cli.RemoveToken(); err != nil {
+	if err := cli.RemoveToken(c.Server()); err != nil {
 		return err
 	}
 	c.Console().Println("You have been logged out!")

--- a/cli/command/org/switch.go
+++ b/cli/command/org/switch.go
@@ -34,7 +34,7 @@ func switch_(c cli.Interface, args []string) error {
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
-	if err := cli.SaveToken(headers); err != nil {
+	if err := cli.SaveToken(headers, c.Server()); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
 	c.Console().Printf("You are now logged in as: %s\n", args[0])

--- a/cli/command/user/forgot-login.go
+++ b/cli/command/user/forgot-login.go
@@ -24,7 +24,7 @@ func NewForgotLoginCommand(c cli.Interface) *cobra.Command {
 }
 
 func forgotLogin(c cli.Interface, args []string) error {
-	if token := cli.GetToken(); token != "" {
+	if token := cli.GetToken(c.Server()); token != "" {
 		return errors.New("you are already logged into an account. Use 'amp whoami' to view your username")
 	}
 	conn := c.ClientConn()

--- a/cli/command/user/remove.go
+++ b/cli/command/user/remove.go
@@ -30,7 +30,7 @@ func removeUser(c cli.Interface, args []string) error {
 	var errs []string
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
-	token, err := cli.ReadToken()
+	token, err := cli.ReadToken(c.Server())
 	if err != nil {
 		return errors.New("you are not logged in. Use `amp login` or `amp user signup`.")
 	}
@@ -50,7 +50,7 @@ func removeUser(c cli.Interface, args []string) error {
 			continue
 		}
 		if name == claims.AccountName {
-			if err := cli.RemoveToken(); err != nil {
+			if err := cli.RemoveToken(c.Server()); err != nil {
 				errs = append(errs, err.Error())
 			}
 		}

--- a/cli/command/whoami/whoami.go
+++ b/cli/command/whoami/whoami.go
@@ -22,7 +22,7 @@ func NewWhoAmICommand(c cli.Interface) *cobra.Command {
 }
 
 func whoami(c cli.Interface) error {
-	token, err := cli.ReadToken()
+	token, err := cli.ReadToken(c.Server())
 	if err != nil {
 		return errors.New("you are not logged in. Use `amp login` or `amp user signup`.")
 	}

--- a/cli/configuration.go
+++ b/cli/configuration.go
@@ -1,5 +1,11 @@
 package cli
 
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
 // Configuration is for all configurable client settings
 type Configuration struct {
 	Version string
@@ -7,4 +13,22 @@ type Configuration struct {
 	Server  string
 	Verbose bool
 	Theme   string
+}
+
+// ReadClientConfig reads the CLI configuration
+func ReadClientConfig(config *Configuration) error {
+	viper.AutomaticEnv() // Ensure env variables take precedence over config settings
+
+	viper.SetConfigName("amp")               // Set CLI config file name
+	viper.AddConfigPath("./.amp")            // Path to store config file in current working directory
+	viper.AddConfigPath("$HOME/.config/amp") // Default path to store config file
+
+	// Find and read the config file
+	if err := viper.ReadInConfig(); err == nil {
+		// Unmarshal the config file into CLI Configuration object
+		if err := viper.Unmarshal(config); err != nil {
+			return fmt.Errorf("error unmarshalling config file: %s", err)
+		}
+	}
+	return nil
 }

--- a/cli/token.go
+++ b/cli/token.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/appcelerator/amp/api/auth"
 	"golang.org/x/net/context"
@@ -14,12 +15,18 @@ import (
 
 var (
 	ampConfigFolder = filepath.Join(".config", "amp")
-	ampTokenFile    = "token"
+)
+
+const (
+	//Credentials suffix for authentication token file
+	Credentials = ".credentials"
 )
 
 // SaveToken saves the authentication token to file
-func SaveToken(headers metadata.MD) error {
+func SaveToken(headers metadata.MD, server string) error {
 	tokens := headers[auth.TokenKey]
+	ampTokenFile := strings.TrimSuffix(server, DefaultPort) + Credentials
+	// Extract token from header
 	if len(tokens) == 0 {
 		return fmt.Errorf("invalid token")
 	}
@@ -41,7 +48,8 @@ func SaveToken(headers metadata.MD) error {
 }
 
 // ReadToken reads the authentication token from file
-func ReadToken() (string, error) {
+func ReadToken(server string) (string, error) {
+	ampTokenFile := strings.TrimSuffix(server, DefaultPort) + Credentials
 	usr, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("cannot get current user: %s", err)
@@ -54,7 +62,8 @@ func ReadToken() (string, error) {
 }
 
 // RemoveToken deletes the authentication token file
-func RemoveToken() error {
+func RemoveToken(server string) error {
+	ampTokenFile := strings.TrimSuffix(server, DefaultPort) + Credentials
 	usr, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("cannot get current user: %s", err)
@@ -88,8 +97,8 @@ func (c *LoginCredentials) RequireTransportSecurity() bool {
 }
 
 // GetToken returns the stored token
-func GetToken() string {
-	token, err := ReadToken()
+func GetToken(server string) string {
+	token, err := ReadToken(server)
 	if err != nil {
 		return ""
 	}

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/appcelerator/amp/cli"
@@ -24,7 +25,12 @@ func main() {
 	config = &cli.Configuration{
 		Version: Version,
 		Build:   Build,
-		Server:  "cloud.appcelerator.io:50101",
+		Server:  cli.DefaultAddress + cli.DefaultPort,
+	}
+
+	// Read the cli config
+	if err := cli.ReadClientConfig(config); err != nil {
+		log.Fatalln(err)
 	}
 
 	// Set terminal emulation based on platform as required.

--- a/platform/tests/config/config_test.sh
+++ b/platform/tests/config/config_test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# server passed on commandline overrides both local and home configs
+test_cli_local_home() {
+  # create local config
+  mkdir -p $PWD/.amp
+  echo "Server: LOCAL" > $PWD/.amp/amp.yml
+
+  # create home config
+  mkdir -p $HOME/.config/amp
+  echo "Server: HOME" > $HOME/.config/amp/amp.yml
+
+  # server address passed as command line argument
+  amp -s SERVER version | pcregrep -q "Server:[[:space:]]+SERVER"
+  local ec=$?
+
+  rm -R $PWD/.amp
+  rm -R $HOME/.config/amp
+  return $ec
+}
+
+# server passed in local config overrides home config
+test_local_home() {
+  # create local config
+  mkdir -p $PWD/.amp
+  echo "Server: LOCAL" > $PWD/.amp/amp.yml
+
+  # create home config
+  mkdir -p $HOME/.config/amp
+  echo "Server: HOME" > $HOME/.config/amp/amp.yml
+
+  amp version | pcregrep -q "Server:[[:space:]]+LOCAL"
+  local ec=$?
+
+  rm -R $PWD/.amp
+  rm -R $HOME/.config/amp
+  return $ec
+}
+
+# server passed in home config
+test_home() {
+  # create home config
+  mkdir -p $HOME/.config/amp
+  echo "Server: HOME" > $HOME/.config/amp/amp.yml
+
+  amp version | pcregrep -q "Server:[[:space:]]+HOME"
+  local ec=$?
+
+  rm -R $HOME/.config/amp
+  return $ec
+}
+
+# no server passed; read default server address
+test_cloud() {
+  amp version | pcregrep -q "Server:[[:space:]]+cloud.appcelerator.io"
+}
+
+test_teardown() {
+  rm -Rf $PWD/.amp
+  rm -Rf $HOME/.config/amp
+}

--- a/platform/tests/config/token_test.sh
+++ b/platform/tests/config/token_test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+amp="amp -s localhost"
+
+test_setup() {
+  $amp user signup --name user2 --password password --email user2@xmail
+  $amp login --name user2 --password password
+}
+
+test_name() {
+  find $HOME/.config/amp -name 'localhost*'
+}
+
+test_teardown() {
+  $amp user rm user2
+}

--- a/platform/tests/gateway/auth_test.sh
+++ b/platform/tests/gateway/auth_test.sh
@@ -2,5 +2,5 @@
 
 amp="amp -s localhost"
 $amp login --name user --password password
-TOKEN=$(cat ~/.config/amp/token)
+TOKEN=$(cat ~/.config/amp/localhost.credentials)
 curl -k --header "Authorization: amp $TOKEN" https://gw.local.atomiq.io/v1/stacks | grep "{}"


### PR DESCRIPTION
Resolves #1175 

The smoke tests are located in `platform/tests/config` 

You should see a `localhost.credentials` file in $HOME/.config/amp directory
If no server address is specified on the command, the server settings specified in the CLI config file is read. 
Note that the CLI config file can be found in one of the following locations - 
- current working directory (`./.amp`)
- user's HOME directory  #(`$HOME/.config/amp`)

If no config file is found or no server address is specified on the command, the default server address is used.