### PR TITLE
Org and Team commands remember the last used org/team

### DIFF
--- a/cli/command/logout/logout.go
+++ b/cli/command/logout/logout.go
@@ -21,6 +21,12 @@ func logout(c cli.Interface) error {
 	if err := cli.RemoveToken(c.Server()); err != nil {
 		return err
 	}
+	if err := cli.SaveOrg("", c.Server()); err != nil {
+		return err
+	}
+	if err := cli.SaveTeam("", c.Server()); err != nil {
+		return err
+	}
 	c.Console().Println("You have been logged out!")
 	return nil
 }

--- a/cli/command/org/create.go
+++ b/cli/command/org/create.go
@@ -48,6 +48,9 @@ func createOrg(c cli.Interface, cmd *cobra.Command, opts createOrgOptions) error
 	if _, err := client.CreateOrganization(context.Background(), request); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
 	}
+	if err := cli.SaveOrg(opts.name, c.Server()); err != nil {
+		return err
+	}
 	c.Console().Println("Organization has been created.")
 	return nil
 }

--- a/cli/command/org/member/remove.go
+++ b/cli/command/org/member/remove.go
@@ -33,8 +33,15 @@ func NewOrgRemoveMemCommand(c cli.Interface) *cobra.Command {
 
 func removeOrgMem(c cli.Interface, cmd *cobra.Command, args []string, opts remMemOrgOptions) error {
 	var errs []string
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.name = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.name = org
+			c.Console().Println("organization name:", opts.name)
+		default:
+			opts.name = c.Console().GetInput("organization name")
+		}
 	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)

--- a/cli/command/org/remove.go
+++ b/cli/command/org/remove.go
@@ -72,5 +72,8 @@ func removeOrg(c cli.Interface, args []string) error {
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))
 	}
