### PR TITLE
elastic 5.4.1

### DIFF
--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ FROM appcelerator/alpine:3.6.0
 RUN apk update && apk upgrade && apk --no-cache add openjdk8-jre bind-tools
 
 ENV PATH /bin:/opt/elasticsearch/bin:$PATH
-ENV ELASTIC_VERSION 5.4.0
+ENV ELASTIC_VERSION 5.4.1
 
 RUN curl -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTIC_VERSION.tar.gz -o /tmp/elasticsearch-$ELASTIC_VERSION.tar.gz && \
     mkdir /opt && \
@@ -19,7 +19,7 @@ COPY config/elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml.tpl
 COPY config/log4j2.properties /opt/elasticsearch/config/
 COPY /bin/docker-entrypoint.sh /bin/
 
-RUN /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.4.0.0.zip
+RUN /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.4.1.0.zip
 
 RUN mkdir -p /opt/elasticsearch/config/scripts
 RUN adduser -D -h /opt/elasticsearch -s /sbin/nologin elastico

--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -1,10 +1,10 @@
-FROM appcelerator/alpine:3.5.2
+FROM appcelerator/alpine:3.6.0
 
 RUN apk --no-cache add nodejs
 
 # Kibana installation
 ENV KIBANA_MAJOR 5.4
-ENV KIBANA_VERSION 5.4.0
+ENV KIBANA_VERSION 5.4.1
 RUN curl -LO https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz \
     && mkdir /opt \
     && tar xzf /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz -C /opt \

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -12,11 +12,11 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.4.0-1
+    image: appcelerator/elasticsearch-amp:5.4.1
     networks:
       - default
     volumes:
-      - elasticsearch-data:/opt/elasticsearch-5.4.0/data
+      - elasticsearch-data:/opt/elasticsearch-5.4.1/data
     labels:
       io.amp.role: "infrastructure"
     environment:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -12,11 +12,11 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.4.0-1
+    image: appcelerator/elasticsearch-amp:5.4.1
     networks:
       - default
     volumes:
-      - elasticsearch-data:/opt/elasticsearch-5.4.0/data
+      - elasticsearch-data:/opt/elasticsearch-5.4.1/data
     labels:
       io.amp.role: "infrastructure"
     environment:

--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -25,7 +25,7 @@ services:
       io.amp.role: "infrastructure"
 
   kibana:
-    image: appcelerator/kibana:5.4.0
+    image: appcelerator/kibana:5.4.1
     networks:
       default:
         aliases:


### PR DESCRIPTION
- upgrade Elasticsearch, Elasticsearch prometheus exporter and Kibana to 5.4.1
- Kibana image now based on Alpine 3.6