### PR TITLE
`amp org rm` switches the user to their logged in account

### DIFF
--- a/cli/command/org/remove.go
+++ b/cli/command/org/remove.go
@@ -2,13 +2,17 @@ package org
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/account"
+	"github.com/appcelerator/amp/api/auth"
 	"github.com/appcelerator/amp/cli"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // NewOrgRemoveCommand returns a new instance of the remove organization command.
@@ -28,15 +32,42 @@ func removeOrg(c cli.Interface, args []string) error {
 	var errs []string
 	conn := c.ClientConn()
 	client := account.NewAccountClient(conn)
+
 	for _, org := range args {
-		request := &account.DeleteOrganizationRequest{
+		requestDelete := &account.DeleteOrganizationRequest{
 			Name: org,
 		}
-		if _, err := client.DeleteOrganization(context.Background(), request); err != nil {
+		if _, err := client.DeleteOrganization(context.Background(), requestDelete); err != nil {
 			errs = append(errs, grpc.ErrorDesc(err))
 			continue
 		}
 		c.Console().Println(org)
+		// Check if user is logged in on behalf of an org
+		token, err := cli.ReadToken(c.Server())
+		if err != nil {
+			return err
+		}
+		pToken, _ := jwt.ParseWithClaims(token, &auth.AuthClaims{}, func(t *jwt.Token) (interface{}, error) {
+			return []byte{}, nil
+		})
+		if claims, ok := pToken.Claims.(*auth.AuthClaims); ok {
+			if claims.ActiveOrganization == org {
+				// Switch back to the users account
+				client := account.NewAccountClient(conn)
+				requestSwitch := &account.SwitchRequest{
+					Account: claims.AccountName,
+				}
+				headers := metadata.MD{}
+				_, err := client.Switch(context.Background(), requestSwitch, grpc.Header(&headers))
+				if err != nil {
+					return fmt.Errorf("%s", grpc.ErrorDesc(err))
+				}
+				if err := cli.SaveToken(headers, c.Server()); err != nil {
+					return fmt.Errorf("%s", grpc.ErrorDesc(err))
+				}
+				c.Console().Printf("Switched back to account: %s\n", claims.AccountName)
+			}
+		}
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "\n"))


### PR DESCRIPTION
fixes: #1416 

`amp org rm` will now switch the user back to their currently logged in account if they are removing an organization that they are logged in on behalf of via the `amp org switch` command.

to test:

```
$ amp org create --org=org --email=sample@user.amp
[user jgrahamjones @ localhost:50101]
Organization has been created.
$ amp org switch org
[user jgrahamjones @ localhost:50101]
You are now logged in as: org
$ amp whoami
[organization org @ localhost:50101]
Logged in as organization: org (on behalf of user jgrahamjones)
$ amp org rm org
[organization org @ localhost:50101]
org
Switched back to account: jgrahamjones
$ amp whoami
[user jgrahamjones @ localhost:50101]
Logged in as user: jgrahamjones
```

You can try removing multiple orgs at the same time as well (but you can only be logged in on behalf of one)