### PR TITLE
amp cli cluster plugin

### DIFF
--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -6,7 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type docker struct {
+	volumes       []string
+}
+
 type clusterOpts struct {
+	docker
 	managers      int
 	workers       int
 	provider      string
@@ -19,6 +24,9 @@ type clusterOpts struct {
 
 var (
 	opts = &clusterOpts{
+		docker: docker{
+			volumes: []string{},
+		},
 		managers:      3,
 		workers:       2,
 		provider:      "local",
@@ -38,6 +46,9 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 		PreRunE: cli.NoArgs,
 		RunE:    c.ShowHelp,
 	}
+
+	cmd.PersistentFlags().StringSliceVarP(&opts.docker.volumes, "volume", "v", []string{}, "Bind mount a volume")
+
 	cmd.AddCommand(NewCreateCommand(c))
 	cmd.AddCommand(NewListCommand(c))
 	cmd.AddCommand(NewRemoveCommand(c))

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -7,7 +7,7 @@ import (
 )
 
 type docker struct {
-	volumes       []string
+	Volumes []string
 }
 
 type clusterOpts struct {
@@ -26,7 +26,7 @@ type clusterOpts struct {
 var (
 	opts = &clusterOpts{
 		docker: docker{
-			volumes: []string{},
+			Volumes: []string{},
 		},
 		managers:      3,
 		workers:       2,
@@ -49,7 +49,7 @@ func NewClusterCommand(c cli.Interface) *cobra.Command {
 		RunE:    c.ShowHelp,
 	}
 
-	cmd.PersistentFlags().StringSliceVarP(&opts.docker.volumes, "volume", "v", []string{}, "Bind mount a volume")
+	cmd.PersistentFlags().StringSliceVarP(&opts.Volumes, "volume", "v", []string{}, "Bind mount a volume")
 
 	cmd.AddCommand(NewCreateCommand(c))
 	cmd.AddCommand(NewListCommand(c))

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -19,6 +19,7 @@ type clusterOpts struct {
 	tag           string
 	registration  string
 	notifications bool
+	// TODO: not clear yet if we'll need this
 	options       map[string]string
 }
 
@@ -34,6 +35,7 @@ var (
 		tag:           "latest",
 		registration:  configuration.RegistrationDefault,
 		notifications: true,
+		// TODO: not clear yet if we'll need this
 		options: map[string]string{},
 	}
 )

--- a/cli/command/cluster/cluster.go
+++ b/cli/command/cluster/cluster.go
@@ -14,6 +14,7 @@ type clusterOpts struct {
 	tag           string
 	registration  string
 	notifications bool
+	options       map[string]string
 }
 
 var (
@@ -25,6 +26,7 @@ var (
 		tag:           "latest",
 		registration:  configuration.RegistrationDefault,
 		notifications: true,
+		options: map[string]string{},
 	}
 )
 

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -23,20 +23,21 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.IntVarP(&opts.workers, "workers", "w", 2, "Initial number of worker nodes")
 	flags.IntVarP(&opts.managers, "managers", "m", 3, "Initial number of manager nodes")
-	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use 'local' for development)")
-	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
 	flags.BoolVarP(&opts.notifications, "notifications", "n", false, "Enable/disable server notifications (default is 'false')")
+	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
+	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use 'local' for development)")
+	flags.IntVarP(&opts.workers, "workers", "w", 2, "Initial number of worker nodes")
 
 	// aws options
-	flags.String("aws-region", "", "The region to use when launching the instance")
-	flags.String("aws-stackname", "", "The name of the AWS stack that will be created")
 	flags.String("aws-onfailure", "", "'DO_NOTHING', 'ROLLBACK' (default), or 'DELETE")
 	flags.String("aws-parameter", "", "A key-value pair to supply to the AWS template")
+	flags.String("aws-region", "", "The region to use when launching the instance")
+	flags.String("aws-stackname", "", "The name of the AWS stack that will be created")
 	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+	flags.String("aws-template", "", "UNSUPPORTED: cloud formation template url")
 
 	return cmd
 }

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -87,6 +87,7 @@ func create(c cli.Interface, cmd *cobra.Command) error {
 	config := PluginConfig{
 		Provider: opts.provider,
 		Options: opts.options,
+		DockerOpts: opts.docker,
 	}
 	p, err := NewPlugin(config)
 	if err != nil {

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -1,18 +1,21 @@
 package cluster
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/appcelerator/amp/cli"
 	"github.com/appcelerator/amp/cmd/amplifier/server/configuration"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 // NewCreateCommand returns a new instance of the create command for bootstrapping an cluster.
 func NewCreateCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create [OPTIONS]",
-		Short:   "Create an amp cluster",
+		Short:   "Set up a cluster in swarm mode",
 		PreRunE: cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return create(c, cmd)
@@ -21,33 +24,75 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.IntVarP(&opts.workers, "workers", "w", 2, "Initial number of worker nodes")
-	flags.IntVarP(&opts.managers, "managers", "m", 3, "Intial number of manager nodes")
+	flags.IntVarP(&opts.managers, "managers", "m", 3, "Initial number of manager nodes")
 	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
 	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use 'local' for development)")
 	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
 	flags.BoolVarP(&opts.notifications, "notifications", "n", false, "Enable/disable server notifications (default is 'false')")
+
+	// aws options
+	flags.String("aws-region", "", "The region to use when launching the instance")
+	flags.String("aws-stackname", "", "The name of the AWS stack that will be created")
+	flags.String("aws-onfailure", "", "'DO_NOTHING', 'ROLLBACK' (default), or 'DELETE")
+	flags.String("aws-parameter", "", "A key-value pair to supply to the AWS template")
+	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+
 	return cmd
 }
 
 // Map cli cluster flags to target bootstrap cluster command flags and update the cluster
 func create(c cli.Interface, cmd *cobra.Command) error {
-	// This is a map from cli cluster flag name to bootstrap script flag name
-	m := map[string]string{
-		"workers":       "-w",
-		"managers":      "-m",
-		"provider":      "-t",
-		"name":          "-l",
-		"tag":           "-T",
-		"registration":  "-r",
-		"notifications": "-n",
+	var args []string
+	var env map[string]string
+
+	// until we finish refactoring, the local provider uses a deploy script that requires
+	// remapping cli options to script args and env vars
+	if opts.provider == "local" {
+		// This is a map from cli cluster flag name to bootstrap script flag name
+		m := map[string]string{
+			"workers":       "-w",
+			"managers":      "-m",
+			"provider":      "-t",
+			"name":          "-l",
+			"tag":           "-T",
+			"registration":  "-r",
+			"notifications": "-n",
+		}
+
+		// TODO: only supporting local cluster management for this release
+		// the following ensures that flags are added before the final command arg
+		// TODO: refactor reflag to handle this
+		args = []string{"bin/deploy"}
+		args = reflag(cmd, m, args)
+		env = map[string]string{"TAG": opts.tag, "REGISTRATION": opts.registration, "NOTIFICATIONS": strconv.FormatBool(opts.notifications)}
+	} else {
+		args = append(args, "init")
 	}
 
-	// TODO: only supporting local cluster management for this release
-	// the following ensures that flags are added before the final command arg
-	// TODO: refactor reflag to handle this
-	args := []string{"bin/deploy"}
-	args = reflag(cmd, m, args)
-	env := map[string]string{"TAG": opts.tag, "REGISTRATION": opts.registration, "NOTIFICATIONS": strconv.FormatBool(opts.notifications)}
-	return queryCluster(c, args, env)
+	// plugin options should be prefixed by the name of the provider
+	// for example: provider "aws" => --aws-region "us-west-2"
+	cmd.Flags().Visit(func (f *flag.Flag) {
+		if strings.HasPrefix(f.Name, opts.provider) {
+			 // TODO: wip, don't think we will need to keep this next line
+			opts.options[f.Name] = f.Value.String()
+
+			name := strings.TrimPrefix(f.Name, opts.provider + "-")
+			opt := fmt.Sprintf("--%s=%s", name, f.Value.String())
+			args = append(args, opt)
+			fmt.Println(opt)
+		}
+	})
+
+	config := PluginConfig{
+		Provider: opts.provider,
+		Options: opts.options,
+	}
+	p, err := NewPlugin(config)
+	if err != nil {
+		return err
+	}
+
+	return p.Run(c, args, env)
 }
+

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -39,6 +39,10 @@ type Plugin interface {
 // (config.Provider must be set to a valid provider or this
 // function will return an error).
 func NewPlugin(config PluginConfig) (Plugin, error) {
+	if config.Provider == "" {
+		return nil, errors.New(fmt.Sprintf("Must specify a plugin provider: %s", config.Provider))
+	}
+
 	var p Plugin
 
 	switch config.Provider {

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -1,0 +1,165 @@
+package cluster
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/appcelerator/amp/cli"
+)
+
+// Notes
+//
+// This is a work in progress to flesh out how the CLI should use cluster plugins.
+// This first iteration isn't going to be terribly elegant; the goal is to first
+// get something quickly that works, then refactor.
+//
+//
+
+// ========================================================
+// Public types
+// ========================================================
+
+// supported plugin providers used by the factory function `NewClusterPlugin`
+const (
+	Local = "local"
+	AWS   = "aws"
+)
+
+// PluginConfig is used by the factory function `NewClusterPlugin` to create a new plugin instance.
+type PluginConfig struct {
+	// Provider is the name of the cluster provider, such as "local" or "aws"
+	Provider string
+	Options  map[string]string
+}
+
+// Plugin declares the methods that all plugin providers,
+// such as local and aws, must implement
+type Plugin interface {
+	// Provider returns the name of the provider, such as "local" or "aws"
+	Provider() string
+
+	// Run executes the plugin with the specified arguments and environment variables
+	Run(c cli.Interface, args []string, env map[string]string) error
+}
+
+// ========================================================
+// base plugin implementation - should never be instantiated
+// ========================================================
+
+type plugin struct {
+	config PluginConfig
+}
+
+func (p *plugin) Provider() string {
+	return p.config.Provider
+}
+
+func (p *plugin) Run(c cli.Interface, args []string, env map[string]string) error {
+	return errors.New("Run method invoked on base plugin type")
+}
+
+// ========================================================
+// local plugin implementation
+// ========================================================
+type localPlugin struct {
+	plugin
+}
+
+func (p *localPlugin) Run(c cli.Interface, args []string, env map[string]string) error {
+	return queryCluster(c, args, env)
+}
+
+// ========================================================
+// aws plugin implementation
+// ========================================================
+type awsPlugin struct {
+	plugin
+}
+
+func (p *awsPlugin) Run(c cli.Interface, args []string, env map[string]string) error {
+	img := "appcelerator/amp-aws"
+	return RunContainer(c, img, args, env)
+}
+
+// ========================================================
+// plugin factory
+// ========================================================
+func NewPlugin(config PluginConfig) (Plugin, error) {
+	var p Plugin
+
+	switch config.Provider {
+	case Local:
+		p = &localPlugin{plugin{config: config}}
+	case AWS:
+		p = &awsPlugin{plugin{config: config}}
+	default:
+		return nil, errors.New(fmt.Sprintf("Not a valid plugin provider: %s", config.Provider))
+	}
+
+	return p, nil
+}
+
+// RunContainer starts a container using the specified image for the cluster plugin.
+// Cluster plugin commands are `init`, `update`, and `destroy` (provided as the single
+// `args` value). Additional arguments are supplied as environment variables in `env`, not `args`.
+func RunContainer(c cli.Interface, img string, args []string, env map[string]string) error {
+	dockerArgs := []string{
+		"run", "-t", "--rm", "--name", "amp-cluster-plugin",
+		"--network", "host",
+		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		// TODO: remove hardcoded path
+		"-v", "/Users/tony/.aws:/root/.aws",
+		"-e", "GOPATH=/go",
+	}
+
+	// make environment variables available to container
+	if env != nil {
+		for k, v := range env {
+			dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	// this completes the docker args
+	dockerArgs = append(dockerArgs, img)
+
+	cmd := "docker"
+	args = append(dockerArgs, args...)
+
+	proc := exec.Command(cmd, args...)
+
+	stdout, err := proc.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	outscanner := bufio.NewScanner(stdout)
+	go func() {
+		for outscanner.Scan() {
+			c.Console().Println(outscanner.Text())
+		}
+	}()
+
+	stderr, err := proc.StderrPipe()
+	if err != nil {
+		return err
+	}
+	errscanner := bufio.NewScanner(stderr)
+	go func() {
+		for errscanner.Scan() {
+			c.Console().Println(errscanner.Text())
+		}
+	}()
+
+	err = proc.Start()
+	if err != nil {
+		return err
+	}
+
+	err = proc.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes #1303

See documentation [here](https://github.com/appcelerator/amp/wiki/AMP-Clusters) for more details.

Using `amp cluster create --provider aws` supports creating an AWS cluster using the AMP user's AWS credentials. The AWS credentials are automatically read from the user's home directory (`$HOME/.aws`) (a future update will support command line options as well, like the AWS CLI).

## Verification

### Using the Docker for AWS template

```
$ REGION=us-west-2                  # or any desired region where your keys are deployed
$ KEYNAME=tony-amp-dev              # use your own keypair name
$ STACKNAME=tony-tmp-stack1         # customize for yourself
$ CLUSTERSIZE=2                     # number of workers
$ MANAGERSIZE=1                     # number of managers

$ amp cluster create --provider aws \
   --aws-region $REGION \
   --aws-stackname $STACKNAME \
   --aws-parameter KeyName=$KEYNAME \
   --aws-parameter ClusterSize=$CLUSTERSIZE \
   --aws-parameter ManagerSize=$MANAGERSIZE \
   --aws-sync

# as one line (for copy/paste):
$ amp cluster create --provider aws --aws-region $REGION --aws-stackname $STACKNAME --aws-parameter KeyName=$KEYNAME --aws-parameter ClusterSize=$CLUSTERSIZE --aws-parameter ManagerSize=$MANAGERSIZE --aws-sync
```

### Using the custom AMP CloudFormation template

```
$ REGION=us-west-2                  # or any desired region where your keys are deployed
$ KEYNAME=tony-amp-dev              # use your own keypair name
$ STACKNAME=tony-tmp-stack1         # customize for yourself
$ TEMPLATE=https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
$ CONFIGURL=https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters

$ amp cluster create --provider aws \
   --aws-region $REGION \
   --aws-stackname $STACKNAME \
   --aws-template $TEMPLATE \
   --aws-parameter KeyName=$KEYNAME \
   --aws-parameter OverlayNetworks=ampnet \
   --aws-parameter DockerChannel=edge \
   --aws-parameter ConfigurationURL=$CONFIGURL \
   --aws-sync

# as one line (for copy/paste):
$ amp cluster create --provider aws --aws-region $REGION --aws-stackname $STACKNAME --aws-template $TEMPLATE --aws-parameter KeyName=$KEYNAME --aws-parameter OverlayNetworks=ampnet --aws-parameter DockerChannel=edge --aws-parameter ConfigurationURL=$CONFIGURL --aws-sync

```
