### PR TITLE
[multi-swarm] HA Swarm managers + infrakit on AWS

### DIFF
--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -325,8 +325,10 @@ _instance_plugin_compute_subtype(){
 _run_ikt_container() {
   local _should_wait_for_plugins=0
   local _infrakit_image
-  docker run --rm -v $BOOTSTRAP_VOLUME:$INFRAKIT_HOME alpine:3.5 sh -c "echo 'group' >> $INFRAKIT_HOME/leader" || exit 1
 
+  if [ "$manager_plugin" = "os" ]; then
+    docker run --rm -v $BOOTSTRAP_VOLUME:$INFRAKIT_HOME alpine:3.5 sh -c "echo 'group' >> $INFRAKIT_HOME/leader" || exit 1
+  fi
   # remove old customized configuration just in case
   docker run --rm -v $BOOTSTRAP_VOLUME:$INFRAKIT_HOME alpine:3.5 sh -c "sed -i.bak 's/^{{ var \"\/script\/baseurl\".\*$//' $INFRAKIT_HOME/env.ikt" || exit 1
   local _extra_plugins=""
@@ -356,7 +358,7 @@ _run_ikt_container() {
       local _ip
       _ip=$(_get_ip)
       docker run --rm -v $BOOTSTRAP_VOLUME:$INFRAKIT_HOME alpine:3.5 sh -c "echo '{{ var \"/bootstrap/ip\" \"$_ip\" }}' >> $INFRAKIT_HOME/env.ikt" || exit 1
-      echo "bootstrap ip ($_ip) added in env.ikt" >&2 
+      echo "bootstrap ip ($_ip) added in env.ikt" >&2
     fi
     if [ "x$provider" = "xdocker" ]; then
         echo "making sure the network $BRIDGE_NETWORK is created" >&2
@@ -370,7 +372,7 @@ _run_ikt_container() {
     docker run -d --restart always --name infrakit \
          $INFRAKIT_OPTIONS $INFRAKIT_PLUGINS_OPTIONS -e PLUGIN_DIR=$INFRAKIT_HOME/${provider} -e INFRAKIT_LOG_LEVEL=$INFRAKIT_LOG_LEVEL $_infrakit_image \
          infrakit plugin start --wait --config-url $CONTAINER_PLUGINS_CFG --exec os --log $INFRAKIT_LOG_LEVEL \
-         manager group-stateless flavor-swarm flavor-vanilla flavor-combo $_extra_plugins >&2
+         manager-${manager_plugin} group-stateless flavor-swarm flavor-vanilla flavor-combo $_extra_plugins >&2
     _should_wait_for_plugins=1
   else
     echo "infraKit container is already started" >&2
@@ -598,6 +600,7 @@ MANAGED_PLUGINS="docker aws"
 target=local
 provider=docker
 default_provider=1
+manager_plugin=swarm
 envfile=""
 providerfile=""
 manager_count=1
@@ -700,7 +703,12 @@ trap _finish EXIT
 if [ "x$target" != "xlocal" ] && [ $default_provider -eq 1 ]; then
     provider="$target"
 fi
+
 subtype=$(_instance_plugin_compute_subtype $provider)
+
+if [ "x$target" = "xlocal" ]; then
+    manager_plugin=os
+fi
 
 if [ -n "$status_request" ]; then
   _status "$status_request"
@@ -722,8 +730,7 @@ if [ $init_swarm -eq 1 ]; then
   _init_swarm || exit 1
 fi
 if [ -n "$swarm_join_ip" ]; then
-  _init_swarm "$swarm_join_ip" || exit 1
-  exit 0
+  _init_swarm $swarm_join_ip || exit 1
 fi
 [[ $target = "local" ]] && ( _system_check || exit 1 )
 _set_source "$1"
@@ -743,29 +750,38 @@ if [ $started -gt 0 ]; then
   looplimit=20
   ready=0
   while [ $ready -lt 3 ]; do
-    docker exec infrakit infrakit manager inspect 2>&1 | grep -vq 'non-leader'
-    rc=$?
     docker exec infrakit infrakit plugin ls 2>/dev/null | grep -q "instance-$provider"
-    rc=$((rc+$?))
+    rc=$?
     docker exec infrakit infrakit instance --name="instance-$provider${subtype:+/$subtype}" describe >/dev/null 2>&1
     rc=$((rc+$?))
+
+    # Only performed on Leader node
+    if [ $init_swarm -eq 1 ]; then
+      docker exec infrakit infrakit manager inspect 2>&1 | grep -vq 'non-leader'
+      rc=$((rc+$?))
+    fi
     if [ $((++loop)) -gt $looplimit ]; then
       echo " aborting after $looplimit attempts" >&2
-      docker exec infrakit infrakit manager inspect >/dev/null
       docker exec infrakit infrakit plugin ls 2>/dev/null
       docker exec infrakit infrakit instance --name="instance-$provider${subtype:+/$subtype}" describe
       # docker inspect infrakit >&2
       docker logs infrakit >&2
-      echo "#####################      manager logs        ############################" >&2
-      docker exec infrakit cat /infrakit/logs/manager.log >&2
       echo "#####################        group logs        ############################" >&2
       docker exec infrakit cat /infrakit/logs/group-stateless.log >&2
       echo "#####################     instance logs        ############################" >&2
       docker exec infrakit cat "/infrakit/logs/instance-$provider.log" >&2
       echo "#####################       flavor logs        ############################" >&2
       docker exec infrakit cat /infrakit/logs/flavor-swarm.log >&2
-      echo "#####################       configuration      ############################" >&2
-      docker exec infrakit cat /infrakit/config.json >&2
+
+      # Only performed on Leader node
+      if [ $init_swarm -eq 1 ]; then
+        echo "#####################      leader operations   ############################" >&2
+        docker exec infrakit infrakit manager inspect >/dev/null
+        echo "#####################      manager logs        ############################" >&2
+        docker exec infrakit cat /infrakit/logs/manager.log >&2
+        echo "#####################       configuration      ############################" >&2
+        docker exec infrakit cat /infrakit/config.json >&2
+      fi
       exit 1
     fi
     sleep 1
@@ -774,19 +790,22 @@ if [ $started -gt 0 ]; then
   done
   echo >&2
 fi
-_prepare_config_container
-_deploy_config_container
-if [ $block -gt 0 ]; then
-  rc=1
-  SECONDS=0
-  echo "waiting for cluster to be ready..." >&2
-  while [ $rc -ne 0 ]; do
-    _status $clusterid 2>/dev/null
-    rc=$?
-    if [ $SECONDS -gt $block ]; then
-      echo "cluster is still not ready after $block sec" >&2
-      exit 1
-    fi
-  done
+_node=$(docker node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)\
+if [ "$_node" = "true" ]; then
+  _prepare_config_container
+  _deploy_config_container
+  if [ $block -gt 0 ]; then
+    rc=1
+    SECONDS=0
+    echo "waiting for cluster to be ready..." >&2
+    while [ $rc -ne 0 ]; do
+      _status $clusterid 2>/dev/null
+      rc=$?
+      if [ $SECONDS -gt $block ]; then
+        echo "cluster is still not ready after $block sec" >&2
+        exit 1
+      fi
+    done
+  fi
 fi
 echo "done" >&2

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -768,7 +768,7 @@ if [ $started -gt 0 ]; then
       docker exec infrakit infrakit instance --name="instance-$provider${subtype:+/$subtype}" describe
       docker logs infrakit >&2
       echo "#####################      manager logs        ############################" >&2
-      docker exec infrakit cat /infrakit/logs/manager.log >&2
+      docker exec infrakit cat /infrakit/logs/manager-${manager_plugin}.log >&2
       echo "#####################        group logs        ############################" >&2
       docker exec infrakit cat /infrakit/logs/group-stateless.log >&2
       echo "#####################     instance logs        ############################" >&2

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -100,6 +100,7 @@ _init_swarm() {
     _manager=$1
     _expose_remote_api "$_manager"
     echo "joining a Docker Swarm..." >&2
+    i_am_the_leader=0
     while [ $((++_loop)) -lt $_maxloop ]; do
       _token=$(docker -H "$_manager:2375" swarm join-token -q manager 2>/dev/null)
       if [ $? -eq 0 ] && [ -n "$_token" ]; then
@@ -127,6 +128,7 @@ _init_swarm() {
     fi
   else
     echo "initializing Docker Swarm" >&2
+    i_am_the_leader=1
     _expose_remote_api 127.0.0.1
     docker swarm init
   fi
@@ -615,6 +617,8 @@ list_request=""
 block=0
 cleanup_file_list=""
 cleanup_image_list=""
+# assume by default that this node is the Swarm manager leader
+i_am_the_leader=1
 while getopts ":1j:t:p:e:m:w:i:l:s:hfdb:" opt; do
   case $opt in
   1)
@@ -730,7 +734,7 @@ if [ $init_swarm -eq 1 ]; then
   _init_swarm || exit 1
 fi
 if [ -n "$swarm_join_ip" ]; then
-  _init_swarm $swarm_join_ip || exit 1
+  _init_swarm "$swarm_join_ip" || exit 1
 fi
 [[ $target = "local" ]] && ( _system_check || exit 1 )
 _set_source "$1"
@@ -754,9 +758,7 @@ if [ $started -gt 0 ]; then
     rc=$?
     docker exec infrakit infrakit instance --name="instance-$provider${subtype:+/$subtype}" describe >/dev/null 2>&1
     rc=$((rc+$?))
-
-    # Only performed on Leader node
-    if [ $init_swarm -eq 1 ]; then
+    if [ $i_am_the_leader -eq 1 ]; then
       docker exec infrakit infrakit manager inspect 2>&1 | grep -vq 'non-leader'
       rc=$((rc+$?))
     fi
@@ -764,24 +766,15 @@ if [ $started -gt 0 ]; then
       echo " aborting after $looplimit attempts" >&2
       docker exec infrakit infrakit plugin ls 2>/dev/null
       docker exec infrakit infrakit instance --name="instance-$provider${subtype:+/$subtype}" describe
-      # docker inspect infrakit >&2
       docker logs infrakit >&2
+      echo "#####################      manager logs        ############################" >&2
+      docker exec infrakit cat /infrakit/logs/manager.log >&2
       echo "#####################        group logs        ############################" >&2
       docker exec infrakit cat /infrakit/logs/group-stateless.log >&2
       echo "#####################     instance logs        ############################" >&2
       docker exec infrakit cat "/infrakit/logs/instance-$provider.log" >&2
       echo "#####################       flavor logs        ############################" >&2
       docker exec infrakit cat /infrakit/logs/flavor-swarm.log >&2
-
-      # Only performed on Leader node
-      if [ $init_swarm -eq 1 ]; then
-        echo "#####################      leader operations   ############################" >&2
-        docker exec infrakit infrakit manager inspect >/dev/null
-        echo "#####################      manager logs        ############################" >&2
-        docker exec infrakit cat /infrakit/logs/manager.log >&2
-        echo "#####################       configuration      ############################" >&2
-        docker exec infrakit cat /infrakit/config.json >&2
-      fi
       exit 1
     fi
     sleep 1
@@ -790,8 +783,9 @@ if [ $started -gt 0 ]; then
   done
   echo >&2
 fi
-_node=$(docker node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)\
-if [ "$_node" = "true" ]; then
+#_node=$(docker node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)\
+#if [ "$_node" = "true" ]; then
+if [ "$i_am_the_leader" -eq 1 ]; then
   _prepare_config_container
   _deploy_config_container
   if [ $block -gt 0 ]; then

--- a/platform/bootstrap/bootstrap.yml
+++ b/platform/bootstrap/bootstrap.yml
@@ -530,28 +530,7 @@ Resources:
                     {{ var "/script/baseurl" "${InfraKitConfigurationBaseURL}" }}
                     {{ var "/docker/aufs/size" "${AufsVolumeSize}" }}
               runcmd:
-                - wget -qO- https://get.docker.com/ | sh && \
-                - usermod -G docker ubuntu && \
-                - systemctl enable docker.service && \
-                - systemctl start docker.service && \
                 - curl ${InfraKitConfigurationBaseURL}/bootstrap -o /usr/local/bin/bootstrap.sh
-                - '_myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)'
-                - '_allips=$(aws ec2 describe-instances --region=${AWS::Region} --filters "Name=tag:Name,Values=${AWS::StackName}-manager" "Name=instance-state-name,Values=pending,running" "Name=vpc-id,Values=${Vpc}" --query="Reservations[*].Instances[*].PrivateIpAddress" --output=text | sort -n)'
-                - '_leaderip=$(echo $_allips | cut -f1 -d " ")'
-                - '_rc=0'
-                - '_nodestatus=()'
-                - 'COUNTER=0'
-                - 'for i in $_allips; do'
-                -   '_nodestatus[$COUNTER]=$(docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)'
-                -   '_rc=$((_rc+$?))'
-                -   'COUNTER=$((COUNTER+1))'
-                - 'done'
-                - 'if [ "$_myip" = "$_leaderip" ] && [ "$_rc" = "${ManagerSize}" ]; then'
-                -   'bash /usr/local/bin/bootstrap.sh -1 -p aws -t aws -e /tmp/env.ikt ${InfraKitConfigurationBaseURL}'
-                - 'fi'
-                - 'for i in $_nodestatus; do'
-                -   'if [ "$i" = "true" ]; then'
-                -     'bash /usr/local/bin/bootstrap.sh -j $(echo $_allips | cut -f1 -d " ") -p aws -t aws -e /tmp/env.ikt ${InfraKitConfigurationBaseURL}'
-                -   'fi'
-                - 'done'
+                - curl ${InfraKitConfigurationBaseURL}/userdata-aws -o /usr/local/bin/asg-init.sh
+                - REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${InfraKitConfigurationBaseURL} ENV_FILE=/tmp/env.ikt /usr/local/bin/asg-init.sh
             - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }

--- a/platform/bootstrap/bootstrap.yml
+++ b/platform/bootstrap/bootstrap.yml
@@ -463,7 +463,7 @@ Resources:
         MaxBatchSize: 1
         MinInstancesInService: 0
         PauseTime: PT10M
-        WaitOnResourceSignals: true
+        WaitOnResourceSignals: false
     Properties:
       DesiredCapacity: !Ref ManagerSize
       HealthCheckGracePeriod: 200

--- a/platform/bootstrap/bootstrap.yml
+++ b/platform/bootstrap/bootstrap.yml
@@ -87,8 +87,18 @@ Parameters:
     - t2.large
     - m3.medium
     - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
     ConstraintDescription: Must be a valid EC2 HVM instance type.
-    Default: t2.micro
+    Default: t2.medium
     Description: EC2 HVM instance type (t2.micro, m3.medium, etc).
   WorkerSize:
     Type: Number
@@ -532,5 +542,6 @@ Resources:
               runcmd:
                 - curl ${InfraKitConfigurationBaseURL}/bootstrap -o /usr/local/bin/bootstrap.sh
                 - curl ${InfraKitConfigurationBaseURL}/userdata-aws -o /usr/local/bin/asg-init.sh
+                - chmod +x /usr/local/bin/bootstrap.sh /usr/local/bin/asg-init.sh
                 - REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${InfraKitConfigurationBaseURL} ENV_FILE=/tmp/env.ikt /usr/local/bin/asg-init.sh
             - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }

--- a/platform/bootstrap/bootstrap.yml
+++ b/platform/bootstrap/bootstrap.yml
@@ -4,24 +4,80 @@ Description: Docker Swarm cluster deployed with InfraKit
 Mappings:
   AMI:
     # Ubuntu 16.04 HVM
-    eu-central-1:
-      Ubuntu: ami-1b4d9e74
+    ap-southeast-2:
+      Ubuntu: ami-92e8e6f1
     eu-west-1:
       Ubuntu: ami-b5a893d3
-    us-east-1:
-      Ubuntu: ami-e4139df2
-    us-west-1:
-      Ubuntu: ami-30476250
+    us-east-2:
+      Ubuntu: ami-33ab8f56
     us-west-2:
       Ubuntu: ami-17ba2a77
   VpcCidrs:
     subnet1:
-      cidr: 192.168.2.0/24
+      cidr: 192.168.0.0/24
+    subnet2:
+      cidr: 192.168.16.0/24
+    subnet3:
+      cidr: 192.168.32.0/24
     vpc:
       cidr: 192.168.0.0/16
 
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Swarm Properties
+      Parameters:
+      - KeyName
+    - Label:
+        default: Swarm Manager Properties
+      Parameters:
+      - ManagerSize
+      - ManagerInstanceType
+    - Label:
+        default: Swarm Worker Properties
+      Parameters:
+      - WorkerSize
+      - WorkerInstanceType
+    - Label:
+        default: InfraKit Configuration
+      Parameters:
+      - InfraKitConfigurationBaseURL
+    - Label:
+        default: Docker Configuration
+      Parameters:
+      - AufsVolumeSize
+    ParameterLabels:
+      KeyName:
+        default: Which SSH key to use?
+      ManagerSize:
+        default: Number of Swarm managers?
+      ManagerInstanceType:
+        default: Swarm manager instance type?
+      WorkerSize:
+        default: Number of Swarm workers?
+      WorkerInstanceType:
+        default: Swarm worker instance type?
+      InfraKitConfigurationBaseURL:
+        default: InfraKit configuration base URL
+      AufsVolumeSize:
+        default: EBS Volume Size
+
 Parameters:
-  BootstrapInstanceType:
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances.
+    MinLength: '1'
+  ManagerSize:
+    Type: Number
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+    Default: 3
+    Description: Number of Swarm manager nodes (1, 3, 5).
+  ManagerInstanceType:
     Type: String
     AllowedValues:
     - t2.nano
@@ -31,40 +87,47 @@ Parameters:
     - t2.large
     - m3.medium
     - m4.large
-    ConstraintDescription: Must be a valid EC2 HVM instance type
-    Default: m3.medium
-    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
-  InstanceType:
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.micro
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc).
+  WorkerSize:
+    Type: Number
+    Default: 2
+    MaxValue: 1000
+    MinValue: 0
+    Description: Number of Swarm worker nodes.
+  WorkerInstanceType:
     Type: String
     AllowedValues:
+    - t2.nano
     - t2.micro
     - t2.small
     - t2.medium
     - t2.large
     - m3.medium
     - m4.large
-    ConstraintDescription: Must be a valid EC2 HVM instance type
-    Default: t2.small
-    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
-  BootstrapKeyName:
-    Type: AWS::EC2::KeyPair::KeyName
-    ConstraintDescription: must be the name of an existing EC2 KeyPair
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the bootstrap instances
-    MinLength: '1'
-  KeyName:
-    Type: AWS::EC2::KeyPair::KeyName
-    ConstraintDescription: must be the name of an existing EC2 KeyPair
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
-    MinLength: '1'
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.medium
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc).
   InfraKitConfigurationBaseURL:
     Type: String
-    ConstraintDescription: must be an URL
-    Description: Base URL for InfraKit configuration. there should be a bootstrap script, a default.ikt and a config.aws.tpl file
-    Default: https://raw.githubusercontent.com/appcelerator/amp/master/bootstrap
+    ConstraintDescription: must be an URL.
+    Description: Base URL for InfraKit configuration. there should be a bootstrap script, a default.ikt and a config.aws.tpl file.
+    Default: https://raw.githubusercontent.com/appcelerator/amp/master/platform/bootstrap
     AllowedPattern: "https?://[0-9a-z\\.-]+\\.[a-z\\.]{2,6}[/\\w\\.-]*/?"
   AufsVolumeSize:
     Type: Number
-    Description: Size in GB of the EBS volume for the Docker AUFS storage on each node
+    Description: Size in GB of the EBS volume for the Docker AUFS storage on each node.
     Default: 26
 
 Resources:
@@ -106,7 +169,7 @@ Resources:
         Ref: InternetGateway
       VpcId:
         Ref: Vpc
-  RouteViaIgw:
+  RouteTable:
     Type: AWS::EC2::RouteTable
     DependsOn: Vpc
     Properties:
@@ -119,43 +182,17 @@ Resources:
             - RT
       VpcId:
         Ref: Vpc
-  PublicRouteViaIgw:
+  PublicRoute:
     Type: AWS::EC2::Route
     DependsOn:
     - AttachGateway
-    - RouteViaIgw
+    - RouteTable
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId:
         Ref: InternetGateway
       RouteTableId:
-        Ref: RouteViaIgw
-  SecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    DependsOn: InternetGateway
-    Properties:
-      GroupDescription: VPC-wide security group
-      SecurityGroupIngress:
-      - CidrIp:
-          Fn::FindInMap:
-          - VpcCidrs
-          - vpc
-          - cidr
-        IpProtocol: '-1'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '443'
-        ToPort: '443'
-      VpcId:
-        Ref: Vpc
+        Ref: RouteTable
   PublicSubnet1:
     Type: AWS::EC2::Subnet
     DependsOn: Vpc
@@ -180,16 +217,118 @@ Resources:
             - PublicSubnet1
       VpcId:
         Ref: Vpc
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    DependsOn: Vpc
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - subnet2
+        - cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - PublicSubnet2
+      VpcId:
+        Ref: Vpc
+  PublicSubnet3:
+    Type: AWS::EC2::Subnet
+    DependsOn: Vpc
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '2'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - subnet3
+        - cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - PublicSubnet3
+      VpcId:
+        Ref: Vpc
   PublicSubnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     DependsOn:
     - PublicSubnet1
-    - RouteViaIgw
+    - RouteTable
     Properties:
       RouteTableId:
-        Ref: RouteViaIgw
+        Ref: RouteTable
       SubnetId:
         Ref: PublicSubnet1
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+    - PublicSubnet2
+    - RouteTable
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: PublicSubnet2
+  PublicSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+    - PublicSubnet3
+    - RouteTable
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: PublicSubnet3
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: VPC-wide security group
+      SecurityGroupIngress:
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: '-1'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '2375'
+        ToPort: '2375'
+      VpcId:
+        Ref: Vpc
   ProvisionerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -212,6 +351,8 @@ Resources:
           - 'ec2:Describe*'
           - 'ec2:Get*'
           - 'ec2:CreateTags'
+          - 'autoscaling:Describe*'
+          - 'autoscaling:CreateOrUpdateTags'
           Resource: '*'
           Effect: Allow
         - Action:
@@ -222,6 +363,7 @@ Resources:
           - 'ec2:TerminateInstances'
           - 'ec2:AttachVolume'
           - 'ec2:DetachVolume'
+          - 'autoscaling:*'
           Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*'
           Condition:
             StringEquals:
@@ -300,36 +442,64 @@ Resources:
       Path: /
       Roles:
       - Ref: ClusterRole
-  BootstrapInstance:
-    Type: AWS::EC2::Instance
-    DependsOn: PublicSubnet1
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT10M
+        WaitOnResourceSignals: true
     Properties:
-      SubnetId: !Ref PublicSubnet1
-      SecurityGroupIds:
-        - !GetAtt SecurityGroup.GroupId
-      AvailabilityZone: !GetAtt PublicSubnet1.AvailabilityZone
+      DesiredCapacity: !Ref ManagerSize
+      HealthCheckGracePeriod: 200
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref AsgLaunchConfig
+      MaxSize: 5
+      MinSize: 0
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - manager
+      - Key: Deployment
+        PropagateAtLaunch: true
+        Value: Infrakit
+      - Key: Role
+        PropagateAtLaunch: true
+        Value: manager
+      VPCZoneIdentifier:
+      - Fn::Join:
+        - ','
+        -  - !Ref PublicSubnet1
+           - !Ref PublicSubnet2
+           - !Ref PublicSubnet3
+  AsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn:
+      - ProvisionerInstanceProfile
+      - SecurityGroup
+    Properties:
+      AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref ProvisionerInstanceProfile
       ImageId:
         Fn::FindInMap:
         - AMI
         - Ref: AWS::Region
         - Ubuntu
-      InstanceType: !Ref BootstrapInstanceType
-      PrivateIpAddress: "192.168.2.254"
-      KeyName: !Ref BootstrapKeyName
-      Tags:
-      - Key: Name
-        Value:
-          Fn::Join:
-          - '-'
-          - - Ref: AWS::StackName
-            - controller
-      - Key: infrakit.group
-        Value: swarm-managers
-      - Key: infrakit.role
-        Value: managers
+      InstanceType: !Ref ManagerInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: SecurityGroup
       UserData:
-        "Fn::Base64":
+        Fn::Base64:
           !Sub
             - |
               #cloud-config
@@ -341,6 +511,7 @@ Resources:
                 - git
                 - curl
                 - unzip
+                - awscli
               write_files:
                 - path: /tmp/env.ikt
                   content: |
@@ -348,59 +519,39 @@ Resources:
                     {{ var "/aws/region" "${region}" }}
                     {{ var "/aws/stackname" "${stackname}" }}
                     {{ var "/aws/vpcid" "${Vpc}" }}
-                    {{ var "/aws/subnetid" "${PublicSubnet1}" }}
+                    {{ var "/aws/subnetid1" "${PublicSubnet1}" }}
+                    {{ var "/aws/subnetid2" "${PublicSubnet2}" }}
+                    {{ var "/aws/subnetid3" "${PublicSubnet3}" }}
                     {{ var "/aws/securitygroupid" "${SecurityGroup}" }}
                     {{ var "/aws/amiid" "${ami}" }}
-                    {{ var "/aws/instancetype" "${InstanceType}" }}
+                    {{ var "/aws/instancetype" "${ManagerInstanceType}"}}
                     {{ var "/aws/instanceprofile" "${ClusterInstanceProfile}" }}
                     {{ var "/aws/keyname" "${KeyName}" }}
                     {{ var "/script/baseurl" "${InfraKitConfigurationBaseURL}" }}
                     {{ var "/docker/aufs/size" "${AufsVolumeSize}" }}
               runcmd:
-                - wget -qO- https://get.docker.com/ | sh
-                - usermod -G docker ubuntu
-                - systemctl enable docker.service
-                - systemctl start docker.service
+                - wget -qO- https://get.docker.com/ | sh && \
+                - usermod -G docker ubuntu && \
+                - systemctl enable docker.service && \
+                - systemctl start docker.service && \
                 - curl ${InfraKitConfigurationBaseURL}/bootstrap -o /usr/local/bin/bootstrap.sh
-                - bash /usr/local/bin/bootstrap.sh -p aws -e /tmp/env.ikt ${InfraKitConfigurationBaseURL}
+                - '_myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)'
+                - '_allips=$(aws ec2 describe-instances --region=${AWS::Region} --filters "Name=tag:Name,Values=${AWS::StackName}-manager" "Name=instance-state-name,Values=pending,running" "Name=vpc-id,Values=${Vpc}" --query="Reservations[*].Instances[*].PrivateIpAddress" --output=text | sort -n)'
+                - '_leaderip=$(echo $_allips | cut -f1 -d " ")'
+                - '_rc=0'
+                - '_nodestatus=()'
+                - 'COUNTER=0'
+                - 'for i in $_allips; do'
+                -   '_nodestatus[$COUNTER]=$(docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)'
+                -   '_rc=$((_rc+$?))'
+                -   'COUNTER=$((COUNTER+1))'
+                - 'done'
+                - 'if [ "$_myip" = "$_leaderip" ] && [ "$_rc" = "${ManagerSize}" ]; then'
+                -   'bash /usr/local/bin/bootstrap.sh -1 -p aws -t aws -e /tmp/env.ikt ${InfraKitConfigurationBaseURL}'
+                - 'fi'
+                - 'for i in $_nodestatus; do'
+                -   'if [ "$i" = "true" ]; then'
+                -     'bash /usr/local/bin/bootstrap.sh -j $(echo $_allips | cut -f1 -d " ") -p aws -t aws -e /tmp/env.ikt ${InfraKitConfigurationBaseURL}'
+                -   'fi'
+                - 'done'
             - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
-
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-    - Label:
-        default: Cluster Properties
-      Parameters:
-      - BootstrapInstanceType
-      - BootstrapKeyName
-      - InstanceType
-      - KeyName
-    - Label:
-        default: InfraKit Configuration
-      Parameters:
-      - InfraKitConfigurationBaseURL
-    - Label:
-        default: Docker Configuration
-      Parameters:
-      - AufsVolumeSize
-    ParameterLabels:
-      BootstrapInstanceType:
-        default: Bootstrap instance type
-      InstanceType:
-        default: Cluster instances type
-      BootstrapKeyName:
-        default: Bootstrap instance SSH key
-      KeyName:
-        default: Cluster instances SSH key
-      InfraKitConfigurationBaseURL:
-        default: InfraKit configuration base URL
-      AufsVolumeSize:
-        default: EBS Volume Size
-
-Outputs:
-  BootNodePublicIP:
-    Description: The public IP of the boot node
-    Value:
-      Fn::GetAtt:
-      - BootstrapInstance
-      - PublicIp

--- a/platform/bootstrap/config.aws-aws.tpl
+++ b/platform/bootstrap/config.aws-aws.tpl
@@ -48,7 +48,7 @@
                   "InitScriptTemplateURL": "{{ var "/script/baseurl" }}/worker-init.tpl",
                   "SwarmJoinIP": "{{ var "/bootstrap/ip" }}",
                   "Docker" : {
-                    "Host" : "tcp://localhost:{{ var "/docker/remoteapi/port" }}"
+                    "Host" : "unix:///var/run/docker.sock"
                   }
                 }
               }

