### PR TITLE
Cluster Health Alerting part 2

### DIFF
--- a/examples/monitoring/alertmanager.yml
+++ b/examples/monitoring/alertmanager.yml
@@ -1,0 +1,15 @@
+---
+global:
+  slack_api_url: "https://hooks.slack.com/services/YOUR_URL"
+templates:
+- '/etc/alertmanager/template/*.tmpl'
+route:
+  receiver: slack-receiver
+receivers:
+- name: "slack-receiver"
+  slack_configs:
+  - channel: "#YOUR_CHANNEL"
+    username: "Alertmanager"
+    title: '{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}'
+    text: '{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}'
+    send_resolved: true

--- a/examples/monitoring/prometheus_alerts.rules
+++ b/examples/monitoring/prometheus_alerts.rules
@@ -1,0 +1,297 @@
+# Global alert (nats, etcd, haproxy, docker engine, system)
+ALERT FileDescriptors
+  IF 100 * (process_max_fds - process_open_fds)/ process_max_fds < 10
+  FOR 30s
+  ANNOTATIONS {
+   summary = "file descriptors exhaustion",
+   description = "file descriptor usage on {{ $labels.job }} / {{ $labels.instance }} is more than 90%"
+  }
+
+# Global alert (nats, etcd, haproxy, docker engine, system)
+ALERT Availability
+  IF up < 1
+  FOR 5m
+  ANNOTATIONS {
+   summary = "resource unavailability",
+   description = "{{ $labels.job }} / {{ $labels.instance }} is not up"
+  }
+
+# elasticsearch
+ALERT ElasticsearchClusterStatus
+  IF es_cluster_status < 1
+  FOR 1m
+  ANNOTATIONS {
+   summary = "elasticsearch cluster status",
+   description = "elasticsearch cluster status is {{ $value }}"
+  }
+ALERT ElasticsearchHeapPercent
+  IF es_jvm_mem_heap_used_percent > 95
+  FOR 1m
+  ANNOTATIONS {
+   summary = "elasticsearch java heap size high usage",
+   description = "elasticsearch instance on {{ $labels.instance }} uses {{ $value }} of its java heap size"
+  }
+ALERT ElasticsearchPendingTasks
+  IF es_cluster_pending_tasks_number > 1000
+  FOR 1m
+  ANNOTATIONS {
+   summary = "elasticsearch high number of pending tasks",
+   description = "elasticsearch instance on {{ $labels.instance }} has {{ $value }} pending tasks"
+  }
+
+# ETCD
+# from https://github.com/coreos/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules
+# general cluster availability
+
+# alert if another failed member will result in an unavailable cluster
+ALERT InsufficientMembers
+IF count(up{job="etcd"}) > 1 and count(up{job="etcd"} == 0) > (count(up{job="etcd"}) / 2 - 1)
+FOR 3m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "etcd cluster insufficient members",
+  description = "If one more etcd member goes down the cluster will be unavailable",
+}
+
+# etcd leader alerts
+# ==================
+
+# alert if any etcd instance has no leader
+ALERT NoLeader
+IF etcd_server_has_leader{job="etcd"} == 0
+FOR 1m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "etcd member has no leader",
+  description = "etcd member {{ $labels.instance }} has no leader",
+}
+
+# alert if there are lots of leader changes
+ALERT HighNumberOfLeaderChanges
+IF increase(etcd_server_leader_changes_seen_total{job="etcd"}[1h]) > 3
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "a high number of leader changes within the etcd cluster are happening",
+  description = "etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour",
+}
+
+# gRPC request alerts
+# ===================
+
+# alert if more than 1% of gRPC method calls have failed within the last 5 minutes
+ALERT HighNumberOfFailedGRPCRequests
+IF sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
+  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.01
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "a high number of gRPC requests are failing",
+  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
+}
+
+# alert if more than 5% of gRPC method calls have failed within the last 5 minutes
+ALERT HighNumberOfFailedGRPCRequests
+IF sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
+  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.05
+FOR 5m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "a high number of gRPC requests are failing",
+  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
+}
+
+# alert if the 99th percentile of gRPC method calls take more than 150ms
+ALERT GRPCRequestsSlow
+IF histogram_quantile(0.99, rate(etcd_grpc_unary_requests_duration_seconds_bucket[5m])) > 0.15
+FOR 10m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "slow gRPC requests",
+  description = "on etcd instance {{ $labels.instance }} gRPC requests to {{ $label.grpc_method }} are slow",
+}
+
+# HTTP requests alerts
+# ====================
+
+# alert if more than 1% of requests to an HTTP endpoint have failed within the last 5 minutes
+ALERT HighNumberOfFailedHTTPRequests
+IF sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m]))
+  / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.01
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "a high number of HTTP requests are failing",
+  description = "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
+}
+
+# alert if more than 5% of requests to an HTTP endpoint have failed within the last 5 minutes
+ALERT HighNumberOfFailedHTTPRequests
+IF sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m])) 
+  / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.05
+FOR 5m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "a high number of HTTP requests are failing",
+  description = "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
+}
+
+# alert if the 99th percentile of HTTP requests take more than 150ms
+ALERT HTTPRequestsSlow
+IF histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "slow HTTP requests",
+  description = "on etcd instance {{ $labels.instance }} HTTP requests to {{ $label.method }} are slow",
+}
+
+# file descriptor alerts
+# ======================
+
+instance:fd_utilization = process_open_fds / process_max_fds
+
+# alert if file descriptors are likely to exhaust within the next 4 hours
+ALERT FdExhaustionClose
+IF predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "file descriptors soon exhausted",
+  description = "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon",
+}
+
+# alert if file descriptors are likely to exhaust within the next hour
+ALERT FdExhaustionClose
+IF predict_linear(instance:fd_utilization[10m], 3600) > 1
+FOR 10m
+LABELS {
+  severity = "critical"
+}
+ANNOTATIONS {
+  summary = "file descriptors soon exhausted",
+  description = "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon",
+}
+
+# etcd member communication alerts
+# ================================
+
+# alert if 99th percentile of round trips take 150ms
+ALERT EtcdMemberCommunicationSlow
+IF histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m])) > 0.15
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "etcd member communication is slow",
+  description = "etcd instance {{ $labels.instance }} member communication with {{ $label.To }} is slow",
+}
+
+# etcd proposal alerts
+# ====================
+
+# alert if there are several failed proposals within an hour
+ALERT HighNumberOfFailedProposals
+IF increase(etcd_server_proposals_failed_total{job="etcd"}[1h]) > 5
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "a high number of proposals within the etcd cluster are failing",
+  description = "etcd instance {{ $labels.instance }} has seen {{ $value }} proposal failures within the last hour",
+}
+
+# etcd disk io latency alerts
+# ===========================
+
+# alert if 99th percentile of fsync durations is higher than 500ms
+ALERT HighFsyncDurations
+IF histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "high fsync durations",
+  description = "etcd instance {{ $labels.instance }} fync durations are high",
+}
+
+# alert if 99th percentile of commit durations is higher than 250ms
+ALERT HighCommitDurations
+IF histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
+FOR 10m
+LABELS {
+  severity = "warning"
+}
+ANNOTATIONS {
+  summary = "high commit durations",
+  description = "etcd instance {{ $labels.instance }} commit durations are high",
+}
+
+
+# NATS
+ALERT NatsHttpRequestDuration
+  IF http_request_duration_microseconds{job="nats", quantile="0.9"} > 5000
+  ANNOTATIONS {
+   summary = "slow nats http requests",
+   description = "a nats instance on {{ $labels.instance }} experiences slow http requests ({{ $value }} sec)"
+  }
+
+# HAPROXY
+ALERT HaproxyServerCurrentQueue
+  IF haproxy_server_current_queue{job="haproxy"} > 10
+  FOR 2m
+  ANNOTATIONS {
+   summary = "Queue is filling up",
+   description = "haproxy backend {{ $labels.backend }} has ({{ $value }} requests in queue"
+  }
+
+# NODES
+ALERT SystemLoad15
+  IF node_load15{job="nodes"} > 2
+  FOR 1m
+  ANNOTATIONS {
+   summary = "high system load",
+   description = "the average system load on 15 min on {{ $labels.instance }} has reached {{ $value }}"
+  }
+ALERT SystemLoad5
+  IF node_load5{job="nodes"} > 4
+  FOR 1m
+  ANNOTATIONS {
+   summary = "high system load",
+   description = "the average system load on 5 min on {{ $labels.instance }} has reached {{ $value }}"
+  }
+ALERT FSUsage
+  IF 100 * node_filesystem_free / node_filesystem_size{fstype=~"xfs|ext4",mountpoint=~"/rootfs|/rootfs/var/lib/docker"} <  20
+  FOR 1m
+  ANNOTATIONS {
+   summary = "FS soon running out of space",
+   description = "the {{ $labels.mountpoint }} on {{ $labels.instance }} has only {{ $value }}% space available"
+  }
+ALERT MemoryUsage
+  IF 100 * node_memory_MemFree / node_memory_MemTotal < 10
+  FOR 5m 
+  ANNOTATIONS {
+   summary = "high memory usage",
+   description = "instance {{ $labels.instance }} has only {{ $value }}% memory available"
+  }

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ FROM appcelerator/alpine:3.5.2
 RUN apk update && apk upgrade && apk --no-cache add openjdk8-jre bind-tools
 
 ENV PATH /bin:/opt/elasticsearch/bin:$PATH
