### PR TITLE
Using service for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,10 @@ script:
   - ls -la bin/linux/amd64
   - amp --server=localhost cluster create --tag=local --registration=none --notifications=false
   - TESTINCLUDE=platform/testing testrunner platform/tests
-  - docker run --rm --network ampnet -v $PWD:/go/src/github.com/appcelerator/amp -w /go/src/github.com/appcelerator/amp appcelerator/amptools go test github.com/appcelerator/amp/tests/integration/...
+  - docker build -t appcelerator/amp-integration .
+  - docker service create --detach=false --restart-condition=none --network ampnet --name integration appcelerator/amp-integration
+  - docker logs -f $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}")
+  - $(exit $(docker inspect $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}") --format "{{.State.ExitCode}}"))
   - amp --server localhost cluster rm
   #- ampmake lint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM appcelerator/amptools
+
+COPY . /go/src/github.com/appcelerator/amp
+WORKDIR /go/src/github.com/appcelerator/amp
+
+CMD ["go", "test", "github.com/appcelerator/amp/tests/integration/..."]

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cleanall: clean cleanall-deps
 DOCKER_CMD ?= "docker"
 
 build-base: install-deps protoc build-server build-gateway build-beat build-agent build-bootstrap build-monit
-build: build-base buildall-cli
+build: build-base build-cli
 
 # =============================================================================
 # BUILD CLI (`amp`)


### PR DESCRIPTION
Resolves #1359 

Using a docker service instead of a docker container to run integration tests.

## How to test
Make sure the travis build passes.
 