### PR TITLE
Ensure required env vars set for test`

### DIFF
--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -18,11 +18,11 @@ clean:
 
 .PHONY: test
 test: build
+	@: "$${KEYNAME:?KEYNAME environment variable null, empty, or not set}"
+	@: "$${REGION:?REGION environment variable null, empty, or not set}"
 	docker run -it --rm -v $(HOME)/.aws:/root/.aws -v $(PWD):/go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-w /go/src/github.com/appcelerator/amp/cluster/plugin/aws \
 		-e KEYNAME=$(KEYNAME) \
 		-e REGION=$(REGION) \
 		appcelerator/amp-aws-compiler test -v -timeout 30m
 
-pwd:
-	echo $(PWD)

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -12,14 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	templateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
-)
-
-func initSession() {
-
-}
-
 var (
 	opts = &plugin.RequestOptions{
 		OnFailure: "ROLLBACK",


### PR DESCRIPTION
## Verification

    make test-amp-aws
    # should exit with error due to missing KEYNAME or REGION env var

    KEYNAME=keyname REGION=region make test-amp-aws
    # should succeed with valid keyname and region values

