### PR TITLE
travis cluster rm now uses --tag=local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ script:
   - set -e
   - ampmake clean build-base build-cli
   - ls -la bin/linux/amd64
-  - amp --server=localhost cluster create --tag=local --registration=none --notifications=false
+  - amp --server=localhost cluster create --tag=local
   - TESTINCLUDE=platform/testing testrunner platform/tests
   - docker build -t appcelerator/amp-integration .
   - docker service create --detach=false --restart-condition=none --network ampnet --name integration appcelerator/amp-integration
   - docker logs -f $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}")
   - $(exit $(docker inspect $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}") --format "{{.State.ExitCode}}"))
-  - amp --server localhost cluster rm
+  - amp --server=localhost cluster rm --tag=local
   #- ampmake lint
 
 after_success:


### PR DESCRIPTION
fixes: #1349 

the `amp cluster rm` call in `.travis.yml` now uses `--tag=local`