+	if err := cli.RemoveFile(c.Server()); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cli/command/team/get.go
+++ b/cli/command/team/get.go
@@ -32,8 +32,15 @@ func NewTeamGetCommand(c cli.Interface) *cobra.Command {
 }
 
 func getTeam(c cli.Interface, cmd *cobra.Command, args []string, opts getTeamOptions) error {
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
 
 	conn := c.ClientConn()

--- a/cli/command/team/list.go
+++ b/cli/command/team/list.go
@@ -36,8 +36,15 @@ func NewTeamListCommand(c cli.Interface) *cobra.Command {
 }
 
 func listTeam(c cli.Interface, cmd *cobra.Command, opts listTeamOptions) error {
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)

--- a/cli/command/team/member/list.go
+++ b/cli/command/team/member/list.go
@@ -37,11 +37,25 @@ func NewListTeamMemCommand(c cli.Interface) *cobra.Command {
 }
 
 func listTeamMem(c cli.Interface, cmd *cobra.Command, opts listTeamMemOptions) error {
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
+	team, err := cli.ReadTeam(c.Server())
 	if !cmd.Flag("team").Changed {
-		opts.team = c.Console().GetInput("team name")
+		switch {
+		case err == nil:
+			opts.team = team
+			c.Console().Println("team name:", opts.team)
+		default:
+			opts.team = c.Console().GetInput("team name")
+		}
 	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
@@ -52,6 +66,12 @@ func listTeamMem(c cli.Interface, cmd *cobra.Command, opts listTeamMemOptions) e
 	reply, err := client.GetTeam(context.Background(), request)
 	if err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	if err := cli.SaveOrg(opts.org, c.Server()); err != nil {
+		return err
+	}
+	if err := cli.SaveTeam(opts.team, c.Server()); err != nil {
+		return err
 	}
 	if opts.quiet {
 		for _, member := range reply.Team.Members {

--- a/cli/command/team/member/remove.go
+++ b/cli/command/team/member/remove.go
@@ -36,11 +36,25 @@ func NewRemoveTeamMemCommand(c cli.Interface) *cobra.Command {
 
 func remTeamMem(c cli.Interface, cmd *cobra.Command, args []string, opts remTeamMemOptions) error {
 	var errs []string
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
+	team, err := cli.ReadTeam(c.Server())
 	if !cmd.Flag("team").Changed {
-		opts.team = c.Console().GetInput("team name")
+		switch {
+		case err == nil:
+			opts.team = team
+			c.Console().Println("team name:", opts.team)
+		default:
+			opts.team = c.Console().GetInput("team name")
+		}
 	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
@@ -58,6 +72,12 @@ func remTeamMem(c cli.Interface, cmd *cobra.Command, args []string, opts remTeam
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))
+	}
+	if err := cli.SaveOrg(opts.org, c.Server()); err != nil {
+		return err
+	}
+	if err := cli.SaveTeam(opts.team, c.Server()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/command/team/remove.go
+++ b/cli/command/team/remove.go
@@ -34,8 +34,15 @@ func NewTeamRemoveCommand(c cli.Interface) *cobra.Command {
 
 func removeTeam(c cli.Interface, cmd *cobra.Command, args []string, opts removeTeamOptions) error {
 	var errs []string
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
@@ -52,6 +59,9 @@ func removeTeam(c cli.Interface, cmd *cobra.Command, args []string, opts removeT
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))
+	}
+	if err := cli.SaveTeam("", c.Server()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/command/team/resource/add.go
+++ b/cli/command/team/resource/add.go
@@ -35,11 +35,25 @@ func NewAddTeamResCommand(c cli.Interface) *cobra.Command {
 }
 
 func addTeamRes(c cli.Interface, cmd *cobra.Command, opts addTeamResOptions) error {
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
+	team, err := cli.ReadTeam(c.Server())
 	if !cmd.Flag("team").Changed {
-		opts.team = c.Console().GetInput("team name")
+		switch {
+		case err == nil:
+			opts.team = team
+			c.Console().Println("team name:", opts.team)
+		default:
+			opts.team = c.Console().GetInput("team name")
+		}
 	}
 	if !cmd.Flag("res").Changed {
 		opts.resource = c.Console().GetInput("resource id")
@@ -54,6 +68,12 @@ func addTeamRes(c cli.Interface, cmd *cobra.Command, opts addTeamResOptions) err
 	}
 	if _, err := client.AddToTeam(context.Background(), request); err != nil {
 		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	}
+	if err := cli.SaveOrg(opts.org, c.Server()); err != nil {
+		return err
+	}
+	if err := cli.SaveTeam(opts.team, c.Server()); err != nil {
+		return err
 	}
 	c.Console().Println("Resource has been added to team.")
 	return nil

--- a/cli/command/team/resource/remove.go
+++ b/cli/command/team/resource/remove.go
@@ -37,11 +37,25 @@ func NewRemoveTeamResCommand(c cli.Interface) *cobra.Command {
 
 func remTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts remTeamResOptions) error {
 	var errs []string
+	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
-		opts.org = c.Console().GetInput("organization name")
+		switch {
+		case err == nil:
+			opts.org = org
+			c.Console().Println("organization name:", opts.org)
+		default:
+			opts.org = c.Console().GetInput("organization name")
+		}
 	}
+	team, err := cli.ReadTeam(c.Server())
 	if !cmd.Flag("team").Changed {
-		opts.team = c.Console().GetInput("team name")
+		switch {
+		case err == nil:
+			opts.team = team
+			c.Console().Println("team name:", opts.team)
+		default:
+			opts.team = c.Console().GetInput("team name")
+		}
 	}
 	conn := c.ClientConn()
 	client := resource.NewResourceClient(conn)
@@ -59,6 +73,12 @@ func remTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts remTeam
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))
+	}
+	if err := cli.SaveOrg(opts.org, c.Server()); err != nil {
+		return err
+	}
+	if err := cli.SaveTeam(opts.team, c.Server()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/command/user/remove.go
+++ b/cli/command/user/remove.go
@@ -56,9 +56,11 @@ func removeUser(c cli.Interface, args []string) error {
 		}
 		c.Console().Println(name)
 	}
-
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))
+	}
+	if err := cli.RemoveFile(c.Server()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cli/preferences.go
+++ b/cli/preferences.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Preferences struct {
+	Org  string
+	Team string
+}
+
+const (
+	//Preferences suffix for file
+	preferences = "-preferences"
+)
+
+// SaveOrg saves the active org to file
+func SaveOrg(org string, server string) error {
+	existingPrefs, _ := readPreferences(server)
+	if existingPrefs == nil {
+		existingPrefs = &Preferences{}
+	}
+	existingPrefs.Org = org
+	if err := savePreferences(existingPrefs, server); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SaveTeam saves the active team to file
+func SaveTeam(team string, server string) error {
+	existingPrefs, _ := readPreferences(server)
+	if existingPrefs == nil {
+		existingPrefs = &Preferences{}
+	}
+	existingPrefs.Team = team
+	if err := savePreferences(existingPrefs, server); err != nil {
+		return err
+	}
+	return nil
+}
+
+// savePreferences saves the preferences to file
+func savePreferences(prefs *Preferences, server string) error {
+	ampPrefFile := strings.TrimSuffix(server, DefaultPort) + preferences + ".yml"
+	usr, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("cannot get current user: %s", err)
+	}
+	if err := os.MkdirAll(filepath.Join(usr.HomeDir, ampConfigFolder), os.ModePerm); err != nil {
+		return fmt.Errorf("cannot create folder: %s", err)
+	}
+	data, err := yaml.Marshal(prefs)
+	if err != nil {
+		return fmt.Errorf("cannot marshal preferences: %s", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(usr.HomeDir, ampConfigFolder, ampPrefFile), data, 0600); err != nil {
+		return fmt.Errorf("cannot write preferences: %s", err)
+	}
+	return nil
+}
+
+// ReadOrg reads the active org from file
+func ReadOrg(server string) (string, error) {
+	existingPrefs, err := readPreferences(server)
+	if err != nil {
+		return "", err
+	}
+	if existingPrefs.Org == "" {
+		return "", fmt.Errorf("invalid org")
+	}
+	return existingPrefs.Org, nil
+}
+
+// ReadTeam reads the active team from file
+func ReadTeam(server string) (string, error) {
+	existingPrefs, err := readPreferences(server)
+	if err != nil {
+		return "", err
+	}
+	if existingPrefs.Team == "" {
+		return "", fmt.Errorf("invalid team")
+	}
+	return existingPrefs.Team, nil
+}
+
+// readPreferences reads the preferences from file
+func readPreferences(server string) (*Preferences, error) {
+	ampPrefFile := strings.TrimSuffix(server, DefaultPort) + preferences + ".yml"
+	usr, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get current user: %s", err)
+	}
+	data, err := ioutil.ReadFile(filepath.Join(usr.HomeDir, ampConfigFolder, ampPrefFile))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read preferences: %s", err)
+	}
+	preferences := &Preferences{}
+	err = yaml.Unmarshal(data, &preferences)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal preferences: %s", err)
+	}
+	return preferences, nil
+}
+
+// RemoveFile removes the preferences file from the .config folder
+func RemoveFile(server string) error {
+	ampPrefFile := strings.TrimSuffix(server, DefaultPort) + preferences + ".yml"
+	usr, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("cannot get current user: %s", err)
+	}
+	filePath := filepath.Join(usr.HomeDir, ampConfigFolder, ampPrefFile)
+	_ = os.Remove(filePath)
+	return nil
+}

--- a/platform/tests/cli/pr-1148-error-hints.sh
+++ b/platform/tests/cli/pr-1148-error-hints.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# simulate that a cluster creation is already in progress
-cid=$(docker run --rm -d --name amp-bootstrap alpine:3.5 sleep 3 2>/dev/null)
-# we should get a hint to terminate the container
-amp -s localhost cluster create -t local 2>&1 | grep -q terminate
-ret=$?
-docker kill $cid >/dev/null 2>&1
-exit $ret

--- a/platform/tests/org/create/create_test.sh
+++ b/platform/tests/org/create/create_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org create --org=org --email=sample@user.amp | grep -q "Organization has been created."

--- a/platform/tests/org/get/get_test.sh
+++ b/platform/tests/org/get/get_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp org get org | grep -q "Organization: org"
+amp org get org | grep -q "Email: sample@user.amp"

--- a/platform/tests/org/list/list_test.sh
+++ b/platform/tests/org/list/list_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org ls | grep -q "org"

--- a/platform/tests/org/member/add/add_test.sh
+++ b/platform/tests/org/member/add/add_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org member add --member=user | grep -q "Member has been added to organization."

--- a/platform/tests/org/member/list/list_test.sh
+++ b/platform/tests/org/member/list/list_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp org member ls | grep -q "su"
+amp org member ls | grep -q "user"

--- a/platform/tests/org/member/role/role_test.sh
+++ b/platform/tests/org/member/role/role_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org member role --member=user --role=owner | grep -q "Member role has been changed."

--- a/platform/tests/org/member/setup.sh
+++ b/platform/tests/org/member/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp user signup --name user --password password --email email@user.amp --autologin=false

--- a/platform/tests/org/member/teardown.sh
+++ b/platform/tests/org/member/teardown.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+amp login --name user --password password
+amp user rm user
+amp login --name su --password password

--- a/platform/tests/org/switch/switch_test.sh
+++ b/platform/tests/org/switch/switch_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org switch org | grep -q "You are now logged in as: org"

--- a/platform/tests/org/teardown.sh
+++ b/platform/tests/org/teardown.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org rm org | grep -q "org"

--- a/platform/tests/team/create/create_test.sh
+++ b/platform/tests/team/create/create_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp team create --team=team --org=org | grep -q "Team has been created in the organization."

--- a/platform/tests/team/get/get_test.sh
+++ b/platform/tests/team/get/get_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp team get team | grep -q "Team: team"
+amp team get team | grep -q "Organization: org"

--- a/platform/tests/team/list/list_test.sh
+++ b/platform/tests/team/list/list_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp team ls | grep -q "team"

--- a/platform/tests/team/member/add/add_test.sh
+++ b/platform/tests/team/member/add/add_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp team member add --member=user | grep -q "Member has been added to team."

--- a/platform/tests/team/member/list/list_test.sh
+++ b/platform/tests/team/member/list/list_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp team member ls | grep -q "su"
+amp team member ls | grep -q "user"

--- a/platform/tests/team/member/remove/remove_test.sh
+++ b/platform/tests/team/member/remove/remove_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp team member rm user | grep -q "user"

--- a/platform/tests/team/member/setup.sh
+++ b/platform/tests/team/member/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp user signup --name user --password password --email email@user.amp --autologin=false
+amp org member add --member=user

--- a/platform/tests/team/member/teardown.sh
+++ b/platform/tests/team/member/teardown.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+amp login --name user --password password
+amp user rm user
+amp login --name su --password password

--- a/platform/tests/team/resource/add/add_test.sh
+++ b/platform/tests/team/resource/add/add_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ResId=$(amp stack ls -q)
+amp team resource add --org=org --team=team --res=$ResId |  grep -q "Resource has been added to team."

--- a/platform/tests/team/resource/list/list_test.sh
+++ b/platform/tests/team/resource/list/list_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ResId=$(amp stack ls -q)
+amp team resource ls | grep -q "$ResId"

--- a/platform/tests/team/resource/permission/permission_test.sh
+++ b/platform/tests/team/resource/permission/permission_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ResId=$(amp stack ls -q)
+amp team resource perm $ResId write | grep -q "Permission level has been changed."
+amp team resource ls | grep -q "TEAM_WRITE"

--- a/platform/tests/team/resource/remove/remove_test.sh
+++ b/platform/tests/team/resource/remove/remove_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ResId=$(amp stack ls -q)
+amp team resource rm $ResId | grep -q "$ResId"

--- a/platform/tests/team/resource/setup.sh
+++ b/platform/tests/team/resource/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+amp org switch org
+amp stack up -c examples/stacks/pinger/pinger.yml
+echo "done"

--- a/platform/tests/team/resource/teardown.sh
+++ b/platform/tests/team/resource/teardown.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp stack rm pinger

--- a/platform/tests/team/setup.sh
+++ b/platform/tests/team/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org create --org=org --email=sample@user.amp

--- a/platform/tests/team/teardown.sh
+++ b/platform/tests/team/teardown.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+amp team remove team | grep -q "team"
+amp org rm org


### PR DESCRIPTION
resolves: #1231 

Last used org/team is stored in a `'server'-preferences.yml` (localhost / cloud.appcelerator.io)

to test
```
$ make build-cli
$ amp cluster create --tag=local
$ amp org create --org=test --email=sample@email.com -> this will remember the org name now
$ amp org member ls
[user jgrahamjones @ localhost:50101]
organization name: test <- automatically entered
MEMBER         ROLE
jgrahamjones   ORGANIZATION_OWNER
$ amp org remove test
[user jgrahamjones @ localhost:50101]
test <- check the server-preferences.yml to see that the org is blank
```
There are a number of commands that this can be tested with.

