### PR TITLE
Fix stats memory % issue

### DIFF
--- a/cli/command/stats/stats.go
+++ b/cli/command/stats/stats.go
@@ -203,7 +203,7 @@ func getOneStatLine(query *stats.StatsRequest, entry *stats.MetricsEntry) string
 		line = fmt.Sprintf("%s\t%.2f%%", line, entry.Cpu.TotalUsage)
 	}
 	if query.StatsMem {
-		line = fmt.Sprintf("%s\t%s\t%s\t%.1f%%", line, formatBytes(entry.Mem.Usage), formatBytes(entry.Mem.Limit), entry.Mem.UsageP)
+		line = fmt.Sprintf("%s\t%s\t%s\t%.1f%%", line, formatBytes(entry.Mem.Usage), formatBytes(entry.Mem.Limit), entry.Mem.UsageP*100)
 	}
 	if query.StatsIo {
 		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Io.Read), formatBytes(entry.Io.Write))


### PR DESCRIPTION
Closes #1374

Fix stats command display issue

# test

- make build-cli
- amp -s localhost login
- amp -s localhost stats -i -> see correct values for memory usage %