### PR TITLE
Cloudformation template customized for AMP

### DIFF
--- a/examples/clusters/README.md
+++ b/examples/clusters/README.md
@@ -1,0 +1,54 @@
+# Cloudformation templates for Docker Swarm cluster creation on AWS
+
+## How to use
+
+Use the aws cli or the console to deploy a swarm cluster.
+It is compatible with regions us-east-1, us-east-2, us-west-2, eu-west-1 and ap-southeast-2.
+
+Alternatively it can be used through the aws plugin of AMP:
+
+    docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws:latest init --region us-west-2 --stackname STACKNAME --parameter KeyName=KEYNAME --parameter ConfigurationURL=https://raw.githubusercontent.com/appcelerator/amp/cloudformation-for-amp/examples/clusters --parameter OverlayNetworks=public --parameter DockerChannel=edge --template https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
+
+## Content
+
+The template will create the infrastructure (1 VPC, 3 subnets for HA on 3 datacenters, security groups, internet gateway, instance profile), 1 autoscaling group for the manager nodes, 1 autoscaling group for the amp core services worker nodes, 1 autoscaling group for the amp monitoring services worker nodes and 1 autoscaling group for the user services worker nodes.
+Each autoscaling group run a userdata that initializes or join the swarm depending on the nature of the group and depending on the status of the swarm.
+The engine API of all managers are available from all nodes in the VPC, which allow to set the labels on the nodes.
+
+It is ready for the deployment of AMP, with the help of the CLI on one of the manager nodes:
+
+    amp -s localhost -p local
+
+or the development version:
+
+    amp -s localhost -p local --tag latest
+
+## Parameters
+
+| Parameter | Description | Default Value | Example |
+| --------- | ----------- | ------------- | ------- |
+| KeyName   | Name of an existing EC2 KeyPair to enable SSH access to the instances | - | YOURNAME-REGION |
+| ManagerSize | Number of manager nodes, should be 1, 3 or 5 | 3 | |
+| CoreWorkerSize | Number of worker nodes for core services | 3 | |
+| UserWorkerSize | Number of worker nodes for user services | 3 | |
+| MetricsWorkerSize | Number of worker nodes for metrics services | 1 | |
+| LinuxDistribution | AMI OS, Debian or Ubuntu | Ubuntu | Debian |
+| ManagerInstanceType | Instance type for the manager nodes. Must be a valid EC2 HVM instance type | t2.small | m4.large |
+| CoreInstanceType | Instance type for the core worker nodes. Must be a valid EC2 HVM instance type | m4.large | c4.large |
+| UserInstanceType | Instance type for the user worker nodes. Must be a valid EC2 HVM instance type | t2.medium | m4.large |
+| MetricsInstanceType | Instance type for the metrics worker nodes. Must be a valid EC2 HVM instance type | t2.large | m4.large |
+| DrainManager | Should we drain services from the manager nodes? | false | true |
+| ConfigurationURL | URL for manager and worker userdata configuration | https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters | |
+| AufsVolumeSize | Size in GB of the EBS for the /var/lib/docker FS | 26 | 100 |
+| OverlayNetworks | name of overlay networks that should be created once swarm is initialized | ampnet | public storage search mq |
+| DockerChannel | channel for Docker installation | stable | edge |
+| DockerPlugins | space separated list of plugins to install | | rexray/ebs |
+
+## Output
+
+The output of the stack lists the DNS name of the ELB in front of the manager nodes. It can be used for ssh access, https access to swarm services and configuration of the remote server in the CLI (--server option).
+
+| Output | Description | 
+| --------- | ----------- |
+| DNSTarget | public facing endpoint for the cluster, It can be used for ssh access, https access to swarm services and configuration of the remote server in the CLI |
+| MetricsURL | URL for cluster health dashboard |

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -1,0 +1,1170 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Swarm cluster with autoscaling groups
+
+Mappings:
+  AMI:
+    # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170330
+    # debian-jessie-amd64-hvm-2017-01-15
+    ap-southeast-2:
+      Ubuntu: ami-92e8e6f1
+      Debian: ami-0dcac96e
+    eu-west-1:
+      Ubuntu: ami-b5a893d3
+      Debian: ami-3291be54
+    us-east-1:
+      Ubuntu: ami-e4139df2
+      Debian: ami-cb4b94dd
+    us-east-2:
+      Ubuntu: ami-33ab8f56
+      Debian: ami-c5ba9fa0
+    us-west-2:
+      Ubuntu: ami-17ba2a77
+      Debian: ami-fde96b9d
+  VpcCidrs:
+    subnet1:
+      cidr: 192.168.0.0/24
+    subnet2:
+      cidr: 192.168.16.0/24
+    subnet3:
+      cidr: 192.168.32.0/24
+    vpc:
+      cidr: 192.168.0.0/16
+
+Parameters:
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    MinLength: '1'
+  ManagerSize:
+    Type: Number
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+    Default: 3
+    Description: depending on your HA requirements, should be 1, 3 or 5
+  CoreWorkerSize:
+    Type: Number
+    Default: 3
+    MinValue: 1
+    MaxValue: 9
+    Description: "3 nodes for HA is a safe choice"
+  UserWorkerSize:
+    Type: Number
+    Default: 3
+    MinValue: 1
+    MaxValue: 1000
+    Description: "A good starting point is 3 nodes"
+  MetricsWorkerSize:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 1
+    Description: "single node only for now"
+  LinuxDistribution:
+    Type: String
+    AllowedValues:
+    - Ubuntu
+    - Debian
+    Default: Ubuntu
+  ManagerInstanceType:
+    Type: String
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - m3.medium
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.small
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
+  CoreWorkerInstanceType:
+    Type: String
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - m3.medium
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: m4.large
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
+  UserWorkerInstanceType:
+    Type: String
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - m3.medium
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.medium
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
+  MetricsWorkerInstanceType:
+    Type: String
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - m3.medium
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.large
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
+  DrainManager:
+    Type: String
+    Description: If true, disables the services on the manager nodes
+    AllowedValues:
+    - false
+    - true
+    Default: false
+  ConfigurationURL:
+    Type: String
+    ConstraintDescription: must be an URL.
+    Description: URL for manager and worker userdata configuration
+    Default: https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters
+    AllowedPattern: "https?://[0-9a-z\\.-]+\\.[a-z\\.]{2,6}[/\\w\\.-]*/?"
+  AufsVolumeSize:
+    Type: Number
+    Description: Size in GB of the EBS volume for the Docker AUFS storage on each node (mounted on /dev/xvdl)
+    Default: 26
+    MinValue: 1
+    MaxValue: 16384
+  OverlayNetworks:
+    Type: String
+    Description: Docker overlay networks to create on the swarm, separated by space
+    Default: ampnet
+  DockerChannel:
+    Type: String
+    Default: stable
+    AllowedValues:
+    - stable
+    - edge
+  DockerPlugins:
+    Type: String
+    Description: "space separated list of plugins to install. Example: rexray/ebs"
+    Default: ""
+
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - vpc
+        - cidr
+      EnableDnsHostnames: 'true'
+      EnableDnsSupport: 'true'
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - VPC
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: Vpc
+    Properties:
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - IGW
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    DependsOn:
+    - Vpc
+    - InternetGateway
+    Properties:
+      InternetGatewayId:
+        Ref: InternetGateway
+      VpcId:
+        Ref: Vpc
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: Vpc
+    Properties:
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - RT
+      VpcId:
+        Ref: Vpc
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn:
+    - AttachGateway
+    - RouteTable
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: InternetGateway
+      RouteTableId:
+        Ref: RouteTable
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    DependsOn: Vpc
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '0'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - subnet1
+        - cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - PublicSubnet1
+      VpcId:
+        Ref: Vpc
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    DependsOn: Vpc
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - subnet2
+        - cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - PublicSubnet2
+      VpcId:
+        Ref: Vpc
+  PublicSubnet3:
+    Type: AWS::EC2::Subnet
+    DependsOn: Vpc
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '2'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Fn::FindInMap:
+        - VpcCidrs
+        - subnet3
+        - cidr
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - PublicSubnet3
+      VpcId:
+        Ref: Vpc
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+    - PublicSubnet1
+    - RouteTable
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: PublicSubnet1
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+    - PublicSubnet2
+    - RouteTable
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: PublicSubnet2
+  PublicSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+    - PublicSubnet3
+    - RouteTable
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: PublicSubnet3
+  ManagerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: Manager nodes security group
+      SecurityGroupIngress:
+      # engine API open from all VPC
+      - SourceSecurityGroupId:
+          !Ref CoreSecurityGroup
+        IpProtocol: tcp
+        FromPort: '2375'
+        ToPort: '2375'
+      - SourceSecurityGroupId:
+          !Ref UserSecurityGroup
+        IpProtocol: tcp
+        FromPort: '2375'
+        ToPort: '2375'
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '2375'
+        ToPort: '2375'
+      # docker swarm join
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '2377'
+        ToPort: '2377'
+      # node communication
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '7946'
+        ToPort: '7946'
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '7946'
+        ToPort: '7946'
+      # overlay network traffic
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '4789'
+        ToPort: '4789'
+      # node exporter
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9100'
+        ToPort: '9100'
+      # docker metrics
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9323'
+        ToPort: '9323'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '50101'
+        ToPort: '50101'
+      VpcId:
+        Ref: Vpc
+  ManagerSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId:
+        Ref: ManagerSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId:
+        Ref: ManagerSecurityGroup
+
+  CoreSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: Core services security group
+      SecurityGroupIngress:
+      # node communication
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '7946'
+        ToPort: '7946'
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '7946'
+        ToPort: '7946'
+      # overlay network traffic
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '4789'
+        ToPort: '4789'
+      # node exporter
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9100'
+        ToPort: '9100'
+      # docker metrics
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9323'
+        ToPort: '9323'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '50101'
+        ToPort: '50101'
+      VpcId:
+        Ref: Vpc
+  CoreSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId:
+        Ref: CoreSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId:
+        Ref: CoreSecurityGroup
+
+  UserSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: User services security group
+      SecurityGroupIngress:
+      # node communication
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '7946'
+        ToPort: '7946'
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '7946'
+        ToPort: '7946'
+      # overlay network traffic
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '4789'
+        ToPort: '4789'
+      # node exporter
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9100'
+        ToPort: '9100'
+      # docker metrics
+      - SourceSecurityGroupId:
+          !Ref MetricsSecurityGroup
+        IpProtocol: tcp
+        FromPort: '9323'
+        ToPort: '9323'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '50101'
+        ToPort: '50101'
+      VpcId:
+        Ref: Vpc
+  UserSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId:
+        Ref: UserSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId:
+        Ref: UserSecurityGroup
+
+  MetricsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: Monitoring services security group
+      SecurityGroupIngress:
+      # node communication
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '7946'
+        ToPort: '7946'
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '7946'
+        ToPort: '7946'
+      # overlay network traffic
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: udp
+        FromPort: '4789'
+        ToPort: '4789'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '3000'
+        ToPort: '3000'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '9090'
+        ToPort: '9090'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '50101'
+        ToPort: '50101'
+      VpcId:
+        Ref: Vpc
+  MetricsSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId:
+        Ref: MetricsSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId:
+        Ref: MetricsSecurityGroup
+
+  ClusterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: '2012-10-17'
+      Path: /
+  ClusterPolicies:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Action:
+          - 'ec2:DescribeInstances'
+          - 'ec2:DescribeVolume*'
+          - 'ec2:AttachVolume'
+          - 'ec2:DetachVolume'
+          - 'ec2:CreateVolume'
+          - 'ec2:CreateTags'
+          - 'ec2:ModifyInstanceAttribute'
+          - 'ec2:DescribeAvailabilityZones'
+          Resource: '*'
+          Effect: Allow
+        Version: '2012-10-17'
+      PolicyName: cluster-policy
+      Roles:
+      - Ref: ClusterRole
+  ClusterInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+      - Ref: ClusterRole
+  MetricsWorkerAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT30S
+        WaitOnResourceSignals: false
+    Properties:
+      DesiredCapacity: !Ref MetricsWorkerSize
+      HealthCheckGracePeriod: 200
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref MetricsWorkerAsgLaunchConfig
+      MaxSize: 5
+      MinSize: 0
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - worker
+            - metrics
+      - Key: atomiq.clusterid
+        PropagateAtLaunch: true
+        Value: !Ref AWS::StackName
+      - Key: SwarmRole
+        PropagateAtLaunch: true
+        Value: worker
+      VPCZoneIdentifier:
+      - Fn::Join:
+        - ','
+        -  - !Ref PublicSubnet1
+           - !Ref PublicSubnet2
+           - !Ref PublicSubnet3
+  MetricsWorkerAsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn:
+      - CoreWorkerAutoScalingGroup
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref ClusterInstanceProfile
+      ImageId:
+        Fn::FindInMap:
+        - AMI
+        - Ref: AWS::Region
+        - Ref: LinuxDistribution
+      InstanceType: !Ref MetricsWorkerInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: MetricsSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdl
+          Ebs:
+            VolumeSize: !Ref AufsVolumeSize
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64:
+          !Sub
+            - |
+              #cloud-config
+              repo_update: true
+              repo_upgrade: security
+              packages:
+                - ca-certificates
+                - jq
+                - curl
+                - unzip
+                - awscli
+                - sysstat
+                - iotop
+                - xfsprogs
+              runcmd:
+                - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
+                - chmod +x /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+            - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
+  CoreWorkerAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT30S
+        WaitOnResourceSignals: false
+    Properties:
+      DesiredCapacity: !Ref CoreWorkerSize
+      HealthCheckGracePeriod: 200
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref CoreWorkerAsgLaunchConfig
+      MaxSize: 5
+      MinSize: 0
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - worker
+            - core
+      - Key: atomiq.clusterid
+        PropagateAtLaunch: true
+        Value: !Ref AWS::StackName
+      - Key: SwarmRole
+        PropagateAtLaunch: true
+        Value: worker
+      VPCZoneIdentifier:
+      - Fn::Join:
+        - ','
+        -  - !Ref PublicSubnet1
+           - !Ref PublicSubnet2
+           - !Ref PublicSubnet3
+  CoreWorkerAsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn:
+      - ManagerAutoScalingGroup
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref ClusterInstanceProfile
+      ImageId:
+        Fn::FindInMap:
+        - AMI
+        - Ref: AWS::Region
+        - Ref: LinuxDistribution
+      InstanceType: !Ref CoreWorkerInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: CoreSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdl
+          Ebs:
+            VolumeSize: !Ref AufsVolumeSize
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64:
+          !Sub
+            - |
+              #cloud-config
+              repo_update: true
+              repo_upgrade: security
+              packages:
+                - ca-certificates
+                - jq
+                - curl
+                - unzip
+                - awscli
+                - sysstat
+                - iotop
+                - xfsprogs
+              runcmd:
+                - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
+                - chmod +x /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+            - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
+  UserWorkerAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT30S
+        WaitOnResourceSignals: false
+    Properties:
+      DesiredCapacity: !Ref UserWorkerSize
+      HealthCheckGracePeriod: 200
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref UserWorkerAsgLaunchConfig
+      MaxSize: 5
+      MinSize: 0
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - worker
+            - user
+      - Key: atomiq.clusterid
+        PropagateAtLaunch: true
+        Value: !Ref AWS::StackName
+      - Key: SwarmRole
+        PropagateAtLaunch: true
+        Value: worker
+      VPCZoneIdentifier:
+      - Fn::Join:
+        - ','
+        -  - !Ref PublicSubnet1
+           - !Ref PublicSubnet2
+           - !Ref PublicSubnet3
+  UserWorkerAsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn:
+      - CoreWorkerAutoScalingGroup
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref ClusterInstanceProfile
+      ImageId:
+        Fn::FindInMap:
+        - AMI
+        - Ref: AWS::Region
+        - Ref: LinuxDistribution
+      InstanceType: !Ref UserWorkerInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: UserSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdl
+          Ebs:
+            VolumeSize: !Ref AufsVolumeSize
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64:
+          !Sub
+            - |
+              #cloud-config
+              repo_update: true
+              repo_upgrade: security
+              packages:
+                - ca-certificates
+                - jq
+                - curl
+                - unzip
+                - awscli
+                - sysstat
+                - iotop
+                - xfsprogs
+              runcmd:
+                - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
+                - chmod +x /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+            - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
+  ManagerAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT3M
+        WaitOnResourceSignals: false
+    Properties:
+      DesiredCapacity: !Ref ManagerSize
+      HealthCheckGracePeriod: 200
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref ManagerAsgLaunchConfig
+      MaxSize: 5
+      MinSize: 0
+      LoadBalancerNames:
+      - !Ref ManagerInternalELB
+      - !Ref ManagerExternalELB
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - manager
+      - Key: atomiq.clusterid
+        PropagateAtLaunch: true
+        Value: !Ref AWS::StackName
+      - Key: SwarmRole
+        PropagateAtLaunch: true
+        Value: manager
+      VPCZoneIdentifier:
+      - Fn::Join:
+        - ','
+        -  - !Ref PublicSubnet1
+           - !Ref PublicSubnet2
+           - !Ref PublicSubnet3
+  ManagerAsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref ClusterInstanceProfile
+      ImageId:
+        Fn::FindInMap:
+        - AMI
+        - Ref: AWS::Region
+        - Ref: LinuxDistribution
+      InstanceType: !Ref ManagerInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: ManagerSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdl
+          Ebs:
+            VolumeSize: !Ref AufsVolumeSize
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64:
+          !Sub
+            - |
+              #cloud-config
+              repo_update: true
+              repo_upgrade: security
+              packages:
+                - ca-certificates
+                - jq
+                - curl
+                - unzip
+                - awscli
+                - sysstat
+                - iotop
+                - xfsprogs
+              runcmd:
+                - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/asg-init.sh
+                - chmod +x /usr/local/bin/asg-init.sh
+                - CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${ConfigurationURL} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/asg-init.sh
+            - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
+  ManagerInternalELB:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      Scheme: internal
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+        - !Ref PublicSubnet3
+      SecurityGroups:
+        - Ref: ManagerSecurityGroup
+      CrossZone: true
+      Listeners:
+      - LoadBalancerPort: '2375'
+        InstancePort: '2375'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '2377'
+        InstancePort: '2377'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      HealthCheck:
+        Target: TCP:2375
+        HealthyThreshold: 3
+        UnhealthyThreshold: 5
+        Interval: 30
+        Timeout: 5
+      ConnectionDrainingPolicy:
+        Enabled: 'true'
+        Timeout: '60'
+  ManagerExternalELB:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+        - !Ref PublicSubnet3
+      SecurityGroups:
+        - Ref: ManagerSecurityGroup
+      CrossZone: true
+      Listeners:
+      - LoadBalancerPort: '22'
+        InstancePort: '22'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '80'
+        InstancePort: '80'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '443'
+        InstancePort: '443'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '50101'
+        InstancePort: '50101'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      ConnectionDrainingPolicy:
+        Enabled: 'true'
+        Timeout: '60'
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Cluster Properties
+      Parameters:
+      - KeyName
+      - LinuxDistribution
+      - ConfigurationURL
+    - Label:
+        default: Swarm Properties
+      Parameters:
+      - ManagerSize
+      - ManagerInstanceType
+      - CoreWorkerSize
+      - CoreWorkerInstanceType
+      - UserWorkerSize
+      - UserWorkerInstanceType
+      - MetricsWorkerSize
+      - MetricsWorkerInstanceType
+      - DrainManager
+    - Label:
+        default: Docker Configuration
+      Parameters:
+      - DockerChannel
+      - DockerPlugins
+      - AufsVolumeSize
+      - OverlayNetworks
+    ParameterLabels:
+      KeyName:
+        default: Which SSH key to use?
+      ManagerSize:
+        default: Number of Swarm managers?
+      CoreWorkerSize:
+        default: Number of Swarm workers for AMP core services?
+      UserWorkerSize:
+        default: Number of Swarm workers for AMP user services?
+      MetricsWorkerSize:
+        default: Number of Swarm workers for AMP monitoring services?
+      ManagerInstanceType:
+        default: Swarm manager instance type?
+      CoreWorkerInstanceType:
+        default: Swarm worker instance type for core services?
+      UserWorkerInstanceType:
+        default: Swarm worker instance type for user services?
+      MetricsWorkerInstanceType:
+        default: Swarm worker instance type for monitoring services?
+      DrainManager:
+        default: Drain manager nodes?
+      OverlayNetworks:
+        default: Docker overlay networks
+      DockerChannel:
+        default: Docker channel
+      DockerPlugins:
+        default: Docker plugins
+      ConfigurationURL:
+        default: InfraKit configuration base URL
+      AufsVolumeSize:
+        default: EBS Volume Size for Docker local storage
+      LinuxDistribution:
+        default: Linux Distribution
+
+Outputs:
+  DNSTarget:
+    Description: public facing endpoint for the cluster
+    Value: !GetAtt ManagerExternalELB.DNSName
+  MetricsURL:
+    Description: URL for cluster health dashboard
+    Value:
+      Fn::Join:
+        - ':'
+        - - !GetAtt ManagerExternalELB.DNSName
+          - "9090"
+  VpcId:
+    Description: VPC ID
+    Value: !Ref Vpc

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -783,7 +783,7 @@ Resources:
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
                 - chmod +x /usr/local/bin/asg-init.sh