-ENV ELASTIC_VERSION 5.3.2
+ENV ELASTIC_VERSION 5.4.0
 
 RUN curl -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTIC_VERSION.tar.gz -o /tmp/elasticsearch-$ELASTIC_VERSION.tar.gz && \
     mkdir /opt && \
@@ -18,6 +18,8 @@ COPY config/java.policy /opt/elasticsearch/config/java.policy
 COPY config/elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml.tpl
 COPY config/log4j2.properties /opt/elasticsearch/config/
 COPY /bin/docker-entrypoint.sh /bin/
+
+RUN /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.4.0.0.zip
 
 RUN mkdir -p /opt/elasticsearch/config/scripts
 RUN adduser -D -h /opt/elasticsearch -s /sbin/nologin elastico

--- a/images/elasticsearch/config/java.policy
+++ b/images/elasticsearch/config/java.policy
@@ -1,3 +1,6 @@
 grant {
 	permission javax.management.MBeanTrustPermission "register";
+        permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+        permission java.lang.RuntimePermission "accessDeclaredMembers";
+        permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };

--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,0 +1,5 @@
+FROM appcelerator/grafana:grafana-4.3.2
+ENV FORCE_HOSTNAME	auto
+ENV GRAFANA_PLUGIN_LIST  "grafana-piechart-panel"
+
+COPY config /etc/extra-config/grafana

