### PR TITLE
Fix SignUp issue

### DIFF
--- a/data/accounts/interface.go
+++ b/data/accounts/interface.go
@@ -58,6 +58,9 @@ type Interface interface {
 	// VerifyUser verifies a user account
 	VerifyUser(ctx context.Context, name string) (err error)
 
+	// DeleteNotVerifedUser deletes a not verified user by-passing the authorization check
+	DeleteNotVerifiedUser(ctx context.Context, name string) (err error)
+
 	// DeleteUser deletes a user by name
 	DeleteUser(ctx context.Context, name string) (err error)
 

--- a/data/accounts/store.go
+++ b/data/accounts/store.go
@@ -344,8 +344,25 @@ func (s *Store) ListUsers(ctx context.Context) ([]*User, error) {
 	return users, nil
 }
 
+// DeleteNotVerifiedUser deletes the user by name only if it's not verified
+func (s *Store) DeleteNotVerifiedUser(ctx context.Context, name string) error {
+
+	//Get user to verify it is well not verified
+	user, err := s.GetUser(ctx, name)
+	if err != nil {
+		return err
+	}
+	if user != nil && !user.IsVerified {
+		if err := s.storage.Delete(ctx, path.Join(usersRootKey, name), false, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteUser deletes a user by name
 func (s *Store) DeleteUser(ctx context.Context, name string) error {
+
 	// Check authorization
 	if !s.IsAuthorized(ctx, &Account{AccountType_USER, name}, DeleteAction, UserRN, name) {
 		return NotAuthorized


### PR DESCRIPTION
Closes #1291 

Fix the SignUp error which didn't delete the user when internal error happened (as email not working) 

# test

- Do not install the SendGrid key 
- amp -s localhost cluster create -t local --registration=email --notifications=true
- amp -s localhost user signUp -> error SendGrid API key is empty
- amp -s localhost user signUp -> error SendGrid API key is empty

needed to signup two times, in order to verify the user as well been deleted at the first signUp error