### PR TITLE
Update io-net agent computation

### DIFF
--- a/agent/metrics_io.go
+++ b/agent/metrics_io.go
@@ -10,17 +10,17 @@ import (
 // IOStats IO stats
 type IOStats struct {
 	Time   time.Time
-	Reads  uint64
-	Writes uint64
-	Totals uint64
+	Reads  float64
+	Writes float64
+	Totals float64
 }
 
 // IOStatsDiff diff between two IOStats
 type IOStatsDiff struct {
-	Duration int64
-	Reads    int64
-	Writes   int64
-	Totals   int64
+	Duration float64
+	Reads    float64
+	Writes   float64
+	Totals   float64
 }
 
 // publish one IO metrics event
@@ -35,9 +35,9 @@ func (a *Agent) setIOMetrics(data *ContainerData, statsData *types.StatsJSON, en
 		return
 	}
 	data.previousIOStats = io
-	entry.Io.Read += diff.Reads
-	entry.Io.Write += diff.Writes
-	entry.Io.Total += diff.Totals
+	entry.Io.Read += int64(diff.Reads)
+	entry.Io.Write += int64(diff.Writes)
+	entry.Io.Total += int64(diff.Totals)
 }
 
 // create new io stats
@@ -45,11 +45,11 @@ func (a *Agent) newIOStats(stats *types.StatsJSON) *IOStats {
 	var io = &IOStats{Time: stats.Read}
 	for _, s := range stats.BlkioStats.IoServicedRecursive {
 		if s.Op == "Read" {
-			io.Reads += s.Value
+			io.Reads += float64(s.Value)
 		} else if s.Op == "Write" {
-			io.Writes += s.Value
+			io.Writes += float64(s.Value)
 		} else if s.Op == "Total" {
-			io.Totals += s.Value
+			io.Totals += float64(s.Value)
 		}
 	}
 	return io
@@ -57,12 +57,12 @@ func (a *Agent) newIOStats(stats *types.StatsJSON) *IOStats {
 
 // create a new io diff computing difference between two io stats
 func (a *Agent) newIODiff(newIO *IOStats, previousIO *IOStats) *IOStatsDiff {
-	diff := &IOStatsDiff{Duration: int64(newIO.Time.Sub(previousIO.Time).Seconds())}
+	diff := &IOStatsDiff{Duration: float64(newIO.Time.Sub(previousIO.Time).Minutes())}
 	if diff.Duration <= 0 {
 		return nil
 	}
-	diff.Reads = int64(newIO.Reads-previousIO.Reads) / diff.Duration
-	diff.Writes = int64(newIO.Writes-previousIO.Writes) / diff.Duration
-	diff.Totals = int64(newIO.Totals-previousIO.Totals) / diff.Duration
+	diff.Reads = (newIO.Reads - previousIO.Reads) / diff.Duration
+	diff.Writes = (newIO.Writes - previousIO.Writes) / diff.Duration
+	diff.Totals = (newIO.Totals - previousIO.Totals) / diff.Duration
 	return diff
 }

--- a/agent/metrics_net.go
+++ b/agent/metrics_net.go
@@ -10,27 +10,27 @@ import (
 // NetStats net stats
 type NetStats struct {
 	Time      time.Time
-	RxBytes   uint64
-	RxDropped uint64
-	RxErrors  uint64
-	RxPackets uint64
-	TxBytes   uint64
-	TxDropped uint64
-	TxErrors  uint64
-	TxPackets uint64
+	RxBytes   float64
+	RxDropped float64
+	RxErrors  float64
+	RxPackets float64
+	TxBytes   float64
+	TxDropped float64
+	TxErrors  float64
+	TxPackets float64
 }
 
 // NetStatsDiff diff between two IOStats
 type NetStatsDiff struct {
-	Duration  int64
-	RxBytes   int64
-	RxDropped int64
-	RxErrors  int64
-	RxPackets int64
-	TxBytes   int64
-	TxDropped int64
-	TxErrors  int64
-	TxPackets int64
+	Duration  float64
+	RxBytes   float64
+	RxDropped float64
+	RxErrors  float64
+	RxPackets float64
+	TxBytes   float64
+	TxDropped float64
+	TxErrors  float64
+	TxPackets float64
 }
 
 // publish one net metrics event
@@ -45,46 +45,46 @@ func (a *Agent) setNetMetrics(data *ContainerData, statsData *types.StatsJSON, e
 		return
 	}
 	data.previousNetStats = net
-	entry.Net.TotalBytes += diff.RxBytes + diff.TxBytes
-	entry.Net.RxBytes += diff.RxBytes
-	entry.Net.RxDropped += diff.RxDropped
-	entry.Net.RxErrors += diff.RxErrors
-	entry.Net.RxPackets += diff.RxPackets
-	entry.Net.TxBytes += diff.TxBytes
-	entry.Net.TxDropped += diff.TxDropped
-	entry.Net.TxErrors += diff.TxErrors
-	entry.Net.TxPackets += diff.TxPackets
+	entry.Net.TotalBytes += int64(diff.RxBytes + diff.TxBytes)
+	entry.Net.RxBytes += int64(diff.RxBytes)
+	entry.Net.RxDropped += int64(diff.RxDropped)
+	entry.Net.RxErrors += int64(diff.RxErrors)
+	entry.Net.RxPackets += int64(diff.RxPackets)
+	entry.Net.TxBytes += int64(diff.TxBytes)
+	entry.Net.TxDropped += int64(diff.TxDropped)
+	entry.Net.TxErrors += int64(diff.TxErrors)
+	entry.Net.TxPackets += int64(diff.TxPackets)
 }
 
 // create a new net stats
 func (a *Agent) newNetStats(stats *types.StatsJSON) *NetStats {
 	var net = &NetStats{Time: stats.Read}
 	for _, netStats := range stats.Networks {
-		net.RxBytes += netStats.RxBytes
-		net.RxDropped += netStats.RxDropped
-		net.RxErrors += netStats.RxErrors
-		net.RxPackets += netStats.RxPackets
-		net.TxBytes += netStats.TxBytes
-		net.TxDropped += netStats.TxDropped
-		net.TxErrors += netStats.TxErrors
-		net.TxPackets += netStats.TxPackets
+		net.RxBytes += float64(netStats.RxBytes)
+		net.RxDropped += float64(netStats.RxDropped)
+		net.RxErrors += float64(netStats.RxErrors)
+		net.RxPackets += float64(netStats.RxPackets)
+		net.TxBytes += float64(netStats.TxBytes)
+		net.TxDropped += float64(netStats.TxDropped)
+		net.TxErrors += float64(netStats.TxErrors)
+		net.TxPackets += float64(netStats.TxPackets)
 	}
 	return net
 }
 
 // create a new net diff computing difference between two net stats
 func (a *Agent) newNetDiff(newNet *NetStats, previousNet *NetStats) *NetStatsDiff {
-	diff := &NetStatsDiff{Duration: int64(newNet.Time.Sub(previousNet.Time).Seconds())}
+	diff := &NetStatsDiff{Duration: float64(newNet.Time.Sub(previousNet.Time).Minutes())}
 	if diff.Duration <= 0 {
 		return nil
 	}
-	diff.RxBytes = int64(newNet.RxBytes-previousNet.RxBytes) / diff.Duration
-	diff.RxDropped = int64(newNet.RxDropped-previousNet.RxDropped) / diff.Duration
-	diff.RxErrors = int64(newNet.RxErrors-previousNet.RxErrors) / diff.Duration
-	diff.RxPackets = int64(newNet.RxPackets-previousNet.RxPackets) / diff.Duration
-	diff.TxBytes = int64(newNet.TxBytes-previousNet.TxBytes) / diff.Duration
-	diff.TxDropped = int64(newNet.TxDropped-previousNet.TxDropped) / diff.Duration
-	diff.TxErrors = int64(newNet.TxErrors-previousNet.TxErrors) / diff.Duration
-	diff.TxPackets = int64(newNet.TxPackets-previousNet.TxPackets) / diff.Duration
+	diff.RxBytes = (newNet.RxBytes - previousNet.RxBytes) / diff.Duration
+	diff.RxDropped = (newNet.RxDropped - previousNet.RxDropped) / diff.Duration
+	diff.RxErrors = (newNet.RxErrors - previousNet.RxErrors) / diff.Duration
+	diff.RxPackets = (newNet.RxPackets - previousNet.RxPackets) / diff.Duration
+	diff.TxBytes = (newNet.TxBytes - previousNet.TxBytes) / diff.Duration
+	diff.TxDropped = (newNet.TxDropped - previousNet.TxDropped) / diff.Duration
+	diff.TxErrors = (newNet.TxErrors - previousNet.TxErrors) / diff.Duration
+	diff.TxPackets = (newNet.TxPackets - previousNet.TxPackets) / diff.Duration
 	return diff
 }

--- a/cli/command/stats/stats.go
+++ b/cli/command/stats/stats.go
@@ -206,10 +206,10 @@ func getOneStatLine(query *stats.StatsRequest, entry *stats.MetricsEntry) string
 		line = fmt.Sprintf("%s\t%s\t%s\t%.1f%%", line, formatBytes(entry.Mem.Usage), formatBytes(entry.Mem.Limit), entry.Mem.UsageP*100)
 	}
 	if query.StatsIo {
-		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Io.Read), formatBytes(entry.Io.Write))
+		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Io.Read/60), formatBytes(entry.Io.Write/60))
 	}
 	if query.StatsNet {
-		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Net.RxBytes), formatBytes(entry.Net.TxBytes))
+		line = fmt.Sprintf("%s\t%s/s\t%s/s", line, formatBytes(entry.Net.RxBytes/60), formatBytes(entry.Net.TxBytes/60))
 	}
 	return line
 }


### PR DESCRIPTION

Improve the precision of the IO and NET agent Metrics agent computation

## test

- ampmake rebuild-agent
- amp -s localhost cluster create -t local
- amp -s localhost stats -i  -> net and io are more accurate

 