--- a/images/grafana/README.md
+++ b/images/grafana/README.md
@@ -1,0 +1,22 @@
+# Grafana Docker image
+
+This project builds a Docker image with the latest master build of Grafana and customization for AMP.
+
+## Running your Grafana container
+
+Start your container binding the external port `3000`.
+
+    docker run -d --name=grafana -p 3000:3000 appcelerator/grafana-amp
+
+Try it out, default admin user is admin/changeme.
+
+## Configuration (ENV, -e)
+
+Same as [base image](https://github.com/appcelerator/docker-grafana)
+
+## Tags
+
+- ```1.0.1``` (Grafana 3.1.1)
+- ```1.1.1``` (Grafana 4.0)
+- ```1.1.2``` (Grafana 4.1)
+- ```1.2.0```, ```latest``` (Grafana 4.3)

--- a/images/grafana/config/config-dashboard-cluster-health.js
+++ b/images/grafana/config/config-dashboard-cluster-health.js
@@ -1,0 +1,3507 @@
+{
+  "Dashboard": {
+    "title": "Cluster Health",
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "links": [],
+    "refresh": false,
+    "rows": [
+      {
+        "collapse": false,
+        "height": 93,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 1,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": false
+            },
+            "id": 15,
+            "interval": null,
+            "links": [],
+            "mappingType": 2,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              },
+              {
+                "from": "0",
+                "text": "DOWN",
+                "to": "0"
+              },
+              {
+                "from": "1",
+                "text": "Up",
+                "to": "999"
+              }
+            ],
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "up{job=\"haproxy\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "up",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "HAPROXY",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 14,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": " UP",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              },
+              {
+                "from": "0",
+                "text": "Down",
+                "to": "0"
+              },
+              {
+                "from": "1",
+                "text": "Up",
+                "to": "999"
+              }
+            ],
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "Value",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_has_leader)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "etcd_server_has_leader",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "ETCD",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 12,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": " UP",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              },
+              {
+                "from": "0",
+                "text": "Down",
+                "to": "0"
+              },
+              {
+                "from": "1",
+                "text": "Up",
+                "to": "999"
+              }
+            ],
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "count(up{job=\"nats\"}==1)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "up",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "NATS",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 13,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": " UP",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              },
+              {
+                "from": "0",
+                "text": "Down",
+                "to": "0"
+              },
+              {
+                "from": "1",
+                "text": "Up",
+                "to": "999"
+              }
+            ],
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "count(up{job=\"elasticsearch\"}==1)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "es_cluster_status",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "ES",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "0",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 16,
+            "interval": null,
+            "links": [],
+            "mappingType": 2,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": " UP",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeat": null,
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "Value",
+            "targets": [
+              {
+                "expr": "count(up{job=\"docker-engine\"}==1)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "up",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "DOCKER",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              },
+              {
+                "op": "=",
+                "text": "Down",
+                "value": "0"
+              },
+              {
+                "op": "=",
+                "text": "Up",
+                "value": "1"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 17,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": " KO",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "0",
+                "to": "null"
+              }
+            ],
+            "span": 1,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "Value",
+            "targets": [
+              {
+                "expr": "count(up{job=\"docker-engine\"}) - count(up{job=\"docker-engine\"}==1)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "up",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "DOCKER",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "0",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "OVERALL STATUS",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 36,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "node_load1",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "metric": "node_load1",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Load 1 Minute",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 37,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "node_load5",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "metric": "node_load5",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Load 5 Minutes",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 38,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "node_load15",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "metric": "node_load15",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Load 15 Minutes",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 42,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "100 - 100 * node_memory_MemFree / node_memory_MemTotal",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": "",
+                "logBase": 1,
+                "max": "100",
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 43,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "100 - 100 * node_filesystem_free / node_filesystem_size{fstype=~\"xfs|ext4\",mountpoint=\"/rootfs\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "/ Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": "",
+                "logBase": 1,
+                "max": "100",
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "decimals": 1,
+            "fill": 1,
+            "id": 44,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "100 - 100 * node_filesystem_free / node_filesystem_size{fstype=~\"xfs|ext4\",mountpoint=\"/rootfs/var/lib/docker\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "/var/lib/docker Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": "",
+                "logBase": 1,
+                "max": "100",
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "SYSTEM",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 53,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "haproxy_server_current_queue",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{backend}}",
+                "metric": "haproxy_server_current_queue",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Server Current Queue",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 54,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "haproxy_frontend_current_sessions",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{frontend}}",
+                "metric": "haproxy_frontend_current_sessions",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Frontend Http Sessions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 55,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(haproxy_frontend_http_responses_total[1m])",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{frontend}}-{{code}}",
+                "metric": "haproxy_frontend_http_responses_total",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Frontend Http Responses (per min)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "HAPROXY",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 140,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 1,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_leader_changes_seen_total)",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "etcd_server_leader_changes_seen_total",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "5,100",
+            "title": "Leader Changes Seen",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 2,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_proposals_committed_total)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "metric": "etcd_server_proposals_committed_total",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "",
+            "title": "Proposals Committed",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 3,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_proposals_applied_total)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "metric": "etcd_server_proposals_applied_total",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "",
+            "title": "Proposal Applied",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 4,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_proposals_failed_total)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "metric": "etcd_server_proposals_failed_total",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,10",
+            "title": "Proposal Failed",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 5,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(etcd_server_proposals_pending)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "metric": "etcd_server_proposals_pending",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "50,100",
+            "title": "Proposal Pending",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 45,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate({grpc_type=\"unary\",grpc_code!=\"OK\"} [1m]))",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} RPC Rate",
+                "metric": "grpc_server_started_total",
+                "refId": "A",
+                "step": 20
+              },
+              {
+                "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\",grpc_code!=\"OK\"} [1m])) - sum(rate(grpc_server_handled_total{grpc_type=\"unary\"} [1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} RPC Failed Rate",
+                "metric": "grpc_server_handled_total",
+                "refId": "B",
+                "step": 20
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RPC Rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ops",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 47,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "etcd_debugging_mvcc_db_total_size_in_bytes",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} DB Size",
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "DB Size",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 49,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "process_resident_memory_bytes{job=\"etcd\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} Resident Memory",
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 46,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(grpc_server_started_total {grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",grpc_code!=\"OK\"}) - sum(grpc_server_handled_total {grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "Watch Streams",
+                "metric": "grpc_server_handled_total",
+                "refId": "A",
+                "step": 20
+              },
+              {
+                "expr": "sum(grpc_server_started_total {grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total {grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "Lease Streams",
+                "metric": "grpc_server_handled_total",
+                "refId": "B",
+                "step": 20
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Active Streams",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 48,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"etcd\"} [5m])) by (instance, le))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} WAL fsync",
+                "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
+                "refId": "A",
+                "step": 10
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket [5m])) by (instance, le))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} DB fsync",
+                "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
+                "refId": "B",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Disk Sync Duration",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 50,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(etcd_network_client_grpc_received_bytes_total [1m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} Client Traffic In",
+                "metric": "etcd_network_client_grpc_received_bytes_total",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Traffic In",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 51,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(etcd_network_client_grpc_sent_bytes_total [1m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} Client Traffic Out",
+                "metric": "etcd_network_client_grpc_sent_bytes_total",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Traffic Out",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "ETCD",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 232,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 9,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "min(es_cluster_status)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{cluster}}",
+                "metric": "es_cluster_status",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "",
+            "title": "Cluster Status",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              },
+              {
+                "op": "=",
+                "text": "UP",
+                "value": "1"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 8,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "avg(es_cluster_nodes_number{job=\"elasticsearch\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1",
+            "title": "Nodes Number",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": true,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 7,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "max(es_jvm_mem_heap_used_percent)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "es_jvm_mem_heap_used_percent",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "70,90",
+            "title": "Mem Heap Percent Used",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 10,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(es_cluster_pending_tasks_number)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "metric": "es_cluster_pending_tasks_number",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "50,500",
+            "title": "Pending Tasks",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 11,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "es_cluster_task_max_waiting_time_seconds",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{cluster}}",
+                "metric": "es_cluster_task_max_waiting_time_seconds",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Task Max Waiting Time",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "ELASTICSEARCH",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 33,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "gnatsd_varz_connections",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{server_id}}",
+                "metric": "gnatsd_varz_connections",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Connections",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 34,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "gnatsd_varz_subscriptions",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{server_id}}",
+                "metric": "gnatsd_varz_subscriptions",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Subscriptions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 35,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "gnatsd_varz_slow_consumers",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{server_id}}",
+                "metric": "gnatsd_varz_slow_consumers",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Slow Consumers",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 56,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(gnatsd_varz_in_msgs[1m])",
+                "format": "time_series",
+                "interval": "500ms",
+                "intervalFactor": 2,
+                "legendFormat": "{{server_id}}",
+                "metric": "gnatsd_varz_in_msgs",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "NATS Msgs In Rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "wpm",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "id": 60,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(gnatsd_varz_out_msgs[1m])",
+                "format": "time_series",
+                "interval": "500ms",
+                "intervalFactor": 2,
+                "legendFormat": "{{server_id}}",
+                "metric": "gnatsd_varz_out_msgs",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "NATS Msgs Out Rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "wpm",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "decimals": null,
+            "format": "short",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 57,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "gnatsd_varz_in_msgs",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "gnatsd_varz_in_msgs",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "",
+            "title": "Msgs In",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "decimals": null,
+            "format": "short",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 58,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "gnatsd_varz_out_msgs",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "gnatsd_varz_out_msgs",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "",
+            "title": "Msgs Out",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": null,
+            "decimals": null,
+            "format": "short",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 59,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "gnatsd_varz_in_msgs - gnatsd_varz_out_msgs",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "metric": "gnatsd_varz_in_msgs",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": "1,1000",
+            "title": "Msgs In - Out",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "NATS",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 214,
+        "panels": [
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "heatmap": {},
+            "highlightCards": true,
+            "id": 40,
+            "links": [],
+            "minSpan": 4,
+            "span": 6,
+            "targets": [
+              {
+                "expr": "engine_daemon_container_actions_seconds_bucket",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{job}}",
+                "metric": "engine_daemon_container_actions_seconds_bucket",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "title": "Container Actions Seconds",
+            "tooltip": {
+              "show": true,
+              "showHistogram": false
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "short",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketNumber": null,
+            "yBucketSize": null
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "heatmap": {},
+            "highlightCards": true,
+            "id": 41,
+            "links": [],
+            "minSpan": 4,
+            "span": 6,
+            "targets": [
+              {
+                "expr": "engine_daemon_network_actions_seconds_bucket",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{job}}",
+                "metric": "engine_daemon_network_actions_seconds_bucket",
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "title": "Network Actions Seconds",
+            "tooltip": {
+              "show": true,
+              "showHistogram": false
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "short",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Docker Engine",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus",
+          "hide": 2,
+          "includeAll": true,
+          "label": "Node",
+          "multi": true,
+          "name": "node",
+          "options": [],
+          "query": "label_values(node_load1, instance)",
+          "refresh": 2,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus",
+          "hide": 2,
+          "includeAll": true,
+          "label": "Docker Engine",
+          "multi": true,
+          "name": "engine",
+          "options": [],
+          "query": "label_values(engine_daemon_engine_info, instance)",
+          "refresh": 2,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "version": 1
+  }
+}

--- a/images/grafana/config/config-datasource-prometheus.js
+++ b/images/grafana/config/config-datasource-prometheus.js
@@ -1,0 +1,7 @@
+{
+    "name":"prometheus",
+    "type":"prometheus",
+    "url":"http://{{ .PROMETHEUS_HOST | default "prometheus" }}:{{ .PROMETHEUS_PORT | default "9090" }}",
+    "access":"{{ .PROMETHEUS_ACCESS | default "proxy" }}",
+    "isDefault":true
+}

--- a/images/grafana/docker-compose.test.yml
+++ b/images/grafana/docker-compose.test.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  prometheus:
+    extends:
+      file: docker-compose.yml
+      service: prometheus
+  grafana:
+    extends:
+      file: docker-compose.yml
+      service: grafana
+  sut:
+    image: appcelerator/sut
+    build: ./sut
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - grafana
+      - prometheus

--- a/images/grafana/docker-compose.yml
+++ b/images/grafana/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "2"
+services:
+
+  prometheus:
+    image: prom/prometheus:latest
+
+  grafana:
+    image: appcelerator/grafana-amp
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+     - "30000:3000"
+    environment:
+      GRAFANA_PASS: AxwayPassword*

--- a/images/grafana/sut/Dockerfile
+++ b/images/grafana/sut/Dockerfile
@@ -1,0 +1,4 @@
+From appcelerator/alpine:3.5.2
+RUN apk --update add docker@community
+COPY ./test.sh /bin
+CMD ["/bin/test.sh"]

--- a/images/grafana/sut/test.sh
+++ b/images/grafana/sut/test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+GRAFANA_HOST=${GRAFANA_HOST:-grafana}
+GRAFANA_USER=admin
+GRAFANA_PASS=AxwayPassword*
+
+echo -n "test grafana presence...   "
+i=0
+r=1
+while [[ $r -ne 0 ]]; do
+  nslookup grafana >/dev/null 2>&1
+  r=$?
+  if [[ $i -gt 40 ]]; then break; fi
+  ((i++))
+  sleep 1
+done
+if [[ $r -ne 0 ]]; then
+  echo
+  echo "failed"
+  nslookup grafana
+  exit 1
+fi
+printf "%-16s[OK]\n" "resolves(${i}s)"
+
+echo -n "test grafana api...        "
+i=0
+r=0
+while [[ $r -lt 1 ]]; do
+  ((i++))
+  sleep 1
+  r=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/admin/stats 2>/dev/null | jq -r '.user_count')
+  if [[ $i -gt 40 ]]; then break; fi
+done
+if [[ $r -lt 1 ]]; then
+  echo
+  echo "failed"
+  curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/admin/stats
+  ci=$(docker ps | grep /influxdb | awk '{print $1}')
+  echo "logs from influxdb $ci:"
+  docker logs $ci
+  cg=$(docker ps | grep /grafana | awk '{print $1}')
+  echo "logs from grafana $cg:"
+  docker logs $cg
+  exit 1
+fi
+printf "%-16s[OK]\n" " (${i}s)"
+
+echo -n "test grafana auth...       "
+org=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/org 2>/dev/null | jq -r '.name')
+r=$?
+if [[ $r -ne 0 || -z "$org" || "x$org" = "xnull" ]]; then
+  echo
+  echo "auth failed"
+  curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/org 2>/dev/null
+  exit 1
+fi
+printf "%-16s[OK]\n" "($org)"
+
+echo -n "test grafana datasource... "
+ds=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/datasources/name/prometheus 2>/dev/null | jq -r '.name')
+r=$?
+if [[ $r -ne 0 || "x$ds" != "xprometheus" ]]; then
+  echo
+  echo "failed to find datasource"
+  exit 1
+fi
+printf "%-16s[OK]\n" "($ds)"
+
+echo -n "test grafana dashboards... "
+n=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/search?query=Cluster%20Health 2>/dev/null | jq -r 'map(select(.type=="dash-db"))| length')
+r=$?
+if [[ $r -ne 0 || -z "$n" || "x$n" = "xnull" || $n -lt 1 ]]; then
+  echo
+  echo "failed to found dashboards"
+  exit 1
+fi
+printf "%-16s[OK]\n" "($n)"
+echo "all tests passed successfully"

