### PR TITLE
fix quiet flag for stack ls

### DIFF
--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -43,6 +43,7 @@ func list(c cli.Interface, opts listStackOptions) error {
 		for _, line := range reply.Entries {
 			c.Console().Println(line.Stack.Id)
 		}
+		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, cli.Padding, ' ', 0)
 	fmt.Fprintln(w, "ID\tNAME\tSERVICES\tFAILED SERVICES\tSTATUS\tOWNER\tORGANIZATION")


### PR DESCRIPTION
fixes #1435 

to test
```
$ make build-cli
$ amp stack deploy -c examples/stacks/pinger/pinger.yml
$ amp stack ls -q
b73b4f58cbbeba7a56e90e1734985a75e5a27d4b9b14d55a817d7d384d4a7826
```