### PR TITLE
Instrument amplifier with gRPC prometheus metrics

### DIFF
--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -46,6 +46,7 @@ func main() {
 		Version:          Version,
 		Build:            Build,
 		Port:             configuration.DefaultPort,
+		H1Port:           configuration.DefaultH1Port,
 		EmailSender:      mail.DefaultSender,
 		SmsSender:        sms.DefaultSender,
 		EtcdEndpoints:    []string{etcd.DefaultEndpoint},

--- a/cmd/amplifier/server/configuration/configuration.go
+++ b/cmd/amplifier/server/configuration/configuration.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	DefaultPort         = ":50101"
+	DefaultH1Port       = ":5100"
 	DefaultTimeout      = time.Minute
 	RegistrationNone    = "none"
 	RegistrationEmail   = "email"
@@ -22,6 +23,7 @@ type Configuration struct {
 	Version          string
 	Build            string
 	Port             string
+	H1Port           string
 	EtcdEndpoints    []string
 	ElasticsearchURL string
 	NatsURL          string
@@ -39,7 +41,7 @@ type Configuration struct {
 }
 
 func (c *Configuration) String() string {
-	return fmt.Sprintf("Version: %s\nBuild: %s\nPort: %s\nEtcdEndpoints: %v\nElasticsearchURL: %s\nNatsURL: %s\nDockerURL: %s\nDockerVersion: %s\nRegistration: %s\nNotifications: %v\n", c.Version, c.Build, c.Port, c.EtcdEndpoints, c.ElasticsearchURL, c.NatsURL, c.DockerURL, c.DockerVersion, c.Registration, c.Notifications)
+	return fmt.Sprintf("Version: %s\nBuild: %s\nPort: %s\nH1Port: %s\nEtcdEndpoints: %v\nElasticsearchURL: %s\nNatsURL: %s\nDockerURL: %s\nDockerVersion: %s\nRegistration: %s\nNotifications: %v\n", c.Version, c.Build, c.Port, c.H1Port, c.EtcdEndpoints, c.ElasticsearchURL, c.NatsURL, c.DockerURL, c.DockerVersion, c.Registration, c.Notifications)
 }
 
 // ReadConfig reads the configuration file

--- a/platform/tests/metrics/amplifier-prometheus_test.sh
+++ b/platform/tests/metrics/amplifier-prometheus_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sf http://amplifier:5100/metrics


### PR DESCRIPTION
:warning: needs to be merged after #1452
 
Fix #1450 

This PR enables the https://github.com/grpc-ecosystem/go-grpc-prometheus middleware for amplifier.

:warning: This PR introduces an HTTP/1 server inside `amplifier` in a separate go routine, as well as a new listening port (5100).
I didn't figure out how to serve both protocols (HTTP/1 and HTTP/2) from the same port. It might be possible somehow ... Also note that this new port is not publicly exposed.

A smoke test has been added to `platform/tests/metrics/amplifier-prometheus_test.sh`.

## How to test
```
$ ampmake build
$ amp cluster create -t local
$ docker run --rm --network ampnet appcelerator/amptools curl -sf http://amplifier:5100/metrics
```
