### PR TITLE
sample updates, doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An open source [CaaS](https://blog.docker.com/2016/02/containers-as-a-service-ca
 While not recommended for production use quite yet, it's getting close (anticipated shortly after v0.12 in mid-June).
 In the meantime, you can use the current playground hosted at `cloud.appcelerator.io`,
 and you can also host your own cluster. You can even create a full cluster on your own laptop
-with `amp cluster create` using the CLI.
+with `amp -s localhost cluster create` using the CLI.
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ To make these changes permanent, you can run the following and reboot:
 
 ### Get the AMP CLI
 
-Download the latest release of the CLI for your platorm:
+Download the latest release of the CLI for your platform:
 
 https://github.com/appcelerator/amp/releases
 
@@ -63,7 +63,7 @@ with the amp command and specify `localhost`.
 
     $ amp -s localhost cluster create
     $ amp -s localhost user signup # Ignore the verification email
-    $ amp -s login
+    $ amp -s localhost login
 
 
 ##### Tip:
@@ -92,13 +92,13 @@ Here is a simple example:
 
 ```sh
     $ curl -O https://raw.githubusercontent.com/appcelerator/amp/master/examples/stacks/pinger/pinger.yml
-    $ amp -s localhost stack deploy -c pinger.yml pinger
+    $ amp -s localhost stack deploy -c pinger.yml
     $ amp -s localhost stack ls
     $ amp -s localhost service logs pinger
-    $ curl -k https://pinger.local.appcelerator.io/ping
+    $ curl http://pinger.examples.local.appcelerator.io/ping
 ```
 
-Or browse to: https://pinger.local.appcelerator.io/ping
+Or browse to: https://pinger.examples.local.appcelerator.io/ping
 
 ## Monitoring
 
@@ -113,5 +113,3 @@ http://localhost:50106.
 To test the organization and teams features,
 use the CLI to create your ATOMIQ ID (`amp user signup`), then
 log in (`amp login`).
-
-

--- a/docs/certificate.md
+++ b/docs/certificate.md
@@ -1,0 +1,14 @@
+# Certificate management for AMP
+
+For local deployment, amp will generate a self signed certificate. You'll have to accept it when you connect the first time to the services on local.appcelerator.io.
+
+For remote deployment, if you want to use a valid DNS domain, you can upload a certificate on the Swarm to enable TLS flows.
+
+If your domain is `cloud.mydomain.net`, the certificate should be signed for `cloud.mydomain.net`, `dashboard.cloud.mydomain.net`, `gw.cloud.mydomain.net`, `examples.cloud.mydomain.net` and `service.cloud.domain.net`. If you can get a wildcard certificate, it's even better.
+
+As an admin user of the platform, you can replace the certificate in the swarm. For that, prepare the secret as a pem file (includind the private key, the certificate, and the certificate chain), create a new Docker secret in the swarm, and update the amp_proxy service to mount it as `/run/secrets/certN.pem`, with N = 1 to 9.
+```
+amp secret create amp_certificate_$(date +%Y%m%d)
+amp service update --secret-add amp_certificate_$(date +%Y%m%d) amp_proxy
+amp service update --secret-rm amp_certificate_old_one amp_proxy
+```

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -8,5 +8,13 @@ container | `io.amp.role` | [`infrastructure`, `tool` ] | Set on amp containers 
 service | `io.amp.role` | [`infrastructure`, `tool` ] | Set on amp containers to describe their role |
 daemon | `atomiq.clusterid` | Cluster ID | Docker engine label for the local bootstrap cluster |
 daemon | `infrakit.group` |  InfraKit group name | Docker engine label for the local bootstrap cluster (is an EC2 tag on AWS cluster deployment) |
+node | `amp.type.api` | true | Docker node label for service scheduling (api server) |
+node | `amp.type.route` | true | Docker node label for service scheduling (proxy service) |
+node | `amp.type.core` | true | Docker node label for service scheduling (core services) |
+node | `amp.type.search` | true | Docker node label for service scheduling (log database service) |
+node | `amp.type.kv` | true | Docker node label for service scheduling (storage service) |
+node | `amp.type.mq` | true | Docker node label for service scheduling (messaging service) |
+node | `amp.type.metrics` | true | Docker node label for service scheduling (monitoring service) |
+node | `amp.type.user` | true | Docker node label for service scheduling (user services) |
 
 Resource type: https://docs.docker.com/engine/userguide/labels-custom-metadata/

--- a/examples/stacks/counter/README.md
+++ b/examples/stacks/counter/README.md
@@ -7,10 +7,10 @@ Run in this directory:
 
     $ amp -s localhost stack deploy -c counter.yml
 
-The app will be running at [http://go.counter.local.appcelerator.io](http://go.counter.local.appcelerator.io)
+The app will be running at [http://go.counter.examples.local.appcelerator.io](http://go.counter.examples.local.appcelerator.io)
 
 Test with
 
-    $ curl http://go.counter.local.appcelerator.io
+    $ curl http://go.counter.examples.local.appcelerator.io
 
 Or open url in browser.

--- a/examples/stacks/counter/counter.yml
+++ b/examples/stacks/counter/counter.yml
@@ -12,11 +12,11 @@ services:
       - default
     environment:
       SERVICE_PORTS: "80"
-      VIRTUAL_HOST: "http://go.*,https://go.*"
+      VIRTUAL_HOST: "http://go.counter.examples*,https://go.counter.examples.*"
     deploy:
       replicas: 3
       placement:
-        constraints: [node.role == worker]
+        constraints: [node.labels.amp.type.user == true]
 
   redis:
     image: redis
@@ -25,4 +25,4 @@ services:
     deploy:
       replicas: 1
       placement:
-        constraints: [node.role == worker]
+        constraints: [node.labels.amp.type.user == true]

--- a/examples/stacks/pinger/README.md
+++ b/examples/stacks/pinger/README.md
@@ -7,17 +7,17 @@ Run in this directory:
 
     $ amp -s localhost stack deploy -c pinger.yml
 
-The app will be available at [https://pinger.local.appcelerator.io/ping](https://pinger.local.appcelerator.io/ping)
+The app will be available at [http://pinger.examples.local.appcelerator.io/ping](http://pinger.examples.local.appcelerator.io/ping)
 
 Test with
 
-    $ curl -k https://pinger.local.appcelerator.io/ping
+    $ curl http://pinger.examples.local.appcelerator.io/ping
     [9a58616b614d] pong
 
-    $ curl -k https://pinger.local.appcelerator.io/ping
+    $ curl http://pinger.examples.local.appcelerator.io/ping
     [81c3c0958600] pong
 
-    $ curl -k https://pinger.local.appcelerator.io/ping
+    $ curl http://pinger.examples.local.appcelerator.io/ping
     [ba7d86288a02] pong
 
 Because 3 replicas was specified, you should see 3 different hosts in

--- a/examples/stacks/pinger/pinger.yml
+++ b/examples/stacks/pinger/pinger.yml
@@ -15,8 +15,10 @@ services:
           - pinger
     environment:
       SERVICE_PORTS: "3000"
-      VIRTUAL_HOST: "https://pinger.*"
+      VIRTUAL_HOST: "pinger.examples.*,https://pinger.examples.*"
     deploy:
       replicas: 3
       restart_policy:
         condition: on-failure
+      placement:
+        constraints: [node.labels.amp.type.user == true]

--- a/examples/stacks/voting-app/README.md
+++ b/examples/stacks/voting-app/README.md
@@ -7,8 +7,8 @@ Run in this directory:
 
     $ amp -s localhost stack up -c voting.yml
 
-The voting app will be available at [https://vote.local.appcelerator.io](https://vote.local.appcelerator.io).
+The voting app will be available at [http://vote.examples.local.appcelerator.io](http://vote.examples.local.appcelerator.io).
 
-The results app will be available at [https://result.local.appcelerator.io](https://result.local.appcelerator.io).
+The results app will be available at [http://result.examples.local.appcelerator.io](http://result.examples.local.appcelerator.io).
 
 Credit: Docker ([LICENSE](https://github.com/docker/example-voting-app/blob/master/LICENSE))

--- a/examples/stacks/voting-app/voting.yml
+++ b/examples/stacks/voting-app/voting.yml
@@ -1,11 +1,9 @@
-version: "3"
+version: "3.1"
 
 services:
 
   redis:
     image: redis:alpine
-    ports:
-      - "6379"
     networks:
       - frontend
     deploy:
@@ -15,6 +13,8 @@ services:
         delay: 10s
       restart_policy:
         condition: on-failure
+      placement:
+        constraints: [node.labels.amp.type.user == true]
   db:
     image: postgres:9.4
     volumes:
@@ -23,12 +23,12 @@ services:
       - backend
     deploy:
       placement:
-        constraints: [node.role == manager]
+        constraints: [node.labels.amp.type.user == true]
   vote:
     image: dockersamples/examplevotingapp_vote:before
     environment:
-      - "SERVICE_PORTS=80"
-      - "VIRTUAL_HOST=https://vote.*"
+      SERVICE_PORTS: 80
+      VIRTUAL_HOST: "https://vote.examples.*,vote.examples.*"
     networks:
       - frontend
       - default
@@ -40,12 +40,14 @@ services:
         parallelism: 2
       restart_policy:
         condition: on-failure
+      placement:
+        constraints: [node.labels.amp.type.user == true]
 
   result:
     image: dockersamples/examplevotingapp_result:before
     environment:
-      - "SERVICE_PORTS=80"
-      - "VIRTUAL_HOST=https://result.*"
+      SERVICE_PORTS: 80
+      VIRTUAL_HOST: "https://result.examples.*,result.examples.*"
     networks:
       - backend
       - default
@@ -58,6 +60,8 @@ services:
         delay: 10s
       restart_policy:
         condition: on-failure
+      placement:
+        constraints: [node.labels.amp.type.user == true]
 
   worker:
     image: dockersamples/examplevotingapp_worker
@@ -74,18 +78,7 @@ services:
         max_attempts: 3
         window: 120s
       placement:
-        constraints: [node.role == manager]
-
-  visualizer:
-    image: dockersamples/visualizer:stable
-    ports:
-      - "8080:8080"
-    stop_grace_period: 1m30s
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
-    deploy:
-      placement:
-        constraints: [node.role == manager]
+        constraints: [node.labels.amp.type.user == true]
 
 networks:
   frontend:

--- a/platform/stacks/amp.stack.yml
+++ b/platform/stacks/amp.stack.yml
@@ -52,8 +52,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
     environment:
-      - "SERVICE_PORTS=80"
-      - "VIRTUAL_HOST=https://gw.*,http://gw.*"
+      SERVICE_PORTS: 80
+      VIRTUAL_HOST: "https://gw.*,http://gw.*"
     deploy:
       mode: global
       labels:

--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -45,4 +45,3 @@ services:
       ELASTICSEARCH_URL: "http://elasticsearch:9200"
       SERVICE_PORTS: 5601
       VIRTUAL_HOST: "http://kibana.*,https://kibana.*"
-      FORCE_SSL: 1

--- a/platform/stacks/portal.stack.yml
+++ b/platform/stacks/portal.stack.yml
@@ -22,7 +22,6 @@ services:
         - node.labels.amp.type.core == true
     environment:
       SERVICE_PORTS: "80"
-      VIRTUAL_HOST: "http://cloud.*,http://local.*,https://cloud.*,https://local.*"
-      FORCE_SSL: 1
+      VIRTUAL_HOST: "http://portal.*,https://portal.*,http://cloud.*,http://local.*,https://cloud.*,https://local.*"
     labels:
       io.amp.role: "infrastructure"

--- a/platform/stacks/visualizer.stack.yml
+++ b/platform/stacks/visualizer.stack.yml
@@ -14,7 +14,6 @@ services:
     environment:
       SERVICE_PORTS: "8080"
       VIRTUAL_HOST: "http://visualizer,https://visualizer.*"
-      FORCE_SSL: 1
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     deploy:
@@ -28,7 +27,6 @@ services:
     environment:
       SERVICE_PORTS: "9000"
       VIRTUAL_HOST: "http://portainer.*,https://portainer.*"
-      FORCE_SSL: 1
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:


### PR DESCRIPTION
fix #1301 (best practices in sample stacks)
ref #1169 (certificate management)

- follow best practices for examples (service scheduling on nodes for user stacks)
- don't force https, with an example ignoring invalid certificates
- update docs
- add a portal.* vhost for the portal when the domain does not starts with cloud.* or local.*
- add a certificate management documentation, based on a CLI feature not yet implemented