--- a/platform/bootstrap/config.aws-aws.tpl
+++ b/platform/bootstrap/config.aws-aws.tpl
@@ -5,77 +5,6 @@
   {
     "Plugin": "group",
     "Properties": {
-      "ID": "amp-manager-{{ var "/aws/vpcid" }}",
-      "Properties": {
-        "Allocation": {
-          "LogicalIds": [
-            "{{ var "/m1/ip" }}",
-            "{{ var "/m2/ip" }}",
-            "{{ var "/m3/ip" }}"
-          ]
-        },
-        "Instance": {
-          "Plugin": "instance-aws/ec2-instance",
-          "Properties": {
-            "RunInstancesInput": {
-              "ImageId": "{{ var "/aws/amiid" }}",
-              "InstanceType": "{{ var "/aws/instancetype" }}",
-              "KeyName": "{{ var "/aws/keyname" }}",
-              "SubnetId": "{{ var "/aws/subnetid" }}",
-              {{ if var "/aws/instanceprofile" }}"IamInstanceProfile": {
-                "Name": "{{ var "/aws/instanceprofile" }}"
-              },{{ end }}
-              "SecurityGroupIds": [ "{{ var "/aws/securitygroupid" }}" ]
-            },
-            "Tags": {
-              "Name": "{{ var "/aws/stackname" }}-manager",
-              "Deployment": "Infrakit",
-              "Role" : "manager"
-            }
-          }
-        },
-        "Flavor": {
-          "Plugin": "flavor-combo",
-          "Properties": {
-            "Flavors": [
-              {
-                "Plugin": "flavor-vanilla",
-                "Properties": {
-                  "Init": [
-                    "#!/bin/bash",
-                    "apt-get install -y awscli jq"
-                  ]
-                }
-              }, {
-                "Plugin": "flavor-swarm/manager",
-                "Properties": {
-                  "InitScriptTemplateURL": "{{ var "/script/baseurl" }}/manager-init.tpl",
-                  "SwarmJoinIP": "{{ var "/m1/ip" }}",
-                  "Docker" : {
-                    "Host" : "tcp://{{ var "/m1/ip" }}:{{ var "/docker/remoteapi/port" }}"
-                  }
-                }
-              }, {
-                "Plugin": "flavor-vanilla",
-                "Properties": {
-                  "Init": [
-                    "set -o errexit",
-                    "docker network inspect {{ var "/amp/network" }} 2>&1 | grep -q 'No such network' && \\",
-                    "  docker network create -d overlay --attachable {{ var "/amp/network" }}",
-                    "docker service ls {{ var "/amp/network" }} 2>&1 | grep -q 'No such network' && \\",
-                    "docker service create --name amplifier --network {{ var "/amp/network" }} {{ var "/amp/amplifier/image" }}:{{ var "/amp/amplifier/version" }} || true"
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
-    }
-  },
-  {
-    "Plugin": "group",
-    "Properties": {
       "ID": "amp-worker-{{ var "/aws/vpcid" }}",
       "Properties": {
         "Allocation": {
@@ -88,7 +17,7 @@
               "ImageId": "{{ var "/aws/amiid" }}",
               "InstanceType": "{{ var "/aws/instancetype" }}",
               "KeyName": "{{ var "/aws/keyname" }}",
-              "SubnetId": "{{ var "/aws/subnetid" }}",
+              "SubnetId": "{{ var "/aws/subnetid1" }}",
               {{ if var "/aws/instanceprofile" }}"IamInstanceProfile": {
                 "Name": "{{ var "/aws/instanceprofile" }}"
               },{{ end }}
@@ -117,9 +46,9 @@
                 "Plugin": "flavor-swarm/worker",
                 "Properties": {
                   "InitScriptTemplateURL": "{{ var "/script/baseurl" }}/worker-init.tpl",
-                  "SwarmJoinIP": "{{ var "/m1/ip" }}",
+                  "SwarmJoinIP": "{{ var "/bootstrap/ip" }}",
                   "Docker" : {
-                    "Host" : "tcp://{{ var "/m1/ip" }}:{{ var "/docker/remoteapi/port" }}"
+                    "Host" : "tcp://localhost:{{ var "/docker/remoteapi/port" }}"
                   }
                 }
               }

--- a/platform/bootstrap/plugins.json
+++ b/platform/bootstrap/plugins.json
@@ -12,7 +12,7 @@
         "Plugin" : "manager-swarm",
         "Launch" : {
             "os": {
-                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless swarm --leader-file {{env "INFRAKIT_HOME"}}/leader --store-dir {{env "INFRAKIT_HOME"}}/configs > {{env "INFRAKIT_HOME"}}/logs/manager-swarm.log 2>&1"
+                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless swarm > {{env "INFRAKIT_HOME"}}/logs/manager-swarm.log 2>&1"
             }
         }
     }

--- a/platform/bootstrap/plugins.json
+++ b/platform/bootstrap/plugins.json
@@ -1,9 +1,18 @@
 [
     {
-        "Plugin" : "manager",
+        "Plugin" : "manager-os",
         "Launch" : {
             "os": {
-                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file {{env "INFRAKIT_HOME"}}/leader --store-dir {{env "INFRAKIT_HOME"}}/configs > {{env "INFRAKIT_HOME"}}/logs/manager.log 2>&1"
+                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file {{env "INFRAKIT_HOME"}}/leader --store-dir {{env "INFRAKIT_HOME"}}/configs > {{env "INFRAKIT_HOME"}}/logs/manager-os.log 2>&1"
+            }
+        }
+    }
+    ,
+    {
+        "Plugin" : "manager-swarm",
+        "Launch" : {
+            "os": {
+                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless swarm --leader-file {{env "INFRAKIT_HOME"}}/leader --store-dir {{env "INFRAKIT_HOME"}}/configs > {{env "INFRAKIT_HOME"}}/logs/manager-swarm.log 2>&1"
             }
         }
     }

--- a/platform/bootstrap/userdata-aws
+++ b/platform/bootstrap/userdata-aws
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o errexit
+
+REGION=${REGION:-us-west-2}
+STACK_NAME=${STACK_NAME:-unset}
+VPC_ID=${VPC_ID:-unset}
+BASE_URL=${BASE_URL:-unset}
+MANAGER_SIZE=${MANAGER_SIZE:-3}
+ENV_FILE=${ENV_FILE:-/tmp/env.ikt}
+
+wget -qO- https://get.docker.com/ | sh
+usermod -G docker ubuntu || true
+systemctl enable docker.service
+systemctl start docker.service || true
+
+_myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)
+_allips=$(aws ec2 describe-instances --region=${REGION} --filters "Name=tag:Name,Values=${STACK_NAME}-manager" "Name=instance-state-name,Values=pending,running" "Name=vpc-id,Values=${VPC_ID}" --query="Reservations[*].Instances[*].PrivateIpAddress" --output=text | sort -n)
+_leaderip=$(echo $_allips | cut -f1 -d " ")
+_rc=0
+_nodestatus=()
+COUNTER=0
+for i in $_allips; do
+  _nodestatus[$COUNTER]=$(docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
+  _rc=$((_rc+$?))
+  COUNTER=$((COUNTER+1))
+done
+if [ "$_myip" = "$_leaderip" ] && [ "$_rc" = "${MANAGER_SIZE}" ]; then
+  bash /usr/local/bin/bootstrap.sh -1 -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
+fi
+for i in $_nodestatus; do
+  if [ "$i" = "true" ]; then
+    bash /usr/local/bin/bootstrap.sh -j $(echo $_allips | cut -f1 -d " ") -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
+  fi
+done

--- a/platform/bootstrap/userdata-aws
+++ b/platform/bootstrap/userdata-aws
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -o errexit
+set -x
 
 REGION=${REGION:-us-west-2}
 STACK_NAME=${STACK_NAME:-unset}
@@ -17,19 +17,27 @@ systemctl start docker.service || true
 _myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)
 _allips=$(aws ec2 describe-instances --region=${REGION} --filters "Name=tag:Name,Values=${STACK_NAME}-manager" "Name=instance-state-name,Values=pending,running" "Name=vpc-id,Values=${VPC_ID}" --query="Reservations[*].Instances[*].PrivateIpAddress" --output=text | sort -n)
 _leaderip=$(echo $_allips | cut -f1 -d " ")
+_nodestatus=""
 _rc=0
-_nodestatus=()
 COUNTER=0
 for i in $_allips; do
-  _nodestatus[$COUNTER]=$(docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
+  docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null
   _rc=$((_rc+$?))
   COUNTER=$((COUNTER+1))
 done
 if [ "$_myip" = "$_leaderip" ] && [ "$_rc" = "${MANAGER_SIZE}" ]; then
-  bash /usr/local/bin/bootstrap.sh -1 -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
+  /usr/local/bin/bootstrap.sh -1 -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
+  exit
 fi
-for i in $_nodestatus; do
-  if [ "$i" = "true" ]; then
-    bash /usr/local/bin/bootstrap.sh -j $(echo $_allips | cut -f1 -d " ") -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
-  fi
+_loop=0
+_maxloop=120
+while [ $((++_loop)) -lt $_maxloop ]; do
+  for i in $_allips; do
+    _nodestatus=$(docker -H "$i:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
+    if [ "$_nodestatus" = "true" ]; then
+      /usr/local/bin/bootstrap.sh -j $i -p aws -t aws -e "$ENV_FILE" "${BASE_URL}"
+      exit
+    fi
+  done
+  sleep 1
 done


### PR DESCRIPTION
fixes #1150, #944 

Updates to the cloudformation stack .yml file for use with the current deployment. New cloudformation deploys 3 manager nodes with an Autoscaling group into 3 separate subnets in different Availability zones within the given region. Each manager determines the leader node for the swarm via the AWS cli and docker remote api. 

In addition, the bootstrap script is modified for better HA deployment as now Infrakit runs on each manager and the manager plugin runs in swarm mode, so that the management of the worker group can be reassigned to different managers.

Some limitations to be worked on:
 - Currently, we can only deploy into regions with 3 availability zones.
- Workers are only deployed onto a single subnet, for the moment, and instead they should be deployed using another autoscaling group.
- There are two different plugin files for both swarm and os modes for the infrakit-manager plugin. This should be modified for better code reuse. 