### PR TITLE
Add aws plugin output (info)

### DIFF
--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -16,6 +16,7 @@ var (
 	opts = &plugin.RequestOptions{
 		OnFailure: "ROLLBACK",
 		Params:    []string{},
+		TemplateURL: plugin.DefaultTemplateURL,
 	}
 
 	sess *session.Session

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"strings"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
@@ -89,4 +90,18 @@ func DeleteStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 	}
 
 	return svc.DeleteStackWithContext(ctx, input)
+}
+
+func describeStack(ctx context.Context, svc *cf.CloudFormation, id string, page int) (string, error) {
+	input := &cf.DescribeStacksInput{
+		StackName: aws.String(id),
+		NextToken: aws.String(strconv.Itoa(page)),
+	}
+	output, err := svc.DescribeStacksWithContext(ctx, input)
+	if err != nil {
+		return "", err
+	}
+
+	s := output.GoString()
+	return s, nil
 }

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -96,8 +96,10 @@ func TestCreate(t *testing.T) {
 	// describe stack
 	// ============
 	ctxDescribe := context.Background()
-	output, err := describeStack(ctxDescribe, svc, stackName, 1)
-	log.Println(output)
+	stackOutput, err := describeStack(ctxDescribe, svc, stackName, 1)
+	for _, so := range stackOutput {
+		log.Printf("[%s] %s: %s\n", so.OutputKey, so.Description, so.OutputValue)
+	}
 
 	// update stack
 	// ============

--- a/cluster/plugin/aws/plugin_test.go
+++ b/cluster/plugin/aws/plugin_test.go
@@ -62,6 +62,7 @@ func TestCreate(t *testing.T) {
 	stackName := fmt.Sprintf("%s-plugin-test-%s", keyName, uuid.NewV4())
 
 	opts := &RequestOptions{
+		TemplateURL: DefaultTemplateURL,
 		Region:    region,
 		StackName: stackName,
 		OnFailure: "DELETE",
@@ -70,6 +71,7 @@ func TestCreate(t *testing.T) {
 			fmt.Sprintf("ClusterSize=%s", "2"),
 			fmt.Sprintf("ManagerSize=%s", "1"),
 		},
+		Sync: true,
 	}
 
 	log.Println("starting test...")
@@ -90,6 +92,12 @@ func TestCreate(t *testing.T) {
 		log.Fatal(err)
 	}
 	log.Printf("stack created: %s\n", opts.StackName)
+
+	// describe stack
+	// ============
+	ctxDescribe := context.Background()
+	output, err := describeStack(ctxDescribe, svc, stackName, 1)
+	log.Println(output)
 
 	// update stack
 	// ============


### PR DESCRIPTION
This PR adds support for getting information about the cluster when it is created. Output is printed in JSON format to `stdout`. It contains the information that AWS produces as "output" during stack creation.

 * The plugin now supports the `info` command. For an existing cluster, the cluster information will be printed to `stdout`.
  * When the `--sync` option is used for the `create` command, cluster information will be printed to `stdout` when the operation is complete

For example:

```
[
        {
          description: "Use this name to update your DNS records",
          key: "DefaultDNSTarget",
          value: "tony-mac-External-OXLF4L5OT8DE-655652008.us-west-2.elb.amazonaws.com"
        },
        {
          description: "Availabilty Zones Comment",
          key: "ZoneAvailabilityComment",
          value: "This region has at least 3 Availability Zones (AZ). This is ideal to ensure a fully functional Swarm in case you lose an AZ."
        },
        {
          description: "You can see the manager nodes associated with this cluster here. Follow the instructions here: https://docs.docker.com/docker-for-aws/deploy/",
          key: "Managers",
          value: "https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Instances:tag:aws:autoscaling:groupName=tony-mac-2017-plugin-test-6ae649ac-b991-4ef5-a78a-f3753c52a177-ManagerAsg-1G7L9P2B80F20;sort=desc:dnsName"
        },
        {
          description: "Use this as the VPC for configuring Private Hosted Zones",
          key: "VPCID",
          value: "vpc-a66e9cc0"
        },
         {
          description: "Use this zone ID to update your DNS records",
          key: "ELBDNSZoneID",
          value: "Z1H1FL5HABSF5"
        }
]
```

This information is a transformed subset of all the information that AWS provides when creating a stack. Sample output from test:

```
{
  Stacks: [{
      Capabilities: ["CAPABILITY_IAM"],
      CreationTime: 2017-06-26 19:57:25.992 +0000 UTC,
      Description: "Docker CE for AWS 17.05.0-ce (17.05.0-ce-aws2)",
      DisableRollback: false,
      Outputs: [
        {
          Description: "Use this name to update your DNS records",
          OutputKey: "DefaultDNSTarget",
          OutputValue: "tony-mac-External-OXLF4L5OT8DE-655652008.us-west-2.elb.amazonaws.com"
        },
        {
          Description: "Availabilty Zones Comment",
          OutputKey: "ZoneAvailabilityComment",
          OutputValue: "This region has at least 3 Availability Zones (AZ). This is ideal to ensure a fully functional Swarm in case you lose an AZ."
        },
        {
          Description: "You can see the manager nodes associated with this cluster here. Follow the instructions here: https://docs.docker.com/docker-for-aws/deploy/",
          OutputKey: "Managers",
          OutputValue: "https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Instances:tag:aws:autoscaling:groupName=tony-mac-2017-plugin-test-6ae649ac-b991-4ef5-a78a-f3753c52a177-ManagerAsg-1G7L9P2B80F20;sort=desc:dnsName"
        },
        {
          Description: "Use this as the VPC for configuring Private Hosted Zones",
          OutputKey: "VPCID",
          OutputValue: "vpc-a66e9cc0"
        },
         {
          Description: "Use this zone ID to update your DNS records",
          OutputKey: "ELBDNSZoneID",
          OutputValue: "Z1H1FL5HABSF5"
        }
      ],
      Parameters: [
        {
          ParameterKey: "KeyName",
          ParameterValue: "tony-mac-2017"
        },
        {
          ParameterKey: "EnableCloudStor",
          ParameterValue: "no"
        },
        {
          ParameterKey: "ManagerInstanceType",
          ParameterValue: "t2.micro"
        },
        {
          ParameterKey: "ClusterSize",
          ParameterValue: "2"
        },
        {
          ParameterKey: "ManagerDiskType",
          ParameterValue: "standard"
        },
        {
          ParameterKey: "WorkerDiskSize",
          ParameterValue: "20"
        },
        {
          ParameterKey: "ManagerDiskSize",
          ParameterValue: "20"
        },
        {
          ParameterKey: "WorkerDiskType",
          ParameterValue: "standard"
        },
        {
          ParameterKey: "EnableSystemPrune",
          ParameterValue: "no"
        },
        {
          ParameterKey: "EnableCloudWatchLogs",
          ParameterValue: "yes"
        },
        {
          ParameterKey: "InstanceType",
          ParameterValue: "t2.micro"
        },
        {
          ParameterKey: "ManagerSize",
          ParameterValue: "1"
        }
      ],
      StackId: "arn:aws:cloudformation:us-west-2:654814900965:stack/tony-mac-2017-plugin-test-6ae649ac-b991-4ef5-a78a-f3753c52a177/ac918400-5aa9-11e7-acf
a-503f20f2ade6",
      StackName: "tony-mac-2017-plugin-test-6ae649ac-b991-4ef5-a78a-f3753c52a177",
      StackStatus: "CREATE_COMPLETE",
      TimeoutInMinutes: 20
    }]
}
```

## Verification

    $ cd cluster/plugin/aws
    # test will complain if either of the following variables aren't set
    $ export KEYNAME=your-keyname
    $ export REGION=aws-region
    $ make test  # should pass

Run the plugin using the AMP CLI with the custom AMP CF template and verify at the end you see JSON output:

```
$ REGION=us-west-2
$ KEYNAME=tony-mac-2017
$ STACKNAME=tony-tmp-stack-info-1
$ TEMPLATE=https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
$ amp cluster create --provider aws --aws-region $REGION --aws-stackname $STACKNAME --aws-template $TEMPLATE --aws-parameter KeyName=$KEYNAME --aws-parameter OverlayNetworks=ampnet --aws-parameter DockerChannel=edge --aws-sync
{"output":[{"description":"VPC ID","key":"VpcId","value":"vpc-809f62e6"},{"description":"URL for cluster health dashboard","key":"MetricsURL","value":"tony-tmp-ManagerE-1DG5DMFJHQJN3-1890537228.us-west-2.elb.amazonaws.com:9090"},{"description":"public facing endpoint for the cluster","key":"DNSTarget","value":"tony-tmp-ManagerE-1DG5DMFJHQJN3-1890537228.us-west-2.elb.amazonaws.com"}]}
```
