### PR TITLE
add amp config cmd

### DIFF
--- a/cli/command/config/config.go
+++ b/cli/command/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/appcelerator/amp/cli"
+	"github.com/spf13/cobra"
+)
+
+type AMPConfig struct {
+	Config *cli.Configuration
+}
+
+var t = `AMP Configuration:
+ Server:        {{.Config.Server}}`
+
+// NewConfigCommand returns a new instance of the config command.
+func NewConfigCommand(c cli.Interface) *cobra.Command {
+	return &cobra.Command{
+		Use:     "config",
+		Short:   "Display amp configuration",
+		PreRunE: cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showConfig(c)
+		},
+	}
+}
+
+func showConfig(c cli.Interface) error {
+	conf := &AMPConfig{
+		&cli.Configuration{
+			Server: c.Server(),
+		},
+	}
+
+	tmpl, err := template.New("t").Parse(t)
+	if err != nil {
+		return fmt.Errorf("template parsing error: %v\n", err)
+	}
+
+	var doc bytes.Buffer
+	if err := tmpl.Execute(&doc, conf); err != nil {
+		return fmt.Errorf("template execution error: %v\n", err)
+	}
+
+	c.Console().Println(doc.String())
+	return nil
+}

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/appcelerator/amp/cli"
 	"github.com/appcelerator/amp/cli/command/cluster"
+	"github.com/appcelerator/amp/cli/command/config"
 	"github.com/appcelerator/amp/cli/command/login"
 	"github.com/appcelerator/amp/cli/command/logout"
 	"github.com/appcelerator/amp/cli/command/logs"
@@ -78,6 +79,9 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 // addCommands adds the cli commands to the root command that we want to make available for a release.
 func addCommands(cmd *cobra.Command, c cli.Interface) {
 	cmd.AddCommand(
+		//config
+		config.NewConfigCommand(c),
+
 		// cluster
 		cluster.NewClusterCommand(c),
 

--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -17,25 +17,25 @@ var (
 	Build string
 
 	//address string
-	config *cli.Configuration
+	cfg *cli.Configuration
 )
 
 func main() {
 	// Initial configuration (before processing environment and flags)
-	config = &cli.Configuration{
+	cfg = &cli.Configuration{
 		Version: Version,
 		Build:   Build,
 		Server:  cli.DefaultAddress + cli.DefaultPort,
 	}
 
 	// Read the cli config
-	if err := cli.ReadClientConfig(config); err != nil {
+	if err := cli.ReadClientConfig(cfg); err != nil {
 		log.Fatalln(err)
 	}
 
 	// Set terminal emulation based on platform as required.
 	stdin, stdout, stderr := term.StdStreams()
-	c := cli.NewCLI(stdin, stdout, stderr, config)
+	c := cli.NewCLI(stdin, stdout, stderr, cfg)
 	cmd := newRootCommand(c)
 
 	if err := cmd.Execute(); err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,25 @@
+### AMP Configuration
+
+The `amp config` command displays the AMP configuration. Currently, only the server address is part of the configuration.
+It can be accessed by storing the value in a config file or passing it as a command-line argument.
+The config file can be stored in one of the following paths:
+
+- Create a new directory called `.amp` in the current working (local) directory and add the config file `amp.yml` in this directory.
+- Create a new directory called `amp` in the `$HOME/.config` directory and add the config file `amp.yml` in this directory.
+
+The default location to store the config file is in the `$HOME/.config/amp` directory
+
+
+#### Usage
+
+* As a command-line argument:
+```
+    $ amp -s localhost config
+    [localhost:50101]
+    Config:
+     Server:       localhost:50101
+```
+
+* Reading from the local directory (from `./.amp/amp.yml`)
+
+* Reading from the HOME directory (from `$HOME/.config/amp.yml`)

--- a/docs/version.md
+++ b/docs/version.md
@@ -1,8 +1,8 @@
-# Version
+### Version
 
 The `amp version` command displays the current version of AMP.
 
-### Usage
+#### Usage
 
     $ amp version
 

--- a/platform/tests/config/config_cmd_test.sh
+++ b/platform/tests/config/config_cmd_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# server address passed as command-line argument
+test_cli_config() {
+  echo $(amp -s localhost config) | grep -E "Server:[[:space:]]+localhost"
+}
+
+# server address passed as command-line argument
+test_local_config() {
+  mkdir -p $PWD/.amp
+  echo "Server: LOCAL" > $PWD/.amp/amp.yml
+  echo $(amp config) | grep -E "Server:[[:space:]]+LOCAL"
+}
+
+test_local_cleanup() {
+   rm -Rf $PWD/.amp
+}
+
+# server address passed as command-line argument
+test_home_config() {
+  mkdir -p $HOME/.config/amp
+  echo "Server: HOME" > $HOME/.config/amp/amp.yml
+  echo $(amp config) | grep -E "Server:[[:space:]]+HOME"
+}
+
+test_home_cleanup() {
+   rm -Rf $HOME/.config/amp
+}


### PR DESCRIPTION
Fixes #1233 
Added `amp config` command to the CLI

```
    $ amp config --help

    Usage:	amp config

    Display amp configuration

    Options:
      -h, --help            Print usage
      -s, --server string   Specify server (host:port)
```

Tests in `platform/tests/config/config_cmd_test.sh`
