### PR TITLE
Allow --template parameter for aws plugin

### DIFF
--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -99,6 +99,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&opts.StackName, "stackname", "n", "", "aws stack name")
 	rootCmd.PersistentFlags().StringSliceVarP(&opts.Params, "parameter", "p", []string{}, "parameter")
 	rootCmd.PersistentFlags().BoolVarP(&opts.Sync, "sync", "s", false, "block until operation is complete")
+	rootCmd.PersistentFlags().StringVarP(&opts.TemplateURL, "template", "t", plugin.DefaultTemplateURL, "cloud formation template url")
 
 	initCmd := &cobra.Command{
 		Use:   "init",

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	templateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
+	DefaultTemplateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
 )
 
 // RequestOptions stores raw request input options before transformation into a AWS SDK specific
@@ -27,6 +27,8 @@ type RequestOptions struct {
 	StackName string
 
 	Sync bool
+
+	TemplateURL string
 }
 
 func parseParam(s string) *cf.Parameter {
@@ -61,7 +63,7 @@ func CreateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 		},
 		OnFailure:        aws.String(opts.OnFailure),
 		Parameters:       toParameters(opts.Params),
-		TemplateURL:      aws.String(templateURL),
+		TemplateURL:      aws.String(DefaultTemplateURL),
 		TimeoutInMinutes: aws.Int64(timeout),
 	}
 
@@ -75,7 +77,7 @@ func UpdateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 			aws.String("CAPABILITY_IAM"),
 		},
 		Parameters:       toParameters(opts.Params),
-		TemplateURL:      aws.String(templateURL),
+		TemplateURL:      aws.String(DefaultTemplateURL),
 	}
 
 	return svc.UpdateStackWithContext(ctx, input)

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -63,7 +63,7 @@ func CreateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 		},
 		OnFailure:        aws.String(opts.OnFailure),
 		Parameters:       toParameters(opts.Params),
-		TemplateURL:      aws.String(DefaultTemplateURL),
+		TemplateURL:      aws.String(opts.TemplateURL),
 		TimeoutInMinutes: aws.Int64(timeout),
 	}
 
@@ -76,8 +76,8 @@ func UpdateStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 		Capabilities: []*string{
 			aws.String("CAPABILITY_IAM"),
 		},
-		Parameters:       toParameters(opts.Params),
-		TemplateURL:      aws.String(DefaultTemplateURL),
+		Parameters:  toParameters(opts.Params),
+		TemplateURL: aws.String(opts.TemplateURL),
 	}
 
 	return svc.UpdateStackWithContext(ctx, input)


### PR DESCRIPTION
Override the default Docker for AWS cloudformation template by specifying a url to a template with the `-t | --template` option.