### PR TITLE
reduce fail rate at aws cluster creation

### DIFF
--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -743,7 +743,7 @@ Resources:
       - PublicSubnet1
       - PublicSubnet2
       - PublicSubnet3
-      - ManagerAutoScalingGroup
+      - ManagerWaitCondition
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1
@@ -838,7 +838,7 @@ Resources:
       - PublicSubnet1
       - PublicSubnet2
       - PublicSubnet3
-      - ManagerAutoScalingGroup
+      - ManagerWaitCondition
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1
@@ -934,7 +934,7 @@ Resources:
       - PublicSubnet1
       - PublicSubnet2
       - PublicSubnet3
-      - ManagerAutoScalingGroup
+      - ManagerWaitCondition
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1


### PR DESCRIPTION
the worker groups now are created only after the manager group is fully up.
This reduces the risk to see a transition phase with worker instances getting killed because the manager nodes are not fully available.