### PR TITLE
Using docker 17.03.1 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: bash
 install:
   - sudo sysctl -w vm.max_map_count=262144
   - sudo apt-get update
-  - sudo apt-get install docker-engine
+  - sudo apt-get install docker-engine=17.03.1~ce-0~ubuntu-trusty
   - sudo apt-get install pcregrep
   - sudo modprobe ip_vs ip_vs_rr
   - sudo mkdir -p $HOME/.config/amp

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cleanall: clean cleanall-deps
 DOCKER_CMD ?= "docker"
 
 build-base: install-deps protoc build-server build-gateway build-beat build-agent build-bootstrap build-monit
-build: build-base buildall-cli
+build: build-base build-cli
 
 # =============================================================================
 # BUILD CLI (`amp`)


### PR DESCRIPTION
Related to #1354 

Using the stable version of docker (17.03.1) for travis builds.

## How to test
Make sure the travis build completes successfully.