-                - LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
             - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
   CoreWorkerAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -865,7 +865,7 @@ Resources:
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
                 - chmod +x /usr/local/bin/asg-init.sh
-                - LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
             - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
   UserWorkerAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -947,7 +947,7 @@ Resources:
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
                 - chmod +x /usr/local/bin/asg-init.sh
-                - LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh
+                - LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
             - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
   ManagerAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -1029,7 +1029,7 @@ Resources:
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/asg-init.sh
                 - chmod +x /usr/local/bin/asg-init.sh
-                - CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${ConfigurationURL} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/asg-init.sh
+                - CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${region} STACK_NAME=${stackname} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${ConfigurationURL} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/asg-init.sh || shutdown -h +2
             - { stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -190,7 +190,7 @@ _elect_leader(){
   local _docker_version
   local _swarm_status
   local _not_ready=1
-  local _timeout=520
+  local _timeout=900
   local _leader
   SECONDS=0
   echo "leader election (will timeout after $_timeout s)" >&2
@@ -291,6 +291,17 @@ _get_node_ip(){
   echo $_myip
 }
 
+_smoke_test(){
+  local reachability
+  SECONDS=0
+  while [[ $SECONDS -lt 10 ]]; do
+    docker node ls &>/dev/null || return 1
+    reachability=$(docker node inspect self -f '{{.ManagerStatus.Reachability}}')
+    [[ "x$reachability" = "xreachable" ]] && return 0
+    sleep 1
+  done
+  return 1
+}
 
 _sanity_check || exit 1
 _mount_docker_volume $DOCKER_DEVICE || exit 1
@@ -313,3 +324,4 @@ else
 fi
 _label_node || exit 1
 _drain_node || exit 1
+_smoke_test

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+CHANNEL=${CHANNEL:-stable}
+#PLUGINS=
+REGION=${REGION:-us-west-2}
+STACK_NAME=${STACK_NAME:-unset}
+VPC_ID=${VPC_ID:-unset}
+MANAGER_SIZE=${MANAGER_SIZE:-3}
+DRAIN_MANAGER=${DRAIN_MANAGER:-false}
+OVERLAY_NETWORKS=${OVERLAY_NETWORKS:-ampnet}
+#MIRROR_REGISTRIES=
+#DOCKER_DEVICE=/dev/sdl
+SYSTEMD_DOCKER_OVERRIDE=/etc/systemd/system/docker.service.d/docker.conf
+SYSV_DOCKER_DEFAULT=/etc/default/docker
+
+_init_system(){
+  systemctl --version >/dev/null 2>&1 && echo systemd && return
+  [[ `/sbin/init --version` =~ upstart ]] && echo upstart && return
+  echo sysv
+}
+
+_install_docker(){
+  local _release=$(lsb_release -is)
+  local _host
+  case $CHANNEL in
+  stable) _host="get.docker.com" ;;
+  edge|beta|test) _host="test.docker.com" ;;
+  experimental) _host="experimental.docker.com" ;;
+  *) return 1 ;;
+  esac
+  echo "installing Docker from $_host" >&2
+  wget -qO- "https://$_host/" | sh || return 1
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin 
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl enable docker.service
+    systemctl start docker.service
+  else
+    chkconfig docker on
+    service docker start
+  fi
+  docker version >&2
+}
+
+_install_plugins(){
+  local plugin
+  local alias
+  for plugin in $PLUGINS; do
+    alias=${plugin#store/}
+    alias=${alias%:*}
+    docker plugin install "$plugin" --alias "$alias" --grant-all-permissions # || return 1
+  done
+  return 0
+}
+
+# expose the Docker remote api
+_expose_remote_api() {
+  case $(_init_system) in
+  systemd)
+    mkdir -p "$(dirname $SYSTEMD_DOCKER_OVERRIDE)"
+    echo "exposing the engine API" >&2
+    cat > "$SYSTEMD_DOCKER_OVERRIDE" <<EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:2375 -H unix:///var/run/docker.sock
+EOF
+    systemctl daemon-reload
+  ;;
+  sysv)
+    cat >> "$SYSV_DOCKER_DEFAULT" <<EOF
+DOCKER_OPTS='-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock'
+EOF
+  ;;
+  *)
+    echo "not implemented" >&2
+    return 1
+  ;;
+  esac
+}
+
+_restart_docker(){
+  echo "restarting Docker" >&2
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl restart docker.service
+  else
+    service docker restart
+  fi
+}
+
+_sanity_check(){
+  which aws >/dev/null || return 1
+  which jq >/dev/null || return 1
+  which base64 >/dev/null || return 1
+}
+
+_mount_docker_volume(){
+  local _mount_point="/var/lib/docker"
+  local _device
+  local _fstype=xfs
+  [[ -z "$1" ]] && return 0
+  _device=$(echo $1 | sed 's/\/sd/\/xvd/')
+  mkfs.$_fstype $_device || return 1
+  echo "$_device    $_mount_point   $_fstype    defaults    0    2" >> /etc/fstab
+  rm -rf "$_mount_point"
+  mkdir -p "$_mount_point"
+  mount "$_mount_point"
+}
+
+_system_prerequisites(){
+  typeset -i mmc
+  local mmcmin=262144
+  if mmc=$(sysctl -n vm.max_map_count 2>/dev/null); then
+    if [[ $mmc -lt $mmcmin ]]; then
+      echo "setting vm.max_map_count to a safe value for elasticsearch"
+      sysctl -w vm.max_map_count=262144 || return 1
+      echo "vm.max_map_count = 262144" > /etc/sysctl.d/99-amp.conf
+    fi
+  else
+    return 1
+  fi
+}
+
+# update the docker daemon configuration with the mirror registries
+_set_mirror_registries(){
+  local _registries="$*"
+  local _registry
+  local _tmp
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  for _registry in $_registries; do
+    if ! echo "$_registry" | grep -q "://" ; then
+      echo "$_registry should contain a scheme, ignore" >&2
+      continue
+    fi
+    echo "adding registry $_registry" >&2
+    cat /etc/docker/daemon.json | jq ".[\"registry-mirrors\"] |= .+ [\"$_registry\"]" > "$_tmp" || return 1
+    mv "$_tmp" /etc/docker/daemon.json
+  done
+}
+
+_set_log_rotation(){
+  local _max_size=${1:-10m}
+  local _max_file=${2:-3}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  echo "setting log rotation" >&2
+  cat /etc/docker/daemon.json | jq ".\"log-opts\".\"max-size\" = \"$_max_size\" | .\"log-opts\".\"max-file\" = \"$_max_file\"" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_set_metrics_address(){
+  local _host=${1:-127.0.0.1}
+  local _port=${2:-9323}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  echo "setting the metrics address ($_host:$_port)" >&2
+  cat /etc/docker/daemon.json | jq ".\"metrics-addr\" = \"${_host}:${_port}\" | .experimental = true" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_wait_for_quorum(){
+  local _quorum
+  typeset -i _quorum_size=0
+  TIMEOUT=300
+  SECONDS=0
+  echo "waiting for quorum ($MANAGER_SIZE) (will timeout after $TIMEOUT s)" >&2
+  while [[ $_quorum_size -lt $MANAGER_SIZE ]]; do
+    _quorum=$(aws ec2 describe-instances --region="${REGION}" --filters "Name=tag:Name,Values=${STACK_NAME}-manager" "Name=instance-state-name,Values=pending,running" "Name=vpc-id,Values=${VPC_ID}" | jq -r '.Reservations[].Instances[].PrivateIpAddress')
+    _quorum_size=$(echo $_quorum | wc -w)
+    [[ $SECONDS -gt $TIMEOUT ]] && return 1
+    sleep 2
+  done
+  echo "quorum reached in $SECONDS s" >&2
+  echo $_quorum
+}
+
+# leader election means looking for other members of the group
+# and checking if there's already a leader there
+# if not, the leader should be elected based on an deterministic algorithm 
+_elect_leader(){
+  local _local_node=$1
+  shift
+  local _ips="$*"
+  local _docker_version
+  local _swarm_status
+  local _not_ready=1
+  local _timeout=520
+  local _leader
+  SECONDS=0
+  echo "leader election (will timeout after $_timeout s)" >&2
+  # wait for all nodes to have a running Docker engine
+  while [[ $_not_ready -gt 0 ]]; do
+    _not_ready=0
+    for _node in $_ips; do
+      sleep 1
+      [[ "x$_node" = "x$_local_node" ]] && continue
+      _docker_version=$(docker -H "$_node:2375" version 2>/dev/null)
+      _not_ready=$((_not_ready+$?))
+      [[ -z "$_docker_version" ]] && ((_not_ready++))
+    done
+    [[ $SECONDS -gt $_timeout ]] && return 1
+  done
+  echo "all manager nodes have an available Docker engine API ($SECONDS s)" >&2
+  # look for an existing leader
+  for _node in $_ips; do
+    _swarm_status=$(docker -H "$_node:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
+    if [[ "x$_swarm_status" = "xtrue" ]]; then
+      # we found a leader
+      echo "found an established leader manager: $_node" >&2
+      echo $_node
+      return 0
+    fi
+  done
+  echo "no established leader" >&2
+  # arbitrary convention to elect a leader based on the IP
+  _leader=$(echo $_ips | tr ' ' '\n' | sort -n | head -1)
+  echo "found a new leader: $_leader" >&2
+  echo $_leader
+}
+
+_swarm_init(){
+  local _ip=$1
+  echo "initialize the swarm" >&2
+  docker swarm init --advertise-addr="$_ip"
+}
+
+_get_manager_join_token(){
+  local _manager=$1
+  local _loop=0
+  local _timeout=300
+  local _token
+  echo "retrieving the swarm manager token (will timeout after $_timeout s)" >&2
+  SECONDS=0
+  while [[ $SECONDS -lt $_timeout ]]; do
+    _token=$(docker -H "$_manager:2375" swarm join-token -q manager)
+    if [[ $? -eq 0 && -n "$_token" ]]; then
+      echo "manager token obtained ($SECONDS s)" >&2
+      echo $_token
+      return 0
+    fi
+    sleep 2
+  done
+  echo "timeout" >&2
+  return 1
+}
+
+_create_networks(){
+  local _network
+  for _network in $*; do
+    echo "creating network $_network" >&2
+    docker network create -d overlay --attachable $_network || return 1
+  done
+}
+
+_swarm_join(){
+  local _manager=$1
+  local _token
+  _token=$(_get_manager_join_token "$_manager") || return 1
+  echo "joining the Swarm" >&2
+  docker swarm join --token "$_token" "$_manager:2377"
+}
+
+# add labels on the Swarm node
+_label_node(){
+  local _self
+  local _publicip
+  _self=$(docker node inspect self -f '{{.ID}}') || return 1
+  _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  docker node update --label-add "PublicIP=$_publicip" "$_self" || return 1
+  docker node update --label-add "amp.type.api=true" "$_self" || return 1
+  docker node update --label-add "amp.type.route=true" "$_self"
+}
+
+_drain_node(){
+  local _nodeid
+  [[ "x$DRAIN_MANAGER" != "xtrue" ]] && return 0
+  echo "drain the node" >&2
+  _nodeid=$(docker node inspect self --format '{{.ID}}') || return 1
+  docker node update --availability=drain "$_nodeid"
+}
+
+_get_node_ip(){
+  local _myip
+  _myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)
+  echo $_myip
+}
+
+
+_sanity_check || exit 1
+_mount_docker_volume $DOCKER_DEVICE || exit 1
+_system_prerequisites || exit 1
+nodeip=$(_get_node_ip)
+_install_docker || exit 1
+_install_plugins || exit 1
+_expose_remote_api || exit 1
+_set_mirror_registries "$MIRROR_REGISTRIES" || exit 1
+_set_log_rotation "10m" "3" || exit 1
+_set_metrics_address "$nodeip" "9323" || exit 1
+_restart_docker || exit 1
+ips=$(_wait_for_quorum) || exit 1
+leader="$(_elect_leader $nodeip $ips)" || exit 1
+if [[ "x$nodeip" = "x$leader" ]]; then
+  _swarm_init "$nodeip" || exit 1
+  _create_networks $OVERLAY_NETWORKS || exit 1
+else
+  _swarm_join "$leader" || exit 1
+fi
+_label_node || exit 1
+_drain_node || exit 1

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -1,0 +1,196 @@
+#!/bin/bash
+LABELS=${LABELS:-amp.type.user=true amp.type.core=true amp.type.search=true amp.type.mq=true amp.type.kv=true amp.type.metrics=true}
+CHANNEL=${CHANNEL:-stable}
+#PLUGINS=
+REGION=${REGION:-us-west-2}
+STACK_NAME=${STACK_NAME:-unset}
+VPC_ID=${VPC_ID:-unset}
+#DOCKER_DEVICE=/dev/sdl
+SYSTEMD_DOCKER_OVERRIDE=/etc/systemd/system/docker.service.d/docker.conf
+SYSV_DOCKER_DEFAULT=/etc/default/docker
+#LEADER=
+
+_init_system(){
+  systemctl --version >/dev/null 2>&1 && echo systemd && return
+  [[ `/sbin/init --version` =~ upstart ]] && echo upstart && return
+  echo sysv
+}
+
+_install_docker(){
+  local _release=$(lsb_release -is)
+  local _host
+  case $CHANNEL in
+  stable) _host="get.docker.com" ;;
+  edge|beta|test) _host="test.docker.com" ;;
+  experimental) _host="experimental.docker.com" ;;
+  *) return 1 ;;
+  esac
+  echo "installing Docker from $_host" >&2
+  wget -qO- "https://$_host/" | sh || return 1
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin 
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl enable docker.service
+    systemctl start docker.service
+  else
+    chkconfig docker on
+    service docker start
+  fi
+  docker version >&2
+}
+
+_install_plugins(){
+  local plugin
+  local alias
+  for plugin in $PLUGINS; do
+    alias=${plugin#store/}
+    alias=${alias%:*}
+    docker plugin install "$plugin" --alias "$alias" --grant-all-permissions # || return 1
+  done
+  return 0
+}
+
+_restart_docker(){
+  echo "restarting Docker" >&2
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl restart docker.service
+  else
+    service docker restart
+  fi
+}
+
+_sanity_check(){
+  which aws >/dev/null || return 1
+  which jq >/dev/null || return 1
+}
+
+_mount_docker_volume(){
+  local _mount_point="/var/lib/docker"
+  local _device
+  local _fstype=xfs
+  [[ -z "$1" ]] && return 0
+  _device=$(echo $1 | sed 's/\/sd/\/xvd/')
+  mkfs.$_fstype $_device || return 1
+  echo "$_device    $_mount_point   $_fstype    defaults    0    2" >> /etc/fstab
+  rm -rf "$_mount_point"
+  mkdir -p "$_mount_point"
+  mount "$_mount_point"
+}
+
+_system_prerequisites(){
+  typeset -i mmc
+  local mmcmin=262144
+  if mmc=$(sysctl -n vm.max_map_count 2>/dev/null); then
+    if [[ $mmc -lt $mmcmin ]]; then
+      echo "setting vm.max_map_count to a safe value for elasticsearch"
+      sysctl -w vm.max_map_count=262144 || return 1
+      echo "vm.max_map_count = 262144" > /etc/sysctl.d/99-amp.conf
+    fi
+  else
+    return 1
+  fi
+}
+
+# update the docker daemon configuration with the mirror registries
+_set_mirror_registries(){
+  local _registries="$*"
+  local _registry
+  local _tmp
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  for _registry in $_registries; do
+    if ! echo "$_registry" | grep -q "://" ; then
+      echo "$_registry should contain a scheme, ignore" >&2
+      continue
+    fi
+    echo "adding registry $_registry" >&2
+    cat /etc/docker/daemon.json | jq ".[\"registry-mirrors\"] |= .+ [\"$_registry\"]" > "$_tmp" || return 1
+    mv "$_tmp" /etc/docker/daemon.json
+  done
+}
+
+_set_log_rotation(){
+  local _max_size=${1:-10m}
+  local _max_file=${2:-3}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  echo "setting log rotation" >&2
+  cat /etc/docker/daemon.json | jq ".\"log-opts\".\"max-size\" = \"$_max_size\" | .\"log-opts\".\"max-file\" = \"$_max_file\"" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_set_metrics_address(){
+  local _host=${1:-127.0.0.1}
+  local _port=${2:-9323}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  echo "setting the metrics address ($_host:$_port)" >&2
+  cat /etc/docker/daemon.json | jq ".\"metrics-addr\" = \"${_host}:${_port}\" | .experimental = true" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_get_worker_join_token(){
+  local _manager=$1
+  local _loop=0
+  local _timeout=600
+  local _token
+  echo "retrieving the swarm worker token (will timeout after $_timeout s)" >&2
+  SECONDS=0
+  while [[ $SECONDS -lt $_timeout ]]; do
+    _token=$(docker -H "$_manager:2375" swarm join-token -q worker)
+    if [[ $? -eq 0 && -n "$_token" ]]; then
+      echo "worker token obtained ($SECONDS s)" >&2
+      echo $_token
+      return 0
+    fi
+    sleep 2
+  done
+  echo "timeout" >&2
+  return 1
+}
+
+_swarm_join(){
+  local _manager=$1
+  local _token
+  _token=$(_get_worker_join_token "$_manager") || return 1
+  echo "joining the Swarm" >&2
+  docker swarm join --token "$_token" "$_manager:2377"
+}
+
+# add labels on the Swarm node
+_label_node(){
+  local _manager=$1
+  local _self
+  local _publicip
+  _self=$(docker info -f '{{.Swarm.NodeID}}') || return 1
+  _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  docker -H "$_manager" node update --label-add "PublicIP=$_publicip" "$_self" || return 1
+  for _label in $LABELS; do
+    docker -H "$_manager" node update --label-add "${_label}" "$_self" || return 1
+  done
+}
+
+_get_node_ip(){
+  local _myip
+  _myip=$(curl 169.254.169.254/latest/meta-data/local-ipv4)
+  echo $_myip
+}
+
+_sanity_check || exit 1
+_mount_docker_volume $DOCKER_DEVICE || exit 1
+_system_prerequisites || exit 1
+nodeip=$(_get_node_ip)
+_install_docker || exit 1
+_install_plugins || exit 1
+_set_mirror_registries "$MIRROR_REGISTRIES" || exit 1
+_set_log_rotation "10m" "3" || exit 1
+_set_metrics_address "$nodeip" "9323" || exit 1
+_restart_docker || exit 1
+_swarm_join "$LEADER" || exit 1
+_label_node "$LEADER" || exit 1

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -138,7 +138,7 @@ _set_metrics_address(){
 _get_worker_join_token(){
   local _manager=$1
   local _loop=0
-  local _timeout=600
+  local _timeout=900
   local _token
   echo "retrieving the swarm worker token (will timeout after $_timeout s)" >&2
   SECONDS=0
@@ -182,6 +182,17 @@ _get_node_ip(){
   echo $_myip
 }
 
+_smoke_test(){
+  local _state
+  SECONDS=0
+  while [[ $SECONDS -lt 10 ]]; do
+    _state=$(docker info -f '{{.Swarm.LocalNodeState}}')
+    [[ "x$_state" = "xactive" ]] && return 0
+    sleep 1
+  done
+  return 1
+}
+
 _sanity_check || exit 1
 _mount_docker_volume $DOCKER_DEVICE || exit 1
 _system_prerequisites || exit 1
@@ -194,3 +205,4 @@ _set_metrics_address "$nodeip" "9323" || exit 1
 _restart_docker || exit 1
 _swarm_join "$LEADER" || exit 1
 _label_node "$LEADER" || exit 1
+_smoke_test


### PR DESCRIPTION
AWS Cloudformation templates samples for BYOS
- option for Docker channel
- manager group, core services group, user services group, monitoring group (1 node)
- label the swarm nodes for service scheduling
- options for block storage

Whenever an instance is created (this will happen every time an autoscaling group doesn't reach its desired state) the instance userdata will:
- install Docker
- configure Docker (remote API, metrics endpoint, registries)
- if it's a manager, will look for a leader, or establish who's the leader candidate
- initialize or join the swarm
- label the nodes
- install plugins
- create overlay networks
- basic smoke tests (swarm membership)

see examples/cluster/README.md for instructions
The template is also available on https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml so it can be used even if you don't checkout this branch.

## Verification
Use the aws cli or the console to deploy a swarm cluster.
It is compatible with regions us-east-1, us-east-2, us-west-2, eu-west-1 and ap-southeast-2.

Alternatively it can be used through the aws plugin of AMP:
```docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws:latest init --region us-west-2 --stackname STACKNAME --parameter KeyName=KEYNAME --parameter ConfigurationURL=https://raw.githubusercontent.com/appcelerator/amp/cloudformation-for-amp/examples/clusters --parameter OverlayNetworks=ampnet --parameter DockerChannel=edge --template https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml```

For reference, see the list of parameters below.

| Parameter | Description | Default Value | Example |
| --------- | ----------- | ------------- | ------- |
| KeyName   | Name of an existing EC2 KeyPair to enable SSH access to the instances | - | YOURNAME-REGION |
| ManagerSize | Number of manager nodes, should be 1, 3 or 5 | 3 | |
| CoreWorkerSize | Number of worker nodes for core services | 3 | |
| UserWorkerSize | Number of worker nodes for user services | 3 | |
| MetricsWorkerSize | Number of worker nodes for metrics services | 1 | |
| LinuxDistribution | AMI OS, Debian or Ubuntu | Ubuntu | Debian |
| ManagerInstanceType | Instance type for the manager nodes. Must be a valid EC2 HVM instance type | t2.small | m4.large |
| CoreInstanceType | Instance type for the core worker nodes. Must be a valid EC2 HVM instance type | m4.large | c4.large |
| UserInstanceType | Instance type for the user worker nodes. Must be a valid EC2 HVM instance type | t2.medium | m4.large |
| MetricsInstanceType | Instance type for the metrics worker nodes. Must be a valid EC2 HVM instance type | t2.large | m4.large |
| DrainManager | Should we drain services from the manager nodes? | false | true |
| ConfigurationURL | URL for manager and worker userdata configuration | https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters | |
| AufsVolumeSize | Size in GB of the EBS for the /var/lib/docker FS | 26 | 100 |
| OverlayNetworks | name of overlay networks that should be created once swarm is initialized | ampnet | public storage search mq |
| DockerChannel | channel for Docker installation | stable | edge |
| DockerPlugins | space separated list of plugins to install | | rexray/ebs |
