### PR TITLE
Skip cross compilation on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script:
   - set -e
-  - ampmake clean build
+  - ampmake clean build-base build-cli
   - ls -la bin/linux/amd64
   - amp --server=localhost cluster create --tag=local --registration=none --notifications=false
   - TESTINCLUDE=platform/testing testrunner platform/tests

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cleanall: clean cleanall-deps
 DOCKER_CMD ?= "docker"
 
 build-base: install-deps protoc build-server build-gateway build-beat build-agent build-bootstrap build-monit
-build: build-base build-cli
+build: build-base buildall-cli
 
 # =============================================================================
 # BUILD CLI (`amp`)


### PR DESCRIPTION
Restore the initial `Makefile` target and configure travis to build only compile target OS CLI.

## How to test
Make sure the build is passing on travis.
