### PR TITLE
Implements TLS for amp, amplifier and gateway

### DIFF
--- a/cli/connection.go
+++ b/cli/connection.go
@@ -1,19 +1,24 @@
 package cli
 
 import (
+	"crypto/tls"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // NewClientConn is a helper function that wraps the steps involved in setting up a grpc client connection to the API.
-func NewClientConn(addr string, token string) (*grpc.ClientConn, error) {
-	return grpc.Dial(addr,
-		grpc.WithInsecure(),
+func NewClientConn(addr string, token string, skipVerify bool) (*grpc.ClientConn, error) {
+	tlsConfig := &tls.Config{InsecureSkipVerify: skipVerify}
+	creds := credentials.NewTLS(tlsConfig)
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
 		grpc.WithBlock(),
 		grpc.WithTimeout(time.Second),
 		grpc.WithPerRPCCredentials(&LoginCredentials{Token: token}),
 		grpc.WithCompressor(grpc.NewGZIPCompressor()),
 		grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
-	)
+	}
+	return grpc.Dial(addr, opts...)
 }

--- a/cli/token.go
+++ b/cli/token.go
@@ -93,7 +93,7 @@ func (c *LoginCredentials) GetRequestMetadata(context.Context, ...string) (map[s
 
 // RequireTransportSecurity implements credentials.PerRPCCredentials
 func (c *LoginCredentials) RequireTransportSecurity() bool {
-	return false
+	return true
 }
 
 // GetToken returns the stored token

--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -26,8 +26,9 @@ import (
 )
 
 type opts struct {
-	version bool
-	server  string
+	version    bool
+	server     string
+	skipVerify bool
 }
 
 // newRootCommand returns a new instance of the amp cli root command.
@@ -43,6 +44,7 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 			if opts.server != "" {
 				c.SetServer(opts.server)
 			}
+			c.SetSkipVerify(opts.skipVerify)
 
 			//print current context
 			info(c)
@@ -72,6 +74,7 @@ func newRootCommand(c cli.Interface) *cobra.Command {
 
 	cmd.Flags().BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
 	cmd.PersistentFlags().StringVarP(&opts.server, "server", "s", "", "Specify server (host:port)")
+	cmd.PersistentFlags().BoolVarP(&opts.skipVerify, "insecure", "k", false, "Control whether amp verifies the server's certificate chain and host name")
 
 	cmd.SetOutput(c.Out())
 	addCommands(cmd, c)

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -68,5 +68,5 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	amplifier.Start()
+	log.Fatalln(amplifier.Start())
 }

--- a/cmd/amplifier/server/configuration/configuration.go
+++ b/cmd/amplifier/server/configuration/configuration.go
@@ -16,6 +16,9 @@ const (
 	RegistrationNone    = "none"
 	RegistrationEmail   = "email"
 	RegistrationDefault = RegistrationEmail
+	SecretsFolder       = "/run/secrets/"
+	ConfigSecret        = "amplifier"
+	CertificateSecret   = "cert0.pem"
 )
 
 // Configuration is used for amplifier configuration settings
@@ -50,8 +53,8 @@ func ReadConfig(config *Configuration) error {
 	viper.AutomaticEnv()
 
 	// Add default config file search paths in order of decreasing precedence.
-	viper.SetConfigName("amplifier")
-	viper.AddConfigPath("/run/secrets/")
+	viper.SetConfigName(ConfigSecret)
+	viper.AddConfigPath(SecretsFolder)
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("Fatal error reading configuration file: %s", err)
 	}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"net/http"
 	"os"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -73,9 +75,11 @@ func main() {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	creds := credentials.NewTLS(tlsConfig)
 	mux := runtime.NewServeMux(runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{OrigName: true, EmitDefaults: true}))
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithBlock(),
 		grpc.WithTimeout(time.Minute),
 		grpc.WithCompressor(grpc.NewGZIPCompressor()),

--- a/platform/bin/deploy
+++ b/platform/bin/deploy
@@ -582,6 +582,7 @@ deploy_stacks() {
 
   prepare_amplifier_configuration
   checkexit "secret creation for amplifier failed"
+  prepare_certificates $domainname
   echo "deploy amp stack to cluster"
   deploystack amp.stack.yml amp
   echo "wait for all amp service replicas to be running ($maxwait sec)"
@@ -589,7 +590,6 @@ deploy_stacks() {
   checkexit "amp service replica checks timed out"
   ok
 
-  prepare_certificates $domainname
   if [[ $? -eq 0 ]]; then
     echo "deploy amp proxy stack to cluster"
     deploystack ampproxy.stack.yml amp

--- a/platform/stacks/amp.stack.yml
+++ b/platform/stacks/amp.stack.yml
@@ -11,6 +11,8 @@ volumes:
 secrets:
   amplifier_yml:
     external: true
+  certificate_atomiq:
+    external: true
 
 services:
 
@@ -41,6 +43,9 @@ services:
     secrets:
       - source: amplifier_yml
         target: amplifier.yml
+        mode: 0400
+      - source: certificate_atomiq
+        target: cert0.pem
         mode: 0400
 
   gateway:

--- a/platform/tests/config/config-cmd/config_cmd_test.sh
+++ b/platform/tests/config/config-cmd/config_cmd_test.sh
@@ -2,14 +2,14 @@
 
 # server address passed as command-line argument
 test_cli_config() {
-  echo $(amp config) | grep -Eq "Configuration file: none\s+[[:alpha:][:space:]]+: Server:\s+localhost"
+  echo $(amp -k config) | grep -Eq "Configuration file: none\s+[[:alpha:][:space:]]+: Server:\s+localhost"
 }
 
 # server address passed in local config
 test_local_config() {
   mkdir -p $PWD/.amp
   echo "Server: LOCAL" > $PWD/.amp/amp.yml
-  echo $(amp config) | grep -Eq "Configuration file: $PWD/.amp/amp.yml\s+[[:alpha:][:space:]]+: Server:\s+LOCAL"
+  echo $(amp -k config) | grep -Eq "Configuration file: $PWD/.amp/amp.yml\s+[[:alpha:][:space:]]+: Server:\s+LOCAL"
 }
 
 test_local_cleanup() {
@@ -20,7 +20,7 @@ test_local_cleanup() {
 test_home_config() {
   mkdir -p $HOME/.config/amp
   echo "Server: HOME" > $HOME/.config/amp/amp.yml
-  echo $(amp config) | grep -Eq "Configuration file: $HOME/.config/amp/amp.yml\s+[[:alpha:][:space:]]+: Server:\s+HOME"
+  echo $(amp -k config) | grep -Eq "Configuration file: $HOME/.config/amp/amp.yml\s+[[:alpha:][:space:]]+: Server:\s+HOME"
 }
 
 test_home_cleanup() {

--- a/platform/tests/config/different-configs/config_test.sh
+++ b/platform/tests/config/different-configs/config_test.sh
@@ -11,7 +11,7 @@ test_cli_local_home() {
   echo "Server: HOME" > $HOME/.config/amp/amp.yml
 
   # server address passed as command line argument
-  amp -s SERVER version | pcregrep -q "Server:[[:space:]]+SERVER"
+  amp -k -s SERVER version | pcregrep -q "Server:[[:space:]]+SERVER"
   local ec=$?
 
   rm -R $PWD/.amp
@@ -29,7 +29,7 @@ test_local_home() {
   mkdir -p $HOME/.config/amp
   echo "Server: HOME" > $HOME/.config/amp/amp.yml
 
-  amp version | pcregrep -q "Server:[[:space:]]+LOCAL"
+  amp -k version | pcregrep -q "Server:[[:space:]]+LOCAL"
   local ec=$?
 
   rm -R $PWD/.amp
@@ -43,7 +43,7 @@ test_home() {
   mkdir -p $HOME/.config/amp
   echo "Server: HOME" > $HOME/.config/amp/amp.yml
 
-  amp version | pcregrep -q "Server:[[:space:]]+HOME"
+  amp -k version | pcregrep -q "Server:[[:space:]]+HOME"
   local ec=$?
 
   rm -R $HOME/.config/amp

--- a/platform/tests/config/token/token_test.sh
+++ b/platform/tests/config/token/token_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 test_setup() {
-  amp user signup --name user1 --password password --email email@user1.amp
+  amp -k user signup --name user1 --password password --email email@user1.amp
 }
 
 test_name() {
@@ -9,5 +9,5 @@ test_name() {
 }
 
 test_teardown() {
-  amp user rm user1
+  amp -k user rm user1
 }

--- a/platform/tests/logs/logs_test.sh
+++ b/platform/tests/logs/logs_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp login --name su --password password
-amp logs -m | grep -q "timestamp:"
+amp -k login --name su --password password
+amp -k logs -m | grep -q "timestamp:"

--- a/platform/tests/org/create/create_test.sh
+++ b/platform/tests/org/create/create_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org create --org=org --email=sample@user.amp | grep -q "Organization has been created."
+amp -k org create --org=org --email=sample@user.amp | grep -q "Organization has been created."

--- a/platform/tests/org/get/get_test.sh
+++ b/platform/tests/org/get/get_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp org get org | grep -q "Organization: org"
-amp org get org | grep -q "Email: sample@user.amp"
+amp -k org get org | grep -q "Organization: org"
+amp -k org get org | grep -q "Email: sample@user.amp"

--- a/platform/tests/org/list/list_test.sh
+++ b/platform/tests/org/list/list_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org ls | grep -q "org"
+amp -k org ls | grep -q "org"

--- a/platform/tests/org/member/add/add_test.sh
+++ b/platform/tests/org/member/add/add_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp org member add user | grep -q "Member(s) have been added to organization."
-amp org member add user1 user2 | grep -q "Member(s) have been added to organization."
+amp -k org member add user | grep -q "Member(s) have been added to organization."
+amp -k org member add user1 user2 | grep -q "Member(s) have been added to organization."

--- a/platform/tests/org/member/list/list_test.sh
+++ b/platform/tests/org/member/list/list_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp org member ls | grep -q "su"
-amp org member ls | grep -q "user"
+amp -k org member ls | grep -q "su"
+amp -k org member ls | grep -q "user"

--- a/platform/tests/org/member/remove/remove_test.sh
+++ b/platform/tests/org/member/remove/remove_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org member rm user | grep -q "user"
+amp -k org member rm user | grep -q "user"

--- a/platform/tests/org/member/role/role_test.sh
+++ b/platform/tests/org/member/role/role_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp org member add user
-amp org member role --member=user --role=owner | grep -q "Member role has been changed."
+amp -k org member add user
+amp -k org member role --member=user --role=owner | grep -q "Member role has been changed."

--- a/platform/tests/org/member/setup.sh
+++ b/platform/tests/org/member/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-amp user signup --name user --password password --email email@user.amp --autologin=false
-amp user signup --name user1 --password password --email email@user1.amp --autologin=false
-amp user signup --name user2 --password password --email email@user2.amp --autologin=false
+amp -k user signup --name user --password password --email email@user.amp --autologin=false
+amp -k user signup --name user1 --password password --email email@user1.amp --autologin=false
+amp -k user signup --name user2 --password password --email email@user2.amp --autologin=false

--- a/platform/tests/org/member/teardown.sh
+++ b/platform/tests/org/member/teardown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp login --name su --password password
-amp user rm user user1 user2
+amp -k login --name su --password password
+amp -k user rm user user1 user2

--- a/platform/tests/org/switch/switch_test.sh
+++ b/platform/tests/org/switch/switch_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org switch org | grep -q "You are now logged in as: org"
+amp -k org switch org | grep -q "You are now logged in as: org"

--- a/platform/tests/org/teardown.sh
+++ b/platform/tests/org/teardown.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org rm org | grep -q "org"
+amp -k org rm org | grep -q "org"

--- a/platform/tests/service/inspect/inspect_test.sh
+++ b/platform/tests/service/inspect/inspect_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp service inspect pinger_pinger 2>/dev/null | pcregrep -q "pinger"
+amp -k service inspect pinger_pinger 2>/dev/null | pcregrep -q "pinger"

--- a/platform/tests/service/list-stack/list_based_on_stack_test.sh
+++ b/platform/tests/service/list-stack/list_based_on_stack_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 test_stack_deploy() {
-   amp stack up -c examples/stacks/counter/counter.yml
+   amp -k stack up -c examples/stacks/counter/counter.yml
  }
 
 test_service_list_based_on_stack() {
-  amp service ls --stack pinger | grep -Evq "counter"
+  amp -k service ls --stack pinger | grep -Evq "counter"
 }

--- a/platform/tests/service/list/list_test.sh
+++ b/platform/tests/service/list/list_test.sh
@@ -3,19 +3,19 @@
 SECONDS=0
 
 test_stack_deploy() {
-  amp stack up -c platform/tests/service/list/global.service.yml global
-  amp stack up -c platform/tests/service/list/replicated.service.yml replicated
+  amp -k stack up -c platform/tests/service/list/global.service.yml global
+  amp -k stack up -c platform/tests/service/list/replicated.service.yml replicated
 }
 
 test_service_starting() {
-  amp service ls 2>/dev/null | pcregrep -q "\s*global\s*0/1\s*[0-9]\s*STARTING\s*subfuzion/pinger\s*latest\s*"
-  amp service ls 2>/dev/null | pcregrep -q "\s*replicated\s*0/2\s*[0-9]\s*STARTING\s*subfuzion/pinger\s*latest\s*"
+  amp -k service ls 2>/dev/null | pcregrep -q "\s*global\s*0/1\s*[0-9]\s*STARTING\s*subfuzion/pinger\s*latest\s*"
+  amp -k service ls 2>/dev/null | pcregrep -q "\s*replicated\s*0/2\s*[0-9]\s*STARTING\s*subfuzion/pinger\s*latest\s*"
 }
 
 test_service_global_running() {
   while true
   do
-     if amp service ls 2>/dev/null | pcregrep -q "\s*global_pinger\s*global\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
+     if amp -k service ls 2>/dev/null | pcregrep -q "\s*global_pinger\s*global\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
      then
              break
      fi
@@ -27,7 +27,7 @@ test_service_global_running() {
 test_service_replicated_running() {
   while true
   do
-     if amp service ls 2>/dev/null | pcregrep -q "\s*replicated_pinger\s*replicated\s*2/2\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
+     if amp -k service ls 2>/dev/null | pcregrep -q "\s*replicated_pinger\s*replicated\s*2/2\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
      then
              break
      fi

--- a/platform/tests/service/ps/ps_test.sh
+++ b/platform/tests/service/ps/ps_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp service ps pinger_pinger 2>/dev/null | grep -o -w -E -q '[[:alnum:]]{25}'
+amp -k service ps pinger_pinger 2>/dev/null | grep -o -w -E -q '[[:alnum:]]{25}'

--- a/platform/tests/service/scale/scale_test.sh
+++ b/platform/tests/service/scale/scale_test.sh
@@ -3,10 +3,10 @@
 SECONDS=0
 
 test_service_scale() {
-  amp service scale --service pinger_pinger --replicas 4 2>/dev/null
+  amp -k service scale --service pinger_pinger --replicas 4 2>/dev/null
    while true
     do
-       if amp service ls 2>/dev/null | pcregrep -q "\s*replicated\s*4/4\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
+       if amp -k service ls 2>/dev/null | pcregrep -q "\s*replicated\s*4/4\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
        then
                break
        fi

--- a/platform/tests/service/setup.sh
+++ b/platform/tests/service/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp stack up -c examples/stacks/pinger/pinger.yml
+amp -k stack up -c examples/stacks/pinger/pinger.yml

--- a/platform/tests/service/teardown.sh
+++ b/platform/tests/service/teardown.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-amp stack rm global
-amp stack rm replicated
-amp stack rm pinger
-amp stack rm counter
+amp -k stack rm global
+amp -k stack rm replicated
+amp -k stack rm pinger
+amp -k stack rm counter

--- a/platform/tests/setup.sh
+++ b/platform/tests/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp login --name su --password password
+amp -k login --name su --password password

--- a/platform/tests/signup/signup_test.sh
+++ b/platform/tests/signup/signup_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-amp user signup --name user --password password --email email@user.amp
-amp user ls -q | grep -q "user"
-amp user rm user
+amp -k user signup --name user --password password --email email@user.amp
+amp -k user ls -q | grep -q "user"
+amp -k user rm user

--- a/platform/tests/stacks/create/create_test.sh
+++ b/platform/tests/stacks/create/create_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp stack up -c platform/stacks/visualizer.stack.yml
-amp stack ls 2>/dev/null | grep -q "\svisualizer\s"
+amp -k stack up -c platform/stacks/visualizer.stack.yml
+amp -k stack ls 2>/dev/null | grep -q "\svisualizer\s"

--- a/platform/tests/stacks/list/list_test.sh
+++ b/platform/tests/stacks/list/list_test.sh
@@ -3,19 +3,19 @@
 SECONDS=0
 
 test_stack_deploy() {
-  amp stack up -c platform/tests/stacks/list/global.service.yml global
-  amp stack up -c platform/tests/stacks/list/replicated.service.yml replicated
+  amp -k stack up -c platform/tests/stacks/list/global.service.yml global
+  amp -k stack up -c platform/tests/stacks/list/replicated.service.yml replicated
 }
 
 test_stack_starting() {
-  amp stack ls 2>/dev/null | pcregrep -q "\s*global\s*0/1\s*[0-9]\s*STARTING\s*"
-  amp stack ls 2>/dev/null | pcregrep -q "\s*replicated\s*0/1\s*[0-9]\s*STARTING\s*"
+  amp -k stack ls 2>/dev/null | pcregrep -q "\s*global\s*0/1\s*[0-9]\s*STARTING\s*"
+  amp -k stack ls 2>/dev/null | pcregrep -q "\s*replicated\s*0/1\s*[0-9]\s*STARTING\s*"
 }
 
 test_stack_global_running() {
   while true
   do
-     if amp stack ls 2>/dev/null | pcregrep -q "\s*global\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
+     if amp -k stack ls 2>/dev/null | pcregrep -q "\s*global\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
      then
              break
      fi
@@ -27,7 +27,7 @@ test_stack_global_running() {
 test_stack_replicated_running() {
   while true
   do
-     if amp stack ls 2>/dev/null | pcregrep -q "\s*replicated\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
+     if amp -k stack ls 2>/dev/null | pcregrep -q "\s*replicated\s*1/1\s*[0-9]\s*RUNNING\s*" || [ $SECONDS -eq 5 ]
      then
              break
      fi

--- a/platform/tests/stacks/remove/remove_test.sh
+++ b/platform/tests/stacks/remove/remove_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp stack rm visualizer 2>/dev/null | grep -Eq "[a-z0-9]"
+amp -k stack rm visualizer 2>/dev/null | grep -Eq "[a-z0-9]"

--- a/platform/tests/stacks/reserved-resources/reserved_resources_test.sh
+++ b/platform/tests/stacks/reserved-resources/reserved_resources_test.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 test_reserved_secret_amplifier() {
-  amp stack up -c platform/tests/stacks/reserved-resources/secret.amplifier.yml
+  amp -k stack up -c platform/tests/stacks/reserved-resources/secret.amplifier.yml
   return $(($? ^ 1))
 }
 
 test_reserved_secret_certificate() {
-  amp stack up -c platform/tests/stacks/reserved-resources/secret.certificate.yml
+  amp -k stack up -c platform/tests/stacks/reserved-resources/secret.certificate.yml
   return $(($? ^ 1))
 }
 
 test_reserved_label_io_amp_role() {
-  amp stack up -c platform/tests/stacks/reserved-resources/label.io.amp.role.yml
+  amp -k stack up -c platform/tests/stacks/reserved-resources/label.io.amp.role.yml
   return $(($? ^ 1))
 }

--- a/platform/tests/stacks/services/services_test.sh
+++ b/platform/tests/stacks/services/services_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp stack services global | grep -q "global"
+amp -k stack services global | grep -q "global"

--- a/platform/tests/stacks/setup.sh
+++ b/platform/tests/stacks/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp login --name su --password password
+amp -k login --name su --password password

--- a/platform/tests/stacks/teardown.sh
+++ b/platform/tests/stacks/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-amp stack rm visualizer
-amp stack rm global
-amp stack rm replicated
+amp -k stack rm visualizer
+amp -k stack rm global
+amp -k stack rm replicated

--- a/platform/tests/stacks/up/up_test.sh
+++ b/platform/tests/stacks/up/up_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 test_stack_up() {
-  amp stack up -c platform/stacks/visualizer.stack.yml
-  amp stack ls 2>/dev/null | grep -Eq "visualizer"
+  amp -k stack up -c platform/stacks/visualizer.stack.yml
+  amp -k stack ls 2>/dev/null | grep -Eq "visualizer"
 }

--- a/platform/tests/stats/stats_test.sh
+++ b/platform/tests/stats/stats_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 test_main() {
-  res=$(amp stats | wc -l)
+  res=$(amp -k stats | wc -l)
   echo $res
   if [ "$res" -lt 1 ]; then
      exit 1

--- a/platform/tests/team/create/create_test.sh
+++ b/platform/tests/team/create/create_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp team create team --org=org | grep -q "Team has been created in the organization."
+amp -k team create team --org=org | grep -q "Team has been created in the organization."

--- a/platform/tests/team/get/get_test.sh
+++ b/platform/tests/team/get/get_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp team get team | grep -q "Team: team"
-amp team get team | grep -q "Organization: org"
+amp -k team get team | grep -q "Team: team"
+amp -k team get team | grep -q "Organization: org"

--- a/platform/tests/team/list/list_test.sh
+++ b/platform/tests/team/list/list_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp team ls | grep -q "team"
+amp -k team ls | grep -q "team"

--- a/platform/tests/team/member/add/add_test.sh
+++ b/platform/tests/team/member/add/add_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp team member add user | grep -q "Member(s) have been added to team."
-amp team member add user1 user2 | grep -q "Member(s) have been added to team."
+amp -k team member add user | grep -q "Member(s) have been added to team."
+amp -k team member add user1 user2 | grep -q "Member(s) have been added to team."

--- a/platform/tests/team/member/list/list_test.sh
+++ b/platform/tests/team/member/list/list_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp team member ls | grep -q "su"
-amp team member ls | grep -q "user"
+amp -k team member ls | grep -q "su"
+amp -k team member ls | grep -q "user"

--- a/platform/tests/team/member/remove/remove_test.sh
+++ b/platform/tests/team/member/remove/remove_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp team member rm user | grep -q "user"
+amp -k team member rm user | grep -q "user"

--- a/platform/tests/team/member/setup.sh
+++ b/platform/tests/team/member/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-amp user signup --name user --password password --email email@user.amp --autologin=false
-amp user signup --name user1 --password password --email email@user1.amp --autologin=false
-amp user signup --name user2 --password password --email email@user2.amp --autologin=false
-amp org member add user user1 user2
+amp -k user signup --name user --password password --email email@user.amp --autologin=false
+amp -k user signup --name user1 --password password --email email@user1.amp --autologin=false
+amp -k user signup --name user2 --password password --email email@user2.amp --autologin=false
+amp -k org member add user user1 user2

--- a/platform/tests/team/member/teardown.sh
+++ b/platform/tests/team/member/teardown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp login --name su --password password
-amp user rm user user1 user2
+amp -k login --name su --password password
+amp -k user rm user user1 user2

--- a/platform/tests/team/resource/add/add_test.sh
+++ b/platform/tests/team/resource/add/add_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp team resource add --org=org --team=team $(amp stack ls -q) |  grep -q "Resource(s) have been added to team."
+amp -k team resource add --org=org --team=team $(amp -k stack ls -q) |  grep -q "Resource(s) have been added to team."

--- a/platform/tests/team/resource/list/list_test.sh
+++ b/platform/tests/team/resource/list/list_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-ResId=$(amp stack ls -q)
-amp team resource ls | grep -q "$ResId"
+ResId=$(amp -k stack ls -q)
+amp -k team resource ls | grep -q "$ResId"

--- a/platform/tests/team/resource/permission/permission_test.sh
+++ b/platform/tests/team/resource/permission/permission_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-for id in $(amp stack ls -q)
+for id in $(amp -k stack ls -q)
 do
-  amp team resource perm $id write | grep -q "Permission level has been changed."
-  amp team resource ls | grep -q "TEAM_WRITE"
+  amp -k team resource perm $id write | grep -q "Permission level has been changed."
+  amp -k team resource ls | grep -q "TEAM_WRITE"
 done

--- a/platform/tests/team/resource/remove/remove_test.sh
+++ b/platform/tests/team/resource/remove/remove_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-ResId=$(amp stack ls -q)
-amp team resource rm $ResId | grep -q "$ResId"
+ResId=$(amp -k stack ls -q)
+amp -k team resource rm $ResId | grep -q "$ResId"

--- a/platform/tests/team/resource/setup.sh
+++ b/platform/tests/team/resource/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-amp org switch org
-amp stack up -c examples/stacks/pinger/pinger.yml
-amp stack up -c examples/stacks/pinger/pinger.yml pi
+amp -k org switch org
+amp -k stack up -c examples/stacks/pinger/pinger.yml
+amp -k stack up -c examples/stacks/pinger/pinger.yml pi

--- a/platform/tests/team/resource/teardown.sh
+++ b/platform/tests/team/resource/teardown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp stack rm pinger
-amp stack rm pi
+amp -k stack rm pinger
+amp -k stack rm pi

--- a/platform/tests/team/setup.sh
+++ b/platform/tests/team/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-amp org create --org=org --email=sample@user.amp
+amp -k org create --org=org --email=sample@user.amp

--- a/platform/tests/team/teardown.sh
+++ b/platform/tests/team/teardown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp team remove team | grep -q "team"
-amp org rm org
+amp -k team remove team | grep -q "team"
+amp -k org rm org

--- a/platform/tests/version_test.sh
+++ b/platform/tests/version_test.sh
@@ -2,14 +2,14 @@
 
 # not finding the version is an error
 test_has_version() {
-  result=$(amp version)
+  result=$(amp -k version)
   version="v[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}"
   echo $result | grep -E "Version:[[:space:]]+$version"
 }
 
 # finding "not connected" is an error
 test_is_connected() {
-  result=$(amp version)
+  result=$(amp -k version)
   echo $result | grep "not connected"
   (( $? == 0 )) && return 1 || return 0
 }

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"gopkg.in/yaml.v2"
 )
@@ -33,8 +35,10 @@ const testAmplifierConfig = "test.amplifier.yml"
 func AmplifierConnection() (*grpc.ClientConn, error) {
 	amplifierEndpoint := "amplifier" + configuration.DefaultPort
 	log.Println("Connecting to amplifier")
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	creds := credentials.NewTLS(tlsConfig)
 	conn, err := grpc.Dial(amplifierEndpoint,
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithBlock(),
 		grpc.WithTimeout(60*time.Second),
 		grpc.WithCompressor(grpc.NewGZIPCompressor()),


### PR DESCRIPTION
Resolves #1058 

This PR enables TLS for the AMP platform:
- `amplifier` reads the server certificate chain and key from the docker secret `certificate_atomiq`, using the same certificate as the reverse proxy. There is currently no option to listen without TLS.
- `amp` CLI has been updated accordingly to negotiate TLS by default. There is currently no option to establish a clear connection. However, a `-k` (or `--insecure`) option has been added to enable skipping the certification chain verification (typically when using a self-signed certificates in local deployment).
- the gRPC gateway has been updated accordingly to negotiate TLS by default. There is currently no option to establish a clear connection.

The smokes tests and integration tests have been updated accordingly.

## How to test
```
$ ampmake build
$ docker secret rm certificate_atomiq
$ amp cluster create -t local
$ amp -k version
```