### PR TITLE
Disable some user and password cmds when `--registration=none`

### DIFF
--- a/cli/command/password/reset.go
+++ b/cli/command/password/reset.go
@@ -1,10 +1,13 @@
 package password
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/appcelerator/amp/api/rpc/account"
+	"github.com/appcelerator/amp/api/rpc/version"
 	"github.com/appcelerator/amp/cli"
+	"github.com/appcelerator/amp/cmd/amplifier/server/configuration"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -24,6 +27,16 @@ func NewResetCommand(c cli.Interface) *cobra.Command {
 
 func reset(c cli.Interface, args []string) error {
 	conn := c.ClientConn()
+	clientVer := version.NewVersionClient(conn)
+	requestVer := &version.GetRequest{}
+	reply, err := clientVer.Get(context.Background(), requestVer)
+	if err != nil {
+		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	if reply.Info.Registration == configuration.RegistrationNone {
+		return errors.New("`amp password reset` disabled. This cluster has no registration policy")
+	}
+
 	client := account.NewAccountClient(conn)
 	request := &account.PasswordResetRequest{
 		Name: args[0],


### PR DESCRIPTION
resolves: #1232 

Merge after #1352 

Disables the following cmds when `--registration=none`
```
amp user verify
amp user forgot-login
amp password reset
amp password set
```