### PR TITLE
Add support to amp makefile to sub-make amp aws plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,40 @@ push-bootstrap:
 	@$(AMPBOOTDIR)/build
 
 # =============================================================================
+# BUILD CLUSTER PLUGINS (`amp-aws`)
+# Needed for `amp cluster init` CLI command support.
+# Plugins are located under `cluster/plugin`
+# =============================================================================
+CPDIR := cluster/plugin
+CPAWSDIR := $(CPDIR)/aws
+
+.PHONY: build-amp-aws-compiler
+build-amp-aws-compiler:
+	@cd $(CPAWSDIR) && $(MAKE) compiler
+
+.PHONY: build-amp-aws
+build-amp-aws: build-amp-aws-compiler
+	@cd $(CPAWSDIR) && $(MAKE) build
+
+# WARNING:
+# If the environment variables for $KEYNAME and $REGION are not set, the
+# test will fail with misleading error output:
+# docker run -it --rm -v /root/.aws:/root/.aws -v /go/src/github.com/appcelerator/amp/cluster/plugin/aws:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+#          -w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
+#          -e KEYNAME= \
+#          -e REGION= \
+#          appcelerator/amp-aws-compiler test -v -timeout 30m
+#  can't load package: package github.com/appcelerator/amp/cluster/plugin/aws: no buildable Go source files in /go/src/github.com/appcelerator/amp/cluster/plugin/aws
+#  Makefile:21: recipe for target 'test' failed
+#
+# To succeed, ensure that these environment variables have values, like this:
+# $ KEYNAME=tony-amp-dev REGION=us-west-2 make test-amp-aws
+#
+.PHONY: test-amp-aws
+test-amp-aws: build-amp-aws
+	@cd $(CPAWSDIR) && $(MAKE) test
+
+# =============================================================================
 # Quality checks
 # =============================================================================
 CHECKDIRS := agent api cli cmd data tests $(COMMONDIRS)
@@ -392,3 +426,4 @@ env:
 # =============================================================================
 
 check: fmt buildall lint-fast
+

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -6,21 +6,23 @@ build: aws.alpine
 aws.alpine: $(SRC)
 	docker run -it --rm -v $${PWD}:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
-		go:aws build -o aws.alpine cmd/main.go
+		appcelerator/amp-aws-compiler build -o aws.alpine cmd/main.go
 
 .PHONY: compiler
 compiler:
-	docker build -f Dockerfile.compiler -t go:aws .
+	docker build -f Dockerfile.compiler -t appcelerator/amp-aws-compiler .
 
 .PHONY: clean
 clean:
 	rm -f aws.alpine
 
 .PHONY: test
-test:
+test: build
 	docker run -it --rm -v $(HOME)/.aws:/root/.aws -v $(PWD):/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-e KEYNAME=$(KEYNAME) \
 		-e REGION=$(REGION) \
-		go:aws test -v -timeout 30m
+		appcelerator/amp-aws-compiler test -v -timeout 30m
 
+pwd:
+	echo $(PWD)

--- a/cluster/plugin/aws/README.md
+++ b/cluster/plugin/aws/README.md
@@ -11,6 +11,22 @@ AMP cli.
 For more details about the design and use, see the
 [wiki](https://github.com/appcelerator/amp/wiki/AWS-Clusters).
 
+# Build
+
+`make compiler` builds an Alpine image (`appcelerator/amp-aws-compiler`) with
+a Go compiler, the AWS SDK package, and other necessary packages to to build 
+the `appcelerator/amp-aws` image to be used as a cluster plugin by AMP.
+
+An automated build for the repo also creates the `appcelerator/amp-aws-compiler`
+image on [Docker Hub](https://hub.docker.com/r/appcelerator/amp-aws-compiler/).
+
+`make` (or `make build`) builds `appcelerator/amp-aws`.
+
+`make clean` removes the target binary (`aws.alpine`) that is created by the
+compiler to be copied into the `appcelerator/amp-aws` image when building it.
+
+`make test` uses `appcelerator/amp-aws` to create, update, and remove test stacks.
+
 ### Options
 
 The plugin allows you to provide all the parameters that are supported by the [Docker for AWS CloudFormation template](https://docs.docker.com/docker-for-aws/#configuration-options), including:


### PR DESCRIPTION
Updates `cluster/plugin/aws/Makefile` and adds sub-make support to the amp `Makefile`.

Using amp Makefile chained to 

* `make build-amp-aws-compiler` -> (`cluster/plugin/aws`) `make compiler`
* `make build-amp-aws` -> (`cluster/plugin/aws`) `make` (or `make build`)
* `make test-amp-aws` -> (`cluster/plugin/aws`) `make test`

**NOTE:**
If you do not set `KEYNAME` and `REGION` environment variables, then `amp test`
will fail with a misleading error message, as shown below:

```
docker run -it --rm -v /root/.aws:/root/.aws -v /go/src/github.com/appcelerator/amp/cluster/plugin/aws:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
        -w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
        -e KEYNAME= \
        -e REGION= \
        appcelerator/amp-aws-compiler test -v -timeout 30m
can't load package: package github.com/appcelerator/amp/cluster/plugin/aws: no buildable Go source files in /go/src/github.com/appcelerator/amp/cluster/plugin/aws
Makefile:21: recipe for target 'test' failed
```

Ensure you set KEYNAME and REGION with valid values, like this:

    $ KEYNAME=tony-amp-dev REGION=us-west-2 make test-amp-aws

## Verification

The following command should succeed (will take around 15 minutes):

```
$ make build-amp-aws-compiler build-amp-aws test-amp-aws
. . .
docker run -it --rm -v /Users/tony/.aws:/root/.aws -v /Users/tony/go/src/github.com/appcelerator/amp/cluster/plugin/aws:/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
                -w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
                -e KEYNAME=tony-amp-dev \
                -e REGION=us-west-2 \
                appcelerator/amp-aws-compiler test -v -timeout 30m
=== RUN   TestCreate
2017/06/17 19:53:09 starting test...
2017/06/17 19:53:11 {
  StackId: "arn:aws:cloudformation:us-west-2:654814900965:stack/tony-amp-dev-plugin-test-47bf4064-8f97-43b0-81b1-ea31042cb085/95efccd0-5396-11e7-a98b-50d5ca2e7cd2"
}
2017/06/17 19:53:11 creating stack...
2017/06/17 20:00:46 stack created: tony-amp-dev-plugin-test-47bf4064-8f97-43b0-81b1-ea31042cb085
2017/06/17 20:00:47 {
  StackId: "arn:aws:cloudformation:us-west-2:654814900965:stack/tony-amp-dev-plugin-test-47bf4064-8f97-43b0-81b1-ea31042cb085/95efccd0-5396-11e7-a98b-50d5ca2e7cd2"
}
2017/06/17 20:00:47 updating stack...
2017/06/17 20:01:48 stack updated: tony-amp-dev-plugin-test-47bf4064-8f97-43b0-81b1-ea31042cb085
2017/06/17 20:01:49 {

}
2017/06/17 20:01:49 deleting stack...
2017/06/17 20:09:56 stack deleted: tony-amp-dev-plugin-test-47bf4064-8f97-43b0-81b1-ea31042cb085
--- PASS: TestCreate (1006.53s)
PASS
ok      github.com/appcelerator/amp/cluster/plugin/aws  1006.541s
```

