### PR TITLE
better cluster node allocation

### DIFF
--- a/platform/bin/deploy
+++ b/platform/bin/deploy
@@ -158,7 +158,7 @@ cluster_workercount() {
   _target=$(deployment_target)
   case $_target in
   local) # single manager node
-    echo 0
+    docker node ls -q --filter "role=worker" | wc -w
     ;;
   dind|aws)
     _count=$(bootstrap -t $_target -l $_clusterid | grep -c worker)
@@ -538,7 +538,7 @@ deploy_stacks() {
 
   echo "deploy amp monitoring stack to cluster - stage 1"
   _workercount=$(cluster_workercount $CID) || return 1
-  [[ $_workercount -le 9 ]] && deploystack ampmon-single.1.stack.yml amp || deploystack ampmon-cluster.1.stack.yml amp
+  [[ $_workercount -le 2 ]] && deploystack ampmon-single.1.stack.yml amp || deploystack ampmon-cluster.1.stack.yml amp
   echo "wait for all amp monitoring stage 1 stack service replicas to be running"
 
   servicescheck $maxwait

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -207,29 +207,43 @@ _set_size() {
   manager_labels='{"amp.type.api": "true", "amp.type.route": "true"}'
   _vars="{{ var \"/swarm/size/manager\" \"$manager_count\" }} {{ var \"/swarm/labels/manager\" \`${manager_labels}\` }} {{ var \"/swarm/size/worker\" \"$worker_count\" }}"
   if [[ $worker_count -le 3 ]]; then
+    # fits the ampmon-single.1.stack.yml
+    # can be ampmon-cluster for 3 nodes
+    # all gp nodes
     cpu_count=0
     mem_count=0
     dat_count=0
     gp_count=$worker_count
     gp_labels='{"amp.type.search": "true", "amp.type.kv": "true", "amp.type.mq": "true", "amp.type.core": "true", "amp.type.user": "true"}'
-  elif [[ $worker_count -le 9 ]]; then
+  elif [[ $worker_count -le 6 ]]; then
+    # fits the ampmon-cluster.1.stack.yml
+    # one cpu node for nats, and gp node for other services
     cpu_count=1
-    mem_count=1
-    dat_count=1
-    gp_count=$((worker_count - 3 ))
+    gp_count=$((worker_count - 1 ))
     cpu_labels='{"amp.type.mq": "true"}'
-    dat_labels='{"amp.type.kv": "true"}'
-    mem_labels='{"amp.type.search": "true"}'
+    gp_labels='{"amp.type.search": "true", "amp.type.kv": "true", "amp.type.core": "true", "amp.type.user": "true"}'
+  elif [[ $worker_count -le 12 ]]; then
+    # fits the ampmon-cluster.1.stack.yml
+    # 1 cpu node for nats
+    # 3 mem nodes for etcd and elasticsearch
+    cpu_count=1
+    mem_count=3
+    gp_count=$((worker_count - 4))
+    cpu_labels='{"amp.type.mq": "true"}'
+    mem_labels='{"amp.type.search": "true", "amp.type.kv": "true"}'
     gp_labels='{"amp.type.core": "true", "amp.type.user": "true"}'
   else
     # fits the ampmon-cluster.1.stack.yml
+    # 1 cpu node for nats
+    # 3 mem nodes for etcd
+    # 3 dat nodes for etcd
     cpu_count=1
     mem_count=3
     dat_count=3
     gp_count=$((worker_count - 7))
     cpu_labels='{"amp.type.mq": "true"}'
-    dat_labels='{"amp.type.kv": "true"}'
     mem_labels='{"amp.type.search": "true"}'
+    dat_labels='{"amp.type.kv": "true"}'
     gp_labels='{"amp.type.core": "true", "amp.type.user": "true"}'
   fi
   for _w in $WORKER_GROUP_LIST; do

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -23,6 +23,7 @@ services:
       MIN_MASTER_NODES: 2
       NETWORK_HOST: "_eth0_"
       UNICAST_HOSTS: "tasks.elasticsearch"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
     deploy:
       mode: replicated
       replicas: 3

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -21,6 +21,7 @@ services:
       io.amp.role: "infrastructure"
     environment:
       NETWORK_HOST: "_eth0_"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
ref #1382 (elasticsearch out of memory)

- default label mapping reviewed for better elasticsearch and etcd cluster allocation:
  - less than 3 workers, only one etcd and only one ES task
  - 3 workers: all tasks on GP nodes, etcd and ES in cluster mode
  - up to 6 workers: 1 node for nats, all other tasks on gp nodes (ES and etcd clustered)
  - up to 12 workers: 3 nodes for etcd and elasticsearch (clustered), 1 node for nats
  - more than 12 workers: 3 nodes for etcd, 3 nodes for ES, 1 node for nats
 - minor fixes
 - ES java heap size is controllable by a variable. Defaults to 1GB