### PR TITLE
Report failed test count as exit status

### DIFF
--- a/platform/testing/testrunner
+++ b/platform/testing/testrunner
@@ -289,6 +289,8 @@ run() {
   local failed=$(cat "$FLOG" 2>/dev/null | wc -l) || 0
   local count=$(( passed + failed ))
   printresults $(elapsed_hms) $count $passed $failed
+
+  exit $failed
 }
 
 run "$TEST_DIR"


### PR DESCRIPTION
Fixes #1201 

## Verification

    $ mkdir testfix
    $ echo "exit 1" > testfix/test.sh
    $ TESTINCLUDE=/path/to/testing /path/to/testing/testrunner testfix
    $ echo $?  # verify non-zero

    # try renaming test.sh -> setup.sh, teardown.sh and repeat
