### PR TITLE
filter services based on stack name

### DIFF
--- a/api/rpc/service/service.go
+++ b/api/rpc/service/service.go
@@ -57,7 +57,7 @@ func (s *Server) Tasks(ctx context.Context, in *TasksRequest) (*TasksReply, erro
 
 // ListService implements service.ListService
 func (s *Server) ListService(ctx context.Context, in *ServiceListRequest) (*ServiceListReply, error) {
-	log.Println("[service] List")
+	log.Println("[service] List ", in.StackName)
 	serviceList, err := s.Docker.ServicesList(ctx, types.ServiceListOptions{})
 	if err != nil {
 		return nil, grpc.Errorf(codes.Internal, "%v", err)
@@ -100,7 +100,7 @@ func (s *Server) ListService(ctx context.Context, in *ServiceListRequest) (*Serv
 }
 
 func (s *Server) serviceStatusReplicas(ctx context.Context, service *ServiceEntity) (*ServiceListEntry, error) {
-	statusReplicas, err := s.Docker.ServiceState(ctx, service.Id)
+	statusReplicas, err := s.Docker.ServiceStatus(ctx, service.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -13,6 +13,7 @@ import (
 
 type listServiceOptions struct {
 	quiet bool
+	stack string
 }
 
 // NewServiceListCommand returns a new instance of the service list command.
@@ -27,14 +28,18 @@ func NewServiceListCommand(c cli.Interface) *cobra.Command {
 			return listServices(c, opts)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Only display team names")
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display team names")
+	flags.StringVar(&opts.stack, "stack", "", "Filter services based on stack name")
 	return cmd
 }
 
 func listServices(c cli.Interface, opts listServiceOptions) error {
 	conn := c.ClientConn()
 	client := service.NewServiceClient(conn)
-	request := &service.ServiceListRequest{}
+	request := &service.ServiceListRequest{
+		StackName: opts.stack,
+	}
 	reply, err := client.ListService(context.Background(), request)
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -16,7 +16,7 @@ type logsServiceOptions struct {
 	follow bool
 }
 
-// NewServiceLogsCommand returns a new instance of the stack command.
+// NewServiceLogsCommand returns a new instance of the service logs command.
 func NewServiceLogsCommand(c cli.Interface) *cobra.Command {
 	opts := logsServiceOptions{}
 	cmd := &cobra.Command{

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -334,25 +334,6 @@ func (d *Docker) serviceIDs(ctx context.Context, stackName string) ([]string, er
 	return serviceIDs, nil
 }
 
-// ServiceStatus returns service status
-func (d *Docker) ServiceStatus(ctx context.Context, service string) (string, error) {
-	readyTasks, err := d.readyTasks(ctx, service)
-	if err != nil {
-		return "", err
-	}
-	expectedTasks, err := d.ExpectedNumberOfTasks(ctx, service)
-	if err != nil {
-		return "", err
-	}
-	if readyTasks == NoMatchingNodes {
-		return StackStateNoMatchingNode, nil
-	}
-	if readyTasks == expectedTasks {
-		return StackStateRunning, nil
-	}
-	return StackStateStarting, nil
-}
-
 // StackStatus returns stack status
 func (d *Docker) StackStatus(ctx context.Context, stackName string) (*StackStatus, error) {
 	var readyServices int32 = 0
@@ -366,7 +347,7 @@ func (d *Docker) StackStatus(ctx context.Context, stackName string) (*StackStatu
 		if err != nil {
 			return nil, err
 		}
-		if status == StackStateRunning {
+		if status.Status == StackStateRunning {
 			readyServices++
 		}
 	}
@@ -533,8 +514,8 @@ func (d *Docker) readyTasks(ctx context.Context, service string) (int, error) {
 	return readyTasks, nil
 }
 
-// ServiceState returns service status
-func (d *Docker) ServiceState(ctx context.Context, service string) (*ServiceStatus, error) {
+// ServiceStatus returns service status
+func (d *Docker) ServiceStatus(ctx context.Context, service string) (*ServiceStatus, error) {
 	readyTasks, err := d.readyTasks(ctx, service)
 	if err != nil {
 		return &ServiceStatus{}, err

--- a/platform/tests/service/list-stack/list_based_on_stack_test.sh
+++ b/platform/tests/service/list-stack/list_based_on_stack_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+test_setup() {
+  amp="amp -s localhost"
+  $amp user signup --name user106 --password password --email email@user106.amp
+  $amp login --name user106 --password password
+}
+
+test_stack_deploy() {
+   $amp stack up -c examples/stacks/pinger/pinger.yml
+   $amp stack up -c examples/stacks/counter/counter.yml
+ }
+
+test_service_list_based_on_stack() {
+  $amp service ls --stack pinger | grep -Evq "counter"
+}
+
+test_teardown() {
+  $amp stack rm pinger
+  $amp stack rm counter
+  $amp user rm user106
+}


### PR DESCRIPTION
Resolves #1343 

Services can now be filtered based on stack name 

Tests are in `platform/tests/service/list-stack`