--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -3,8 +3,8 @@ FROM appcelerator/alpine:3.5.2
 RUN apk --no-cache add nodejs
 
 # Kibana installation
-ENV KIBANA_MAJOR 5.3
-ENV KIBANA_VERSION 5.3.2
+ENV KIBANA_MAJOR 5.4
+ENV KIBANA_VERSION 5.4.0
 RUN curl -LO https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz \
     && mkdir /opt \
     && tar xzf /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz -C /opt \

--- a/images/nats/sut/Dockerfile
+++ b/images/nats/sut/Dockerfile
@@ -1,4 +1,4 @@
-From appcelerator/alpine:3.5.1
+From appcelerator/alpine:3.5.2
 ENV GOPATH          /go
 ENV GOBIN           /go/bin
 RUN apk update && apk upgrade && \

--- a/images/nats/sut/test.sh
+++ b/images/nats/sut/test.sh
@@ -62,8 +62,8 @@ if [[ $r -ne 0 ]]; then
   echo "failed ($i/$MAX msg sent)"
   exit 1
 fi
-echo " [OK]"
-
+echo "[OK]"
+sleep 10
 echo -n "receive messages... "
 n=$(egrep -c "Received on \[msg.test\].*:.*'test message .*'" $TMPFILE)
 if [[ $n -ne $MAX ]]; then

--- a/images/prometheus-nats-exporter/Dockerfile
+++ b/images/prometheus-nats-exporter/Dockerfile
@@ -1,0 +1,30 @@
+FROM appcelerator/alpine:3.5.2
+
+#ENV PROMETHEUS_NATS_EXPORTER_VERSION 1.0.0
+
+ENV GOLANG_VERSION 1.8.3
+ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
+ENV GOLANG_SRC_SHA256 5f5dea2447e7dcfdc50fa6b94c512e58bfba5673c039259fd843f68829d99fa6
+
+RUN apk update && apk upgrade && \
+    apk --virtual build-deps add openssl git gcc musl-dev make binutils patch go && \
+    export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
+    wget -q "$GOLANG_SRC_URL" -O golang.tar.gz && \
+    echo "$GOLANG_SRC_SHA256  golang.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local -xzf golang.tar.gz && \
+    rm golang.tar.gz && \
+    cd /usr/local/go/src && \
+    ./make.bash && \
+    export GOPATH=/go && \
+    export PATH=/usr/local/go/bin:$PATH && \
+    go version && \
+    go get -v github.com/nats-io/prometheus-nats-exporter && \
+    cd $GOPATH/src/github.com/nats-io/prometheus-nats-exporter && \
+    if [ $PROMETHEUS_NATS_EXPORTER_VERSION != "master" ]; then git checkout -q --detach "${PROMETHEUS_NATS_EXPORTER_VERSION}" ; fi && \
+    go build -o /prometheus-nats-exporter && \
+    apk del build-deps && \
+    cd / && rm -rf /var/cache/apk/* $GOPATH /usr/local/go
+
+EXPOSE 7777
+
+ENTRYPOINT ["/prometheus-nats-exporter"]

--- a/images/prometheus-nats-exporter/build
+++ b/images/prometheus-nats-exporter/build
@@ -1,0 +1,1 @@
+docker build -t appcelerator/prometheus-nats-exporter .

--- a/platform/bin/update-prometheus-configuration.sh
+++ b/platform/bin/update-prometheus-configuration.sh
@@ -9,7 +9,7 @@ ALERTMANAGER_DIR=/etc/alertmanager
 ALERTMANAGER_FILE=config.yml
 D4MIP="192.168.65.1"
 DOCKER_METRICS_PORT=9323
-TELEGRAF_METRICS_PORT=9126
+NODE_EXPORTER_METRICS_PORT=9100
 DRY_RUN=0
 
 manager_list(){
@@ -32,7 +32,6 @@ prepare_prometheus_conf(){
   local _remotes=$*
   local _remote
   local _docker_remotes
-  local _telegraf_remotes
 
   if [[ $# -eq 1 && "$_remotes" = "127.0.0.1" ]]; then
     # Docker for Mac/Windows: loopback address won't work, fix it
@@ -88,12 +87,12 @@ EOF
     echo "        - '${_remote}:$DOCKER_METRICS_PORT'" >> $prometheus_conf
   done
   cat >> $prometheus_conf << EOF
-  - job_name: 'system'
+  - job_name: 'nodes'
     static_configs:
       - targets:
 EOF
   for _remote in $_remotes; do
-    echo "        - '${_remote}:$TELEGRAF_METRICS_PORT'" >> $prometheus_conf
+    echo "        - '${_remote}:$NODE_EXPORTER_METRICS_PORT'" >> $prometheus_conf
   done
 }
 

--- a/platform/bin/update-prometheus-configuration.sh
+++ b/platform/bin/update-prometheus-configuration.sh
@@ -64,7 +64,8 @@ rule_files:
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets:
+        - localhost:9090
   - job_name: 'etcd'
     dns_sd_configs:
       - names:

--- a/platform/bin/update-prometheus-configuration.sh
+++ b/platform/bin/update-prometheus-configuration.sh
@@ -28,14 +28,6 @@ manager_list(){
   echo $_managers
 }
 
-get_telegraf_remotes(){
-  local _telegraf_service=telegraf
-  local _remotes
-  _remotes=$(dig +short tasks.$_telegraf_service)
-  [[ -n "$_remotes" ]] && echo $_remotes
-
-}
-
 prepare_prometheus_conf(){
   local _remotes=$*
   local _remote
@@ -74,6 +66,10 @@ scrape_configs:
 #  - job_name: 'prometheus'
 #    static_configs:
 #      - targets: ['localhost:9090']
+  - job_name: 'nats'
+    static_configs:
+      - targets:
+        - nats_exporter:7777
   - job_name: 'docker-engine'
     static_configs:
       - targets:
@@ -168,7 +164,7 @@ for node in $nodes; do
       break
     elif [[ -n "$remote" && "$remote" = "0.0.0.0" ]]; then
       # try the manager address instead
-      remote=$(docker -H $manager node inspect $node -f '{{.ManagerStatus.Addr}}' | cut -d: -f1) 
+      remote=$(docker -H $manager node inspect $node -f '{{.ManagerStatus.Addr}}' | cut -d: -f1)
       if [[ ${PIPESTATUS[0]} -ne 0 || "x$remote" = "x0.0.0.0" ]]; then
         echo "Failed to get IP of node $node, abort" >&2
         exit 1

--- a/platform/bin/update-prometheus-configuration.sh
+++ b/platform/bin/update-prometheus-configuration.sh
@@ -62,9 +62,9 @@ rule_files:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-#  - job_name: 'prometheus'
-#    static_configs:
-#      - targets: ['localhost:9090']
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
   - job_name: 'etcd'
     dns_sd_configs:
       - names:
@@ -79,6 +79,13 @@ scrape_configs:
     static_configs:
       - targets:
         - nats_exporter:7777
+  - job_name: 'elasticsearch'
+    metrics_path: "/_prometheus/metrics"
+    dns_sd_configs:
+      - names:
+        - 'tasks.elasticsearch'
+        type: 'A'
+        port: 9200
   - job_name: 'docker-engine'
     static_configs:
       - targets:

--- a/platform/bin/update-prometheus-configuration.sh
+++ b/platform/bin/update-prometheus-configuration.sh
@@ -66,6 +66,16 @@ scrape_configs:
 #  - job_name: 'prometheus'
 #    static_configs:
 #      - targets: ['localhost:9090']
+  - job_name: 'etcd'
+    dns_sd_configs:
+      - names:
+        - 'tasks.etcd'
+        type: 'A'
+        port: 2379
+  - job_name: 'haproxy'
+    static_configs:
+      - targets:
+        - haproxy_exporter:9101
   - job_name: 'nats'
     static_configs:
       - targets:

--- a/platform/bootstrap/aws-aws/config-cpu.tpl
+++ b/platform/bootstrap/aws-aws/config-cpu.tpl
@@ -37,7 +37,7 @@
                 "Properties": {
                   "Init": [
                     "#!/bin/bash",
-                    "apt-get install -y awscli jq sysstat iotop",
+                    "apt-get update && apt-get install -y awscli jq sysstat iotop",
                     "sysctl -w vm.max_map_count=262144",
                     "echo 'vm.max_map_count = 262144' > /etc/sysctl.d/99-amp.conf"
                   ]

--- a/platform/bootstrap/aws-aws/config-dat.tpl
+++ b/platform/bootstrap/aws-aws/config-dat.tpl
@@ -37,7 +37,7 @@
                 "Properties": {
                   "Init": [
                     "#!/bin/bash",
-                    "apt-get install -y awscli jq sysstat iotop",
+                    "apt-get update && apt-get install -y awscli jq sysstat iotop",
                     "sysctl -w vm.max_map_count=262144",
                     "echo 'vm.max_map_count = 262144' > /etc/sysctl.d/99-amp.conf"
                   ]

--- a/platform/bootstrap/aws-aws/config-gp.tpl
+++ b/platform/bootstrap/aws-aws/config-gp.tpl
@@ -37,7 +37,7 @@
                 "Properties": {
                   "Init": [
                     "#!/bin/bash",
-                    "apt-get install -y awscli jq sysstat iotop",
+                    "apt-get update && apt-get install -y awscli jq sysstat iotop",
                     "sysctl -w vm.max_map_count=262144",
                     "echo 'vm.max_map_count = 262144' > /etc/sysctl.d/99-amp.conf"
                   ]

--- a/platform/bootstrap/aws-aws/config-mem.tpl
+++ b/platform/bootstrap/aws-aws/config-mem.tpl
@@ -37,7 +37,7 @@
                 "Properties": {
                   "Init": [
                     "#!/bin/bash",
-                    "apt-get install -y awscli jq sysstat iotop",
+                    "apt-get update && apt-get install -y awscli jq sysstat iotop",
                     "sysctl -w vm.max_map_count=262144",
                     "echo 'vm.max_map_count = 262144' > /etc/sysctl.d/99-amp.conf"
                   ]

--- a/platform/bootstrap/aws-aws/config-monit.tpl
+++ b/platform/bootstrap/aws-aws/config-monit.tpl
@@ -37,7 +37,7 @@
                 "Properties": {
                   "Init": [
                     "#!/bin/bash",
-                    "apt-get install -y awscli jq sysstat iotop",
+                    "apt-get update && apt-get install -y awscli jq sysstat iotop",
                     "sysctl -w vm.max_map_count=262144",
                     "echo 'vm.max_map_count = 262144' > /etc/sysctl.d/99-amp.conf"
                   ]

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -54,29 +54,6 @@ _get_dirname() {
     echo $(cd "$_d"; pwd -P)
 }
 
-# expose the Docker remote api
-# and set the registry mirrors
-# only applies to non local deployments
-_expose_remote_api() {
-  local _registry_opt
-  mkdir -p /etc/systemd/system/docker.service.d
-  if [[ $# -gt 0 ]]; then
-    _registry_opt="--registry-mirror=http://$1:5000"
-    if [[ "$1" != "127.0.0.1" ]]; then
-      _registry_opt="$_registry_opt --insecure-registry=http://$1:5000"
-    fi
-  fi
-  cat > /etc/systemd/system/docker.service.d/docker.conf <<EOF
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:2375 -H unix:///var/run/docker.sock --experimental $_registry_opt
-EOF
-  # Restart Docker to let port listening take effect.
-  systemctl daemon-reload
-  systemctl restart docker.service
-}
-
-
 # prepare a Docker volume for the infrakit configuration
 # works even when the Docker host is not local (running from inside a container on the host)
 # args:

--- a/platform/bootstrap/bootstrap.yml
+++ b/platform/bootstrap/bootstrap.yml
@@ -6,12 +6,16 @@ Mappings:
     # Ubuntu 16.04 HVM
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
+      Debian: ami-0dcac96e
     eu-west-1:
       Ubuntu: ami-b5a893d3
+      Debian: ami-3291be54
     us-east-2:
       Ubuntu: ami-33ab8f56
+      Debian: ami-c5ba9fa0
     us-west-2:
       Ubuntu: ami-17ba2a77
+      Debian: ami-fde96b9d
   VpcCidrs:
     subnet1:
       cidr: 192.168.0.0/24
@@ -30,6 +34,7 @@ Metadata:
       Parameters:
       - KeyName
       - TrustedCidr
+      - LinuxDistribution
     - Label:
         default: Swarm Manager Properties
       Parameters:
@@ -78,6 +83,12 @@ Parameters:
       - 5
     Default: 3
     Description: Number of Swarm manager nodes (1, 3, 5).
+  LinuxDistribution:
+    Type: String
+    AllowedValues:
+    - Ubuntu
+    - Debian
+    Default: Ubuntu
   ManagerInstanceType:
     Type: String
     AllowedValues:
@@ -128,6 +139,9 @@ Parameters:
   TrustedCidr:
     Type: String
     Description: CIDR of a trusted origin
+  LinuxDistribution:
+    Type: String
+    Description: Linux Distribution
 
 Conditions:
   WithTrustedCidr:
@@ -521,7 +535,7 @@ Resources:
         Fn::FindInMap:
         - AMI
         - Ref: AWS::Region
-        - Ubuntu
+        - Ref: LinuxDistribution
       InstanceType: !Ref ManagerInstanceType
       KeyName: !Ref KeyName
       SecurityGroups:
@@ -546,6 +560,7 @@ Resources:
                 - awscli
                 - sysstat
                 - iotop
+                - xfsprogs
               write_files:
                 - path: /etc/infrakit.conf
                   content: |
@@ -568,7 +583,7 @@ Resources:
                 - curl -sf ${InfraKitConfigurationBaseURL}/userdata-aws -o /usr/local/bin/asg-init.sh
                 - chmod +x /usr/local/bin/asg-init.sh
                 - REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${InfraKitConfigurationBaseURL} MIRROR_REGISTRIES=${MirrorRegistries} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdn /usr/local/bin/asg-init.sh
-            - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
+            - { ami: !FindInMap [ AMI, !Ref "AWS::Region", !Ref LinuxDistribution ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -664,7 +679,7 @@ Outputs:
     Value: !Ref SecurityGroup
   AMI:
     Description: AMI
-    Value: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ]
+    Value: !FindInMap [ AMI, !Ref "AWS::Region", !Ref LinuxDistribution ]
   InstanceProfile:
     Description: IAM instance profile
     Value: !Ref ClusterInstanceProfile

--- a/platform/bootstrap/install-docker.sh
+++ b/platform/bootstrap/install-docker.sh
@@ -1,5 +1,9 @@
 _install_docker() {
+  local _release=$(lsb_release -is)
   wget -qO- https://get.docker.com/ | sh
-  grep -qw docker /etc/group && grep -qw ubuntu /etc/passwd && usermod -G docker ubuntu || true
+  if [[ $(grep -w docker /etc/group) ]]; then
+    [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu || true
+    [[ "x$_release" = "xDebian" ]] && usermod -G docker admin  || true
+  fi
   systemctl enable docker.service || true
 }

--- a/platform/bootstrap/manager-init.tpl
+++ b/platform/bootstrap/manager-init.tpl
@@ -13,7 +13,7 @@ set -o xtrace
 # or it's a non DinD Docker container and we can't easily install Docker
 if [ "x$provider" != "xdocker" ]; then
   _install_docker
-  systemctl stop docker.service
+  systemctl stop docker.service || service docker stop
 fi
 
 # Use an EBS volume for the devicemapper
@@ -30,7 +30,7 @@ cat << EOF > /etc/docker/daemon.json
 EOF
 
 if [ "x$provider" != "xdocker" ]; then
-  systemctl start docker.service
+  systemctl start docker.service || service docker start
   sleep 2
 fi
 

--- a/platform/bootstrap/userdata-aws
+++ b/platform/bootstrap/userdata-aws
@@ -11,29 +11,60 @@ OVERLAY_NETWORKS=${OVERLAY_NETWORKS:-ampnet}
 #MIRROR_REGISTRIES=
 #DOCKER_DEVICE=/dev/sdn
 SYSTEMD_DOCKER_OVERRIDE=/etc/systemd/system/docker.service.d/docker.conf
+SYSV_DOCKER_DEFAULT=/etc/default/docker
+
+_init_system(){
+  systemctl --version >/dev/null 2>&1 && echo systemd && return
+  [[ `/sbin/init --version` =~ upstart ]] && echo upstart && return
+  echo sysv
+}
 
 _install_docker(){
+  local _release=$(lsb_release -is)
   wget -qO- https://get.docker.com/ | sh || return 1
-  usermod -G docker ubuntu
-  systemctl enable docker.service
-  systemctl start docker.service
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin 
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl enable docker.service
+    systemctl start docker.service
+  else
+    chkconfig docker on
+    service docker start
+  fi
 }
 
 # expose the Docker remote api
 _expose_remote_api() {
-  mkdir -p "$(dirname $SYSTEMD_DOCKER_OVERRIDE)"
-  echo "exposing the engine API" >&2
-  cat > "$SYSTEMD_DOCKER_OVERRIDE" <<EOF
+  case $(_init_system) in
+  systemd)
+    mkdir -p "$(dirname $SYSTEMD_DOCKER_OVERRIDE)"
+    echo "exposing the engine API" >&2
+    cat > "$SYSTEMD_DOCKER_OVERRIDE" <<EOF
 [Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:2375 -H unix:///var/run/docker.sock
 EOF
-  systemctl daemon-reload
+    systemctl daemon-reload
+  ;;
+  sysv)
+    cat >> "$SYSV_DOCKER_DEFAULT" <<EOF
+DOCKER_OPTS='-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock'
+EOF
+  ;;
+  *)
+    echo "not implemented" >&2
+    return 1
+  ;;
+  esac
 }
 
 _restart_docker(){
   echo "restarting Docker" >&2
-  systemctl restart docker.service
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl restart docker.service
+  else
+    service docker restart
+  fi
 }
 
 _sanity_check(){

--- a/platform/bootstrap/worker-init.tpl
+++ b/platform/bootstrap/worker-init.tpl
@@ -13,7 +13,7 @@ set -o xtrace
 # or it's a non DinD Docker container and we can't easily install Docker
 if [ "x$provider" != "xdocker" ]; then
   _install_docker
-  systemctl stop docker.service
+  systemctl stop docker.service || service docker stop
 fi
 # Use an EBS volume for the devicemapper
 if [ "x$provider" = "xaws" ]; then
@@ -42,7 +42,7 @@ cat << EOF > /etc/docker/daemon.json
 EOF
 
 if [ "x$provider" != "xdocker" ]; then
-  systemctl start docker.service
+  systemctl start docker.service || service docker start
   sleep 2
 else
   # TODO: send kill -HUP to reload the labels, see appcelerator/amp#1123

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.1"
 
 networks:
   default:

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -27,7 +27,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.3.8
+    image: appcelerator/amp-nats-streaming:v0.4.0
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.3.2
+    image: appcelerator/elasticsearch-amp:5.4.0
     networks:
       - default
     labels:

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -5,12 +5,18 @@ networks:
     external:
       name: ampnet
 
+volumes:
+  elasticsearch-data:
+  etcd-data:
+
 services:
 
   elasticsearch:
     image: appcelerator/elasticsearch-amp:5.4.0
     networks:
       - default
+    volumes:
+      - elasticsearch-data:/opt/elasticsearch-5.4.0/data
     labels:
       io.amp.role: "infrastructure"
     environment:
@@ -49,6 +55,8 @@ services:
       default:
         aliases:
           - etcd
+    volumes:
+      - etcd-data:/data
     environment:
       SERVICE_NAME: "etcd"
       MIN_SEEDS_COUNT: 3

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -44,7 +44,7 @@ services:
         - node.labels.amp.type.mq == true
 
   etcd:
-    image: appcelerator/etcd:3.1.6
+    image: appcelerator/etcd:3.1.8
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.1"
 
 networks:
   default:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -25,7 +25,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.3.8
+    image: appcelerator/amp-nats-streaming:v0.4.0
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -5,12 +5,18 @@ networks:
     external:
       name: ampnet
 
+volumes:
+  elasticsearch-data:
+  etcd-data:
+
 services:
 
   elasticsearch:
     image: appcelerator/elasticsearch-amp:5.4.0
     networks:
       - default
+    volumes:
+      - elasticsearch-data:/opt/elasticsearch-5.4.0/data
     labels:
       io.amp.role: "infrastructure"
     environment:
@@ -47,6 +53,8 @@ services:
       default:
         aliases:
           - etcd
+    volumes:
+      - etcd-data:/data
     environment:
       SERVICE_NAME: "etcd"
       MIN_SEEDS_COUNT: 1

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -42,7 +42,7 @@ services:
         - node.labels.amp.type.mq == true
 
   etcd:
-    image: appcelerator/etcd:3.1.6
+    image: appcelerator/etcd:3.1.8
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.3.2
+    image: appcelerator/elasticsearch-amp:5.4.0
     networks:
       - default
     labels:

--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -44,7 +44,7 @@ services:
     environment:
       ELASTICSEARCH_URL: "http://elasticsearch:9200"
       SERVICE_PORTS: 5601
-      VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
+      VIRTUAL_HOST: "http://kibana.*,https://kibana.*"
       FORCE_SSL: 1
     ports:
       - "50106:5601"

--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -25,7 +25,7 @@ services:
       io.amp.role: "infrastructure"
 
   kibana:
-    image: appcelerator/kibana:5.3.1
+    image: appcelerator/kibana:5.4.0
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon.3.stack.yml
+++ b/platform/stacks/ampmon.3.stack.yml
@@ -90,3 +90,18 @@ services:
       mode: global
       labels:
         io.amp.role: "infrastructure"
+
+  nats_exporter:
+    image: appcelerator/prometheus-nats-exporter:latest
+    command: ["-varz", "-routez", "-connz", "-subz", "nats,http://nats:8222"]
+    #ports:
+      #- target: 7777
+      #- published: 7777
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true

--- a/platform/stacks/ampmon.3.stack.yml
+++ b/platform/stacks/ampmon.3.stack.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.1"
 
 networks:
   default:
@@ -27,8 +27,7 @@ services:
     volumes:
       - alertmanager-data:/alertmanager
     ports:
-      - target: 9093
-        published: 9093
+      - "9093:9093"
     deploy:
       mode: replicated
       replicas: 1
@@ -54,8 +53,7 @@ services:
     volumes:
       - prometheus-data:/prometheus
     ports:
-      - target: 9090
-        published: 9090
+      - "9090:9090"
     deploy:
       mode: replicated
       replicas: 1
@@ -83,8 +81,7 @@ services:
       - /sys:/host/sys
       - /:/rootfs
     ports:
-      - target: 9100
-        published: 9100
+      - "9100:9100"
     command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
     deploy:
       mode: global

--- a/platform/stacks/ampmon.3.stack.yml
+++ b/platform/stacks/ampmon.3.stack.yml
@@ -8,6 +8,7 @@ networks:
 volumes:
   prometheus-data:
   alertmanager-data:
+  grafana-data:
 
 secrets:
   prometheus_alerts_rules:
@@ -115,6 +116,26 @@ services:
     #ports:
       #- target: 9101
       #- published: 9101
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+
+  grafana:
+    image: appcelerator/grafana-amp:1.2.0
+    networks:
+      default:
+        aliases:
+          - grafana
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      SERVICE_PORTS: 3000
+      VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
     deploy:
       mode: replicated
       replicas: 1

--- a/platform/stacks/ampmon.3.stack.yml
+++ b/platform/stacks/ampmon.3.stack.yml
@@ -105,3 +105,22 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.metrics == true
+
+  haproxy_exporter:
+    image: prom/haproxy-exporter:latest
+    command: ["-haproxy.scrape-uri", "http://stats:stats@proxy:1936/haproxy?stats;csv"]
+    networks:
+      default:
+        aliases:
+          - haproxy_exporter
+    #ports:
+      #- target: 9101
+      #- published: 9101
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true

--- a/platform/stacks/ampmon.3.stack.yml
+++ b/platform/stacks/ampmon.3.stack.yml
@@ -75,17 +75,16 @@ services:
       "-web.external-url=http://localhost:9090",
       "-alertmanager.url=http://alertmanager:9093" ]
 
-  telegraf:
-    image: appcelerator/telegraf:telegraf-1.2.1-1
+  node_exporter:
+    image: prom/node-exporter:latest
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/utmp:/var/run/utmp:ro
+      - /proc:/host/proc
+      - /sys:/host/sys
+      - /:/rootfs
     ports:
-      - target: 9126
-        published: 9126
-    environment:
-      OUTPUT_INFLUXDB_ENABLED: "false"
-      OUTPUT_PROMETHEUS_ENABLED: "true"
+      - target: 9100
+        published: 9100
+    command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
     deploy:
       mode: global
       labels:


### PR DESCRIPTION
Close #1266 

To be merged after #1265 and #1274 

- update nats streaming server to 0.4.0
- add nats metrics
- update etcd to 3.1.8
- add etcd metrics
- update elasticsearch and kibana to 5.4.0
- add elasticsearch metrics
- add haproxy metrics
- system metrics with node_exporter instead of telegraf
- Grafana dashboards for these metrics. Grafana is available through a ssh tunnel on port 3000
- sample alert definitions in examples/monitoring. Should be placed in platform/secrets/ before a deployment
- deployment on AWS can be done on Ubuntu Xenial or Debian Jessie
- persistence for etcd and elasticsearch (now that we only have one single container per node with #1121)

![image](https://cloud.githubusercontent.com/assets/11839374/26702729/389ead84-46db-11e7-9812-64b69dd8cbf9.png)
![image](https://cloud.githubusercontent.com/assets/11839374/26702780/64a87e3c-46db-11e7-8098-2cec34bb3694.png)

