### PR TITLE
Set default portal tag to latest

### DIFF
--- a/platform/stacks/portal.stack.yml
+++ b/platform/stacks/portal.stack.yml
@@ -9,7 +9,7 @@ networks:
 services:
 
   portal:
-    image: appcelerator/portal:${TAG:-0.11.0}
+    image: appcelerator/portal:latest
     networks:
       - default
     deploy:


### PR DESCRIPTION
Considering we moved portal in a separated repository, we can't anymore use the tag 
${TAG:-0.11.0}  for portal, because the portal image is not build in amp build and so the tag local does't exist (when local build the TAG=local)
Move to tag 'latest'.
Versionning of portal to be managed in future pr