### PR TITLE
Initial commit of aws plugin

### DIFF
--- a/cluster/plugin/aws/Dockerfile
+++ b/cluster/plugin/aws/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk add --no-cache ca-certificates
+COPY aws.alpine /usr/local/bin/aws
+ENTRYPOINT [ "aws" ]

--- a/cluster/plugin/aws/Dockerfile.compiler
+++ b/cluster/plugin/aws/Dockerfile.compiler
@@ -1,0 +1,6 @@
+FROM golang:1.8-alpine
+RUN apk add --no-cache git
+RUN go get -u github.com/aws/aws-sdk-go/...
+RUN go get -u github.com/spf13/cobra/cobra
+
+

--- a/cluster/plugin/aws/Dockerfile.compiler
+++ b/cluster/plugin/aws/Dockerfile.compiler
@@ -1,6 +1,7 @@
 FROM golang:1.8-alpine
+
 RUN apk add --no-cache git
 RUN go get -u github.com/aws/aws-sdk-go/...
 RUN go get -u github.com/spf13/cobra/cobra
 
-
+ENTRYPOINT [ "go" ]

--- a/cluster/plugin/aws/Dockerfile.compiler
+++ b/cluster/plugin/aws/Dockerfile.compiler
@@ -3,5 +3,6 @@ FROM golang:1.8-alpine
 RUN apk add --no-cache git
 RUN go get -u github.com/aws/aws-sdk-go/...
 RUN go get -u github.com/spf13/cobra/cobra
+RUN go get -u github.com/satori/go.uuid
 
 ENTRYPOINT [ "go" ]

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -1,0 +1,17 @@
+
+build: aws.alpine
+	docker build -t appcelerator/amp-aws-plugin .
+
+aws.alpine: main.go
+	docker run -it --rm -v $${PWD}:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+		awssdk go build -o aws.alpine .
+
+.PHONY: compiler
+compiler:
+	docker build -f Dockerfile.compiler -t awssdk .
+
+.PHONY: clean
+clean:
+	rm -f aws.alpine
+

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -6,13 +6,23 @@ build: aws.alpine
 aws.alpine: $(SRC)
 	docker run -it --rm -v $${PWD}:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
-		awssdk go build -o aws.alpine cmd/main.go
+		go:aws build -o aws.alpine cmd/main.go
 
 .PHONY: compiler
 compiler:
-	docker build -f Dockerfile.compiler -t awssdk .
+	docker build -f Dockerfile.compiler -t go:aws .
 
 .PHONY: clean
 clean:
 	rm -f aws.alpine
+
+.PHONY: test
+test:
+	@echo $(KEYPAIR)
+	@echo $(REGION)
+	docker run -it --rm -v $(HOME)/.aws:/root/.aws -v $(PWD):/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+		-e KEYPAIR=$(KEYPAIR) \
+		-e REGION=$(REGION) \
+		go:aws test
 

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -1,11 +1,12 @@
+SRC := $(shell find . -type f -name '*.go')
 
 build: aws.alpine
 	docker build -t appcelerator/amp-aws-plugin .
 
-aws.alpine: main.go
+aws.alpine: $(SRC)
 	docker run -it --rm -v $${PWD}:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
-		awssdk go build -o aws.alpine .
+		awssdk go build -o aws.alpine cmd/main.go
 
 .PHONY: compiler
 compiler:

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -22,5 +22,5 @@ test:
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-e KEYNAME=$(KEYNAME) \
 		-e REGION=$(REGION) \
-		go:aws test
+		go:aws test -timeout 30m
 

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -22,5 +22,5 @@ test:
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-e KEYNAME=$(KEYNAME) \
 		-e REGION=$(REGION) \
-		go:aws test -timeout 30m
+		go:aws test -v -timeout 30m
 

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -18,11 +18,9 @@ clean:
 
 .PHONY: test
 test:
-	@echo $(KEYPAIR)
-	@echo $(REGION)
 	docker run -it --rm -v $(HOME)/.aws:/root/.aws -v $(PWD):/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
-		-e KEYPAIR=$(KEYPAIR) \
+		-e KEYNAME=$(KEYNAME) \
 		-e REGION=$(REGION) \
 		go:aws test
 

--- a/cluster/plugin/aws/README.md
+++ b/cluster/plugin/aws/README.md
@@ -1,0 +1,13 @@
+# AWS Plugin
+
+This is the plugin for creating and initializing an AWS cluster.
+
+`Dockerfile.compiler` builds the image for compiling the Go source files for
+the plugin.
+
+`Dockerfile` builds the image for the actual plugin that will be used by the
+AMP cli.
+
+For more details about the design and use, see the
+[wiki](https://github.com/appcelerator/amp/wiki/AWS-Clusters).
+

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -18,6 +18,7 @@ const (
 var (
 	stackSpec = &plugin.StackSpec{
 		OnFailure: "ROLLBACK",
+		Params: []string{},
 	}
 )
 
@@ -27,10 +28,6 @@ func provision(cmd *cobra.Command, args []string) {
 	// Create the service's client with the session.
 	svc := cf.New(sess,
 		aws.NewConfig().WithRegion(stackSpec.Region).WithLogLevel(aws.LogOff))
-
-	stackSpec.Params = []*cf.Parameter{
-		{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(stackSpec.KeyPair)},
-	}
 
 	resp, err := plugin.CreateStack(svc, stackSpec, 20)
 	if err != nil {
@@ -53,9 +50,9 @@ func main() {
 		Use:   "awsplugin",
 		Short: "init/update/destroy an AWS cluster in Docker swarm mode",
 	}
-	rootCmd.PersistentFlags().StringVarP(&stackSpec.KeyPair, "keypair", "k", "", "aws keypair name")
-	rootCmd.PersistentFlags().StringVarP(&stackSpec.StackName, "stackname", "n", "", "aws stack name")
 	rootCmd.PersistentFlags().StringVarP(&stackSpec.Region, "region", "r", "", "aws region")
+	rootCmd.PersistentFlags().StringVarP(&stackSpec.StackName, "stackname", "n", "", "aws stack name")
+	rootCmd.PersistentFlags().StringSliceVarP(&stackSpec.Params, "parameter", "p", []string{}, "parameter")
 
 	initCmd := &cobra.Command{
 		Use:   "init",

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -5,6 +5,7 @@ import (
 
 	plugin "github.com/appcelerator/amp/cluster/plugin/aws"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/spf13/cobra"
@@ -31,9 +32,12 @@ func provision(cmd *cobra.Command, args []string) {
 		{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(stackSpec.KeyPair)},
 	}
 
-	plugin.CreateStack(svc, stackSpec, 20)
+	resp, err := plugin.CreateStack(svc, stackSpec, 20)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	log.Println(svc.APIVersion)
+	log.Println(awsutil.StringValue(resp))
 }
 
 func update(cmd *cobra.Command, args []string) {

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -45,6 +45,16 @@ func provision(cmd *cobra.Command, args []string) {
 	}
 
 	log.Println(awsutil.StringValue(resp))
+
+	input := &cf.DescribeStacksInput{
+		StackName: aws.String(opts.StackName),
+	}
+	if opts.Sync {
+		if err := svc.WaitUntilStackCreateCompleteWithContext(ctx, input); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("stack created: %s\n", opts.StackName)
+	}
 }
 
 func update(cmd *cobra.Command, args []string) {
@@ -59,6 +69,16 @@ func destroy(cmd *cobra.Command, args []string) {
 	}
 
 	log.Println(awsutil.StringValue(resp))
+
+	input := &cf.DescribeStacksInput{
+		StackName: aws.String(opts.StackName),
+	}
+	if opts.Sync {
+		if err := svc.WaitUntilStackDeleteCompleteWithContext(ctx, input); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("stack deleted: %s\n", opts.StackName)
+	}
 }
 
 func main() {
@@ -70,6 +90,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&opts.Region, "region", "r", "", "aws region")
 	rootCmd.PersistentFlags().StringVarP(&opts.StackName, "stackname", "n", "", "aws stack name")
 	rootCmd.PersistentFlags().StringSliceVarP(&opts.Params, "parameter", "p", []string{}, "parameter")
+	rootCmd.PersistentFlags().BoolVarP(&opts.Sync, "sync", "s", false, "block until operation is complete")
 
 	initCmd := &cobra.Command{
 		Use:   "init",

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -58,7 +58,23 @@ func provision(cmd *cobra.Command, args []string) {
 }
 
 func update(cmd *cobra.Command, args []string) {
-	log.Println("update command not implemented yet")
+	ctx := context.Background()
+	resp, err := plugin.UpdateStack(ctx, svc, opts, 20)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(awsutil.StringValue(resp))
+
+	input := &cf.DescribeStacksInput{
+		StackName: aws.String(opts.StackName),
+	}
+	if opts.Sync {
+		if err := svc.WaitUntilStackUpdateCompleteWithContext(ctx, input); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("stack created: %s\n", opts.StackName)
+	}
 }
 
 func destroy(cmd *cobra.Command, args []string) {

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -59,7 +59,7 @@ func provision(cmd *cobra.Command, args []string) {
 
 func update(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	resp, err := plugin.UpdateStack(ctx, svc, opts, 20)
+	resp, err := plugin.UpdateStack(ctx, svc, opts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func update(cmd *cobra.Command, args []string) {
 		if err := svc.WaitUntilStackUpdateCompleteWithContext(ctx, input); err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("stack created: %s\n", opts.StackName)
+		log.Printf("stack updated: %s\n", opts.StackName)
 	}
 }
 

--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/session"
+	cf "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/spf13/cobra"
+)
+
+const (
+	templateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
+)
+
+type StackSpec struct {
+	stackName string
+	region string
+}
+
+var (
+	stackSpec = &StackSpec{}
+)
+
+func createStack(svc *cf.CloudFormation, params []*cf.Parameter, stackName string, timeout int64) {
+	input := &cf.CreateStackInput{
+		StackName: aws.String(stackName),
+		Capabilities: []*string{
+			aws.String("CAPABILITY_IAM"),
+		},
+		OnFailure:        aws.String("DELETE"),
+		Parameters:       params,
+		TemplateURL:      aws.String(templateURL),
+		TimeoutInMinutes: aws.Int64(timeout),
+	}
+
+	resp, err := svc.CreateStack(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(awsutil.StringValue(resp))
+}
+
+func provision(cmd *cobra.Command, args []string) {
+	sess := session.Must(session.NewSession())
+
+	// Create the service's client with the session.
+	svc := cf.New(sess,
+		aws.NewConfig().WithRegion(stackSpec.region).WithLogLevel(aws.LogOff))
+
+	params := []*cf.Parameter{
+		{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String("tony-amp-dev") },
+	}
+
+	createStack(svc, params, stackSpec.stackName, 20)
+
+	log.Println(svc.APIVersion)
+}
+
+func update(cmd *cobra.Command, args []string) {
+	log.Println("update command not implemented yet")
+}
+
+func destroy(cmd *cobra.Command, args []string) {
+	log.Println("destroy command not implemented yet")
+}
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use: "awsplugin",
+		Short: "init/update/destroy an AWS cluster in Docker swarm mode",
+	}
+	rootCmd.PersistentFlags().StringVarP(&stackSpec.stackName, "name", "n", "", "stack name")
+	rootCmd.PersistentFlags().StringVarP(&stackSpec.region, "region", "r", "", "aws region")
+
+	initCmd := &cobra.Command{
+		Use: "init",
+		Short: "init cluster in swarm mode",
+		Run: provision,
+	}
+
+	updateCmd := &cobra.Command{
+		Use: "update",
+		Short: "update the cluster",
+		Run: update,
+	}
+
+	destroyCmd := &cobra.Command{
+		Use: "destroy",
+		Short: "destroy the cluster",
+		Run: destroy,
+	}
+
+	rootCmd.AddCommand(initCmd, updateCmd, destroyCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+
+}

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -68,7 +68,7 @@ func CreateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 	return svc.CreateStackWithContext(ctx, input)
 }
 
-func UpdateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions, timeout int64) (*cf.UpdateStackOutput, error) {
+func UpdateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions) (*cf.UpdateStackOutput, error) {
 	input := &cf.UpdateStackInput{
 		StackName: aws.String(opts.StackName),
 		Capabilities: []*string{

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -25,6 +25,8 @@ type RequestOptions struct {
 	Region string
 
 	StackName string
+
+	Sync bool
 }
 
 func parseParam(s string) *cf.Parameter {

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -68,6 +68,19 @@ func CreateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 	return svc.CreateStackWithContext(ctx, input)
 }
 
+func UpdateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions, timeout int64) (*cf.UpdateStackOutput, error) {
+	input := &cf.UpdateStackInput{
+		StackName: aws.String(opts.StackName),
+		Capabilities: []*string{
+			aws.String("CAPABILITY_IAM"),
+		},
+		Parameters:       toParameters(opts.Params),
+		TemplateURL:      aws.String(templateURL),
+	}
+
+	return svc.UpdateStackWithContext(ctx, input)
+}
+
 func DeleteStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions) (*cf.DeleteStackOutput, error) {
 	input := &cf.DeleteStackInput{
 		StackName: aws.String(opts.StackName),

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	cf "github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+const (
+	templateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
+)
+
+// StackSpec stores raw configuration options before transformation into a CreateStackInput struct
+// used by the cloudformation api.
+type StackSpec struct {
+	KeyPair   string
+
+	// OnFailure determines what happens if stack creations fails.
+	// Valid values are: "DO_NOTHING", "ROLLBACK", "DELETE"
+	// Default: "ROLLBACK"
+	OnFailure string
+
+	Params []*cf.Parameter
+
+	Region    string
+
+	StackName string
+}
+
+func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) {
+	input := &cf.CreateStackInput{
+		StackName: aws.String(stackSpec.StackName),
+		Capabilities: []*string{
+			aws.String("CAPABILITY_IAM"),
+		},
+		OnFailure:        aws.String(stackSpec.OnFailure),
+		Parameters:       stackSpec.Params,
+		TemplateURL:      aws.String(templateURL),
+		TimeoutInMinutes: aws.Int64(timeout),
+	}
+
+	resp, err := svc.CreateStack(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(awsutil.StringValue(resp))
+}
+

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -42,20 +42,22 @@ func parseParam(s string) *cf.Parameter {
 	return p
 }
 
-func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error) {
-	sp := stackSpec.Params
-	params := make([]*cf.Parameter, len(sp))
-	for i := range sp {
-		params[i] = parseParam(sp[i])
+func toParameters(sa []string) []*cf.Parameter {
+	params := make([]*cf.Parameter, len(sa))
+	for i := range sa {
+		params[i] = parseParam(sa[i])
 	}
+	return params
+}
 
+func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error) {
 	input := &cf.CreateStackInput{
 		StackName: aws.String(stackSpec.StackName),
 		Capabilities: []*string{
 			aws.String("CAPABILITY_IAM"),
 		},
 		OnFailure:        aws.String(stackSpec.OnFailure),
-		Parameters:       params,
+		Parameters:       toParameters(stackSpec.Params),
 		TemplateURL:      aws.String(templateURL),
 		TimeoutInMinutes: aws.Int64(timeout),
 	}

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,9 +12,9 @@ const (
 	templateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
 )
 
-// StackSpec stores raw configuration options before transformation into a CreateStackInput struct
-// used by the cloudformation api.
-type StackSpec struct {
+// RequestOptions stores raw request input options before transformation into a AWS SDK specific
+// structs  used by the cloudformation api.
+type RequestOptions struct {
 	// OnFailure determines what happens if stack creations fails.
 	// Valid values are: "DO_NOTHING", "ROLLBACK", "DELETE"
 	// Default: "ROLLBACK"
@@ -50,17 +51,25 @@ func toParameters(sa []string) []*cf.Parameter {
 	return params
 }
 
-func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error) {
+func CreateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions, timeout int64) (*cf.CreateStackOutput, error) {
 	input := &cf.CreateStackInput{
-		StackName: aws.String(stackSpec.StackName),
+		StackName: aws.String(opts.StackName),
 		Capabilities: []*string{
 			aws.String("CAPABILITY_IAM"),
 		},
-		OnFailure:        aws.String(stackSpec.OnFailure),
-		Parameters:       toParameters(stackSpec.Params),
+		OnFailure:        aws.String(opts.OnFailure),
+		Parameters:       toParameters(opts.Params),
 		TemplateURL:      aws.String(templateURL),
 		TimeoutInMinutes: aws.Int64(timeout),
 	}
 
-	return svc.CreateStack(input)
+	return svc.CreateStackWithContext(ctx, input)
+}
+
+func DeleteStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptions) (*cf.DeleteStackOutput, error) {
+	input := &cf.DeleteStackInput{
+		StackName: aws.String(opts.StackName),
+	}
+
+	return svc.DeleteStackWithContext(ctx, input)
 }

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -1,10 +1,7 @@
 package aws
 
 import (
-	"log"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
@@ -29,7 +26,7 @@ type StackSpec struct {
 	StackName string
 }
 
-func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) {
+func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error){
 	input := &cf.CreateStackInput{
 		StackName: aws.String(stackSpec.StackName),
 		Capabilities: []*string{
@@ -41,11 +38,6 @@ func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) {
 		TimeoutInMinutes: aws.Int64(timeout),
 	}
 
-	resp, err := svc.CreateStack(input)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println(awsutil.StringValue(resp))
+	return svc.CreateStack(input)
 }
 

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 )
@@ -12,32 +14,51 @@ const (
 // StackSpec stores raw configuration options before transformation into a CreateStackInput struct
 // used by the cloudformation api.
 type StackSpec struct {
-	KeyPair   string
-
 	// OnFailure determines what happens if stack creations fails.
 	// Valid values are: "DO_NOTHING", "ROLLBACK", "DELETE"
 	// Default: "ROLLBACK"
 	OnFailure string
 
-	Params []*cf.Parameter
+	Params []string
 
-	Region    string
+	Region string
 
 	StackName string
 }
 
-func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error){
+func parseParam(s string) *cf.Parameter {
+	p := &cf.Parameter{}
+
+	// split string to at most 2 substrings
+	// if there is only 1 substring, then assume UsePreviousValue=true
+	kv := strings.SplitN(s, "=", 2)
+	p.SetParameterKey(kv[0])
+	if len(kv) == 1 {
+		p.SetUsePreviousValue(true)
+	} else {
+		p.SetParameterValue(kv[1])
+	}
+
+	return p
+}
+
+func CreateStack(svc *cf.CloudFormation, stackSpec *StackSpec, timeout int64) (*cf.CreateStackOutput, error) {
+	sp := stackSpec.Params
+	params := make([]*cf.Parameter, len(sp))
+	for i := range sp {
+		params[i] = parseParam(sp[i])
+	}
+
 	input := &cf.CreateStackInput{
 		StackName: aws.String(stackSpec.StackName),
 		Capabilities: []*string{
 			aws.String("CAPABILITY_IAM"),
 		},
 		OnFailure:        aws.String(stackSpec.OnFailure),
-		Parameters:       stackSpec.Params,
+		Parameters:       params,
 		TemplateURL:      aws.String(templateURL),
 		TimeoutInMinutes: aws.Int64(timeout),
 	}
 
 	return svc.CreateStack(input)
 }
-

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -2,9 +2,70 @@ package aws
 
 import (
 	"log"
+	"os"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-func TestFoo(t *testing.T) {
-	log.Println("test...")
+var (
+	keyPair string
+	region string
+
+	sess *session.Session
+	svc *cf.CloudFormation
+)
+
+// REQUIREMENTS:
+// AWS credentials in path
+// Environment variables set for the following:
+//   KEYPAIR=<your-aws-key-pair>
+//   REGION=<aws-region>
+func init() {
+	keyPair = os.Getenv("KEYPAIR")
+	if keyPair == "" {
+		log.Fatal("KEYPAIR environment variable not set")
+	}
+	region = os.Getenv("REGION")
+	if region == "" {
+		log.Fatal("REGION environment variable not set")
+	}
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+
+func setup() {
+	sess = session.Must(session.NewSession())
+
+	// Create the service's client with the session.
+	svc = cf.New(sess,
+		aws.NewConfig().WithRegion(region).WithLogLevel(aws.LogOff))
+}
+
+func teardown() {
+}
+
+func TestCreate(t *testing.T) {
+	stackSpec := &StackSpec{
+		KeyPair: keyPair,
+		Region: region,
+		StackName: "test-stack", // TODO: create unique test stackname
+		OnFailure: "DELETE",
+	}
+
+	stackSpec.Params = []*cf.Parameter{
+		{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(keyPair)},
+	}
+
+	_, err := CreateStack(svc, stackSpec, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -58,6 +58,7 @@ func teardown() {
 }
 
 func TestCreate(t *testing.T) {
+
 	stackName := fmt.Sprintf("%s-plugin-test-%s", keyName, uuid.NewV4())
 
 	opts := &RequestOptions{
@@ -66,6 +67,8 @@ func TestCreate(t *testing.T) {
 		OnFailure: "DELETE",
 		Params: []string{
 			fmt.Sprintf("KeyName=%s", keyName),
+			fmt.Sprintf("ClusterSize=%s", "2"),
+			fmt.Sprintf("ManagerSize=%s", "1"),
 		},
 	}
 
@@ -74,17 +77,17 @@ func TestCreate(t *testing.T) {
 	ctxCreate := context.Background()
 	respCreate, err := CreateStack(ctxCreate, svc, opts, 20)
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
-	t.Log(awsutil.StringValue(respCreate))
-	t.Log("waiting...")
+	log.Println(awsutil.StringValue(respCreate))
+	log.Println("waiting...")
 	input := &cf.DescribeStacksInput{
 		StackName: aws.String(opts.StackName),
 	}
 	if err := svc.WaitUntilStackUpdateCompleteWithContext(ctxCreate, input); err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
-	t.Logf("stack created: %s\n", opts.StackName)
+	log.Printf("stack created: %s\n", opts.StackName)
 
 	// update stack
 	// ============
@@ -92,14 +95,14 @@ func TestCreate(t *testing.T) {
 	ctxUpdate := context.Background()
 	respUpdate, err := UpdateStack(ctxUpdate, svc, opts)
 	if err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
 	log.Println(awsutil.StringValue(respUpdate))
-	t.Log("waiting...")
+	log.Println("waiting...")
 	if err := svc.WaitUntilStackUpdateCompleteWithContext(ctxUpdate, input); err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
-	t.Logf("stack update: %s\n", opts.StackName)
+	log.Printf("stack update: %s\n", opts.StackName)
 
 	// delete stack
 	// ============
@@ -109,9 +112,9 @@ func TestCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	log.Println(awsutil.StringValue(respDelete))
-	t.Log("waiting...")
+	log.Println("waiting...")
 	if err := svc.WaitUntilStackDeleteCompleteWithContext(ctxDelete, input); err != nil {
-		t.Fatal(err)
+		log.Fatal(err)
 	}
-	t.Logf("stack deleted: %s\n", opts.StackName)
+	log.Printf("stack deleted: %s\n", opts.StackName)
 }

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -1,13 +1,14 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/satori/go.uuid"
 )
 
 var (
@@ -50,13 +51,16 @@ func setup() {
 }
 
 func teardown() {
+	// TODO destroy test stacks
 }
 
 func TestCreate(t *testing.T) {
+	stackName := fmt.Sprintf("amp-aws-plugin-test-%s", uuid.NewV4())
+
 	stackSpec := &StackSpec{
 		KeyPair: keyPair,
 		Region: region,
-		StackName: "test-stack", // TODO: create unique test stackname
+		StackName: stackName,
 		OnFailure: "DELETE",
 	}
 

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
@@ -12,8 +13,8 @@ import (
 )
 
 var (
-	keyPair string
-	region string
+	keyName string
+	region  string
 
 	sess *session.Session
 	svc *cf.CloudFormation
@@ -25,9 +26,9 @@ var (
 //   KEYPAIR=<your-aws-key-pair>
 //   REGION=<aws-region>
 func init() {
-	keyPair = os.Getenv("KEYPAIR")
-	if keyPair == "" {
-		log.Fatal("KEYPAIR environment variable not set")
+	keyName = os.Getenv("KEYNAME")
+	if keyName == "" {
+		log.Fatal("KEYNAME environment variable not set")
 	}
 	region = os.Getenv("REGION")
 	if region == "" {
@@ -55,17 +56,15 @@ func teardown() {
 }
 
 func TestCreate(t *testing.T) {
-	stackName := fmt.Sprintf("%s-plugin-test-%s", keyPair, uuid.NewV4())
+	stackName := fmt.Sprintf("%s-plugin-test-%s", keyName, uuid.NewV4())
 
 	stackSpec := &StackSpec{
-		KeyPair: keyPair,
-		Region: region,
+		Region:    region,
 		StackName: stackName,
 		OnFailure: "DELETE",
-	}
-
-	stackSpec.Params = []*cf.Parameter{
-		{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(keyPair)},
+		Params: []string{
+			fmt.Sprintf("KeyName=%s", keyName),
+		},
 	}
 
 	_, err := CreateStack(svc, stackSpec, 20)

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -58,7 +59,7 @@ func teardown() {
 func TestCreate(t *testing.T) {
 	stackName := fmt.Sprintf("%s-plugin-test-%s", keyName, uuid.NewV4())
 
-	stackSpec := &StackSpec{
+	opts := &RequestOptions{
 		Region:    region,
 		StackName: stackName,
 		OnFailure: "DELETE",
@@ -67,7 +68,13 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	_, err := CreateStack(svc, stackSpec, 20)
+	ctx := context.Background()
+	_, err := CreateStack(ctx, svc, opts, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = DeleteStack(ctx, svc, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -1,0 +1,10 @@
+package aws
+
+import (
+	"log"
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	log.Println("test...")
+}

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -72,6 +72,8 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
+	log.Println("starting test...")
+
 	// create stack
 	// ============
 	ctxCreate := context.Background()
@@ -80,11 +82,11 @@ func TestCreate(t *testing.T) {
 		log.Fatal(err)
 	}
 	log.Println(awsutil.StringValue(respCreate))
-	log.Println("waiting...")
+	log.Println("creating stack...")
 	input := &cf.DescribeStacksInput{
 		StackName: aws.String(opts.StackName),
 	}
-	if err := svc.WaitUntilStackUpdateCompleteWithContext(ctxCreate, input); err != nil {
+	if err := svc.WaitUntilStackCreateCompleteWithContext(ctxCreate, input); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("stack created: %s\n", opts.StackName)
@@ -98,11 +100,11 @@ func TestCreate(t *testing.T) {
 		log.Fatal(err)
 	}
 	log.Println(awsutil.StringValue(respUpdate))
-	log.Println("waiting...")
+	log.Println("updating stack...")
 	if err := svc.WaitUntilStackUpdateCompleteWithContext(ctxUpdate, input); err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("stack update: %s\n", opts.StackName)
+	log.Printf("stack updated: %s\n", opts.StackName)
 
 	// delete stack
 	// ============
@@ -112,7 +114,7 @@ func TestCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	log.Println(awsutil.StringValue(respDelete))
-	log.Println("waiting...")
+	log.Println("deleting stack...")
 	if err := svc.WaitUntilStackDeleteCompleteWithContext(ctxDelete, input); err != nil {
 		log.Fatal(err)
 	}

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -55,7 +55,7 @@ func teardown() {
 }
 
 func TestCreate(t *testing.T) {
-	stackName := fmt.Sprintf("amp-aws-plugin-test-%s", uuid.NewV4())
+	stackName := fmt.Sprintf("%s-plugin-test-%s", keyPair, uuid.NewV4())
 
 	stackSpec := &StackSpec{
 		KeyPair: keyPair,


### PR DESCRIPTION
## Description

Initial commit of work in progress. See [here](https://github.com/appcelerator/amp/wiki/AMP-Clusters) for design documentation.

### Options

The plugin allows you to provide all the parameters that are supported by the [Docker for AWS CloudFormation template](https://docs.docker.com/docker-for-aws/#configuration-options), including:

 * KeyName
 * EnableCloudWatchLogs
 * ManagerSize
 * ManagerInstanceType
 * ManagerDiskSize
 * ManagerDiskType
 * ClusterSize
 * InstanceType
 * WorkerDiskSize
 * WorkerDiskType

The format for adding a parameter (`-p | --parameter`) is more compact than the format used by the AWS CLI. For example, instead of:

    --parameters ParameterKey=ManagerInstanceType,ParameterValue=t2.medium ...

use this format instead:

    --parameter ManagerInstanceType=t2.medium ...

And for updates, instead of:

    --parameters ParameterKey=ManagerInstanceType,UsePreviousValue=true ...

just use this instead:

    --parameter ManagerInstanceType   # no assigned value assumes UsePreviousValue=true ...

## Prerequisites

* Ensure you have a keypair for the region you want to use to create a stack using the plugin. I recommend you upload your own public key and give it the same name for each region you want to test (see [keypair docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws)).

* Ensure your AWS credentials are configured (see [credentials docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)).

### Sync Operations

You can block until a command completes using the `-s | --sync` option. For example:

    $ docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws-plugin update --region us-west-2 --stackname tony-amp-10 -p KeyName=tony-amp-dev -p ClusterSize=4 --sync

## Verification

**NOTE:** I've provided a lot of detail here for the benefit of everyone on the team who might want to look while this is under development; most of you won't care about ssh tunnels, etc, and will interact with the swarm via the AMP CLI when this is finished.

Please ensure that any stacks you create for testing have your name in it using the following pattern:

    name-test-foo

Ex:

    tony-test-amp-awsplugin

This makes it a bit easier to identify test resources that can be deleted without guilt in case you forget to remove them. Please do try to remember to remove on your own after testing.

From the `cluster/plugin/aws` directory, run the following:

    $ make compiler
    $ make
    $ export REGION=us-west-2 # or any region where you have a valid keypair
    $ export KEYNAME=tony-amp-dev
    $ export STACKNAME=tony-amp-1
    $ export ONFAILURE=DO_NOTHING
    $ docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws-plugin init \
        --region $REGION \
        --stackname $STACKNAME \
        --onfailure $ONFAILURE \
        --parameter KeyName=$KEYNAME \
        --parameter ...

Verify output similar to the following:

```
$ docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws-plugin init --region us-west-2 --name tony-amp-7
2017/06/14 20:31:23 {
  StackId: "arn:aws:cloudformation:us-west-2:654814900965:stack/tony-amp-7/6d88d410-5140-11e7-8af9-503acbd4dc29"
}
2017/06/14 20:31:23 2010-05-15
```

Also verify the stack has been created in the AWS console. The URL looks like this (updated the region value as appropriate):

https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks?filter=active&tab=resources

### SSH to an instance

On the page opened by the previous link, you can click on your stack, then click on "Outputs", then click on the "Managers" link to the manager instances that were created. From there, you can obtain the public IP and DNS names created for each manager. Using the ssh key associated with your AWS keypair, you can ssh into any of these instances.

For example, if your private key is called `id_rsa` and the IP address of a manager node is `34.210.103.37`, then you can ssh into it like this:

    $ ssh -i ~/.ssh/id_rsa docker@ 34.210.103.37

You can then run docker swarm commands, like `docker node ls`.

Once you are connected to a manager node you can then ssh to a worker node using the node name as reported by `docker node ls`. Make sure you have ssh agent forwarding set up from your host system to ensure your keys propagate so that your private key doesn't need to be installed on each node you ssh from (see [docs](https://docs.docker.com/docker-for-aws/deploy/#using-ssh-agent-forwarding)).

    # can only ssh to a worker from a manager node
    $ ssh <worker>

### SSH Tunnel

If you don't need to ssh to a work and just want to connect to a manager for running docker commands, it can be more convenient to open an ssh tunnel. You can do this as follows:

    $ ssh -i ~/.ssh/id_rsa -NL 127.0.0.1:2374:/var/run/docker.sock docker@34.210.103.37

Or run the command and put it in the background -- just don't forget to kill it when done to release the port.

    $ ssh -i ~/.ssh/id_rsa -NL 127.0.0.1:2374:/var/run/docker.sock docker@34.210.103.37 &

Then you can specify the docker host to connect to using that port for the tunnel to run docker commands. For example:

    $ docker -H localhost:2374 node ls

Finally, you can set `DOCKER_HOST` so you don't have to use the `-H` option each time:

    $ export DOCKER_HOST=localhost:2374
    $ docker node ls

### Update Stack

Update an existing stack with the `update` command:

    $ docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws-plugin update \
        --region $REGION \
        --stackname $STACKNAME \
        -p KeyName=$KEYNAME \
        -p ClusterSize=4 # new value! \
        --sync # block until done!

### Destroy Stack

Execute the `destroy` command with the stackname and region used for the `init` command:

    $ docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws-plugin destroy \
        --region $REGION \
        --stackname $STACKNAME

## Tests

    $ KEYNAME=<aws-keypair-name> REGION=<aws-region> make test

Tests now automatically destroy the stacks they create.