### PR TITLE
Update servers

### DIFF
--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ FROM appcelerator/alpine:3.6.0
 RUN apk update && apk upgrade && apk --no-cache add openjdk8-jre bind-tools
 
 ENV PATH /bin:/opt/elasticsearch/bin:$PATH
-ENV ELASTIC_VERSION 5.4.1
+ENV ELASTIC_VERSION 5.4.2
 
 RUN curl -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTIC_VERSION.tar.gz -o /tmp/elasticsearch-$ELASTIC_VERSION.tar.gz && \
     mkdir /opt && \
@@ -19,7 +19,7 @@ COPY config/elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml.tpl
 COPY config/log4j2.properties /opt/elasticsearch/config/
 COPY /bin/docker-entrypoint.sh /bin/
 
-RUN /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.4.1.0.zip
+RUN /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.4.2.0.zip
 
 RUN mkdir -p /opt/elasticsearch/config/scripts
 RUN adduser -D -h /opt/elasticsearch -s /sbin/nologin elastico

--- a/images/elasticsearch/bin/docker-entrypoint.sh
+++ b/images/elasticsearch/bin/docker-entrypoint.sh
@@ -16,14 +16,14 @@ if [[ -z "$ES_JAVA_OPTS" && -z "$JAVA_HEAP_SIZE" ]]; then
     echo "INFO - system memory is ${tmem}M"
     if [[ $tmem -lt 1024 ]]; then
         echo "INFO - set java heap size to floor value"
-        JAVA_HEAP_SIZE=256
-    elif [[ $tmem -lt 4092 ]]; then
+        JAVA_HEAP_SIZE=512
+    elif [[ $tmem -lt 4096 ]]; then
         echo "INFO - set java heap size to ramping value"
-        # 256 to 410
-        JAVA_HEAP_SIZE=$((256 + (tmem - 1024) / 19))
+        # 512 to 2048
+        JAVA_HEAP_SIZE=$((512 + (tmem - 1024) / 2))
     else
-        echo "INFO - set java heap size to 10%"
-        JAVA_HEAP_SIZE=$((tmem / 10))
+        echo "INFO - set java heap size to 50%"
+        JAVA_HEAP_SIZE=$((tmem / 2))
     fi
     export JAVA_HEAP_SIZE
     echo "Java Heap Size: $JAVA_HEAP_SIZE MB"

--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -1,33 +1,36 @@
 FROM appcelerator/alpine:3.6.0
 
-RUN apk --no-cache add nodejs
+RUN apk --no-cache add nodejs freetype-dev fontconfig-dev
 
 # Kibana installation
 ENV KIBANA_MAJOR 5.4
-ENV KIBANA_VERSION 5.4.1
+ENV KIBANA_VERSION 5.4.2
+RUN mkdir -p /opt/kibana && adduser -D -h /opt/kibana -s /sbin/nologin elastico && rm -rf /opt/kibana
 RUN curl -LO https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz \
-    && mkdir /opt \
     && tar xzf /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz -C /opt \
     && mv /opt/kibana-${KIBANA_VERSION}-linux-x86_64 /opt/kibana \
     && rm /opt/kibana/node/bin/node \
     && rm /opt/kibana/node/bin/npm \
     && ln -s /usr/bin/node /opt/kibana/node/bin/node \
     && ln -s /usr/bin/npm /opt/kibana/node/bin/npm \
-    && rm /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz
+    && chown -R elastico:elastico /opt/kibana \
+    && rm /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz /opt/kibana/config/kibana.yml
 
 ENV PATH /opt/kibana/bin:$PATH
 ENV ELASTICSEARCH_URL http://elasticsearch:9200
 
 COPY kibana.yml.tpl /opt/kibana/config/kibana.yml.tpl
-RUN rm -v /opt/kibana/config/kibana.yml
 
 COPY preconfiguration.sh /
 COPY saved-objects /var/lib/kibana/saved-objects
 COPY index-patterns /var/lib/kibana/index-patterns
 COPY run.sh /
 
+
 EXPOSE 5601
 ENTRYPOINT ["/bin/sh", "-c"]
 CMD ["/run.sh"]
+ENTRYPOINT ["/run.sh"]
+CMD ["kibana"]
 
 #HEALTHCHECK --interval=5s --retries=24 --timeout=1s CMD curl -s "127.0.0.1:5601/api/status" | jq -r '.status.overall.state' | grep -q green

--- a/platform/bin/deploy
+++ b/platform/bin/deploy
@@ -158,7 +158,8 @@ cluster_workercount() {
   _target=$(deployment_target)
   case $_target in
   local) # single manager node
-    echo 0
+    docker node ls -q --filter "role=worker" | wc -w
+    return ${PIPESTATUS[0]}
     ;;
   dind|aws)
     _count=$(bootstrap -t $_target -l $_clusterid | grep -c worker)
@@ -538,7 +539,7 @@ deploy_stacks() {
 
   echo "deploy amp monitoring stack to cluster - stage 1"
   _workercount=$(cluster_workercount $CID) || return 1
-  [[ $_workercount -le 9 ]] && deploystack ampmon-single.1.stack.yml amp || deploystack ampmon-cluster.1.stack.yml amp
+  [[ $_workercount -le 2 ]] && deploystack ampmon-single.1.stack.yml amp || deploystack ampmon-cluster.1.stack.yml amp
   echo "wait for all amp monitoring stage 1 stack service replicas to be running"
 
   servicescheck $maxwait

--- a/platform/bootstrap/bootstrap
+++ b/platform/bootstrap/bootstrap
@@ -207,29 +207,43 @@ _set_size() {
   manager_labels='{"amp.type.api": "true", "amp.type.route": "true"}'
   _vars="{{ var \"/swarm/size/manager\" \"$manager_count\" }} {{ var \"/swarm/labels/manager\" \`${manager_labels}\` }} {{ var \"/swarm/size/worker\" \"$worker_count\" }}"
   if [[ $worker_count -le 3 ]]; then
+    # fits the ampmon-single.1.stack.yml
+    # can be ampmon-cluster for 3 nodes
+    # all gp nodes
     cpu_count=0
     mem_count=0
     dat_count=0
     gp_count=$worker_count
     gp_labels='{"amp.type.search": "true", "amp.type.kv": "true", "amp.type.mq": "true", "amp.type.core": "true", "amp.type.user": "true"}'
-  elif [[ $worker_count -le 9 ]]; then
+  elif [[ $worker_count -le 6 ]]; then
+    # fits the ampmon-cluster.1.stack.yml
+    # one cpu node for nats, and gp node for other services
     cpu_count=1
-    mem_count=1
-    dat_count=1
-    gp_count=$((worker_count - 3 ))
+    gp_count=$((worker_count - 1 ))
     cpu_labels='{"amp.type.mq": "true"}'
-    dat_labels='{"amp.type.kv": "true"}'
-    mem_labels='{"amp.type.search": "true"}'
+    gp_labels='{"amp.type.search": "true", "amp.type.kv": "true", "amp.type.core": "true", "amp.type.user": "true"}'
+  elif [[ $worker_count -le 12 ]]; then
+    # fits the ampmon-cluster.1.stack.yml
+    # 1 cpu node for nats
+    # 3 mem nodes for etcd and elasticsearch
+    cpu_count=1
+    mem_count=3
+    gp_count=$((worker_count - 4))
+    cpu_labels='{"amp.type.mq": "true"}'
+    mem_labels='{"amp.type.search": "true", "amp.type.kv": "true"}'
     gp_labels='{"amp.type.core": "true", "amp.type.user": "true"}'
   else
     # fits the ampmon-cluster.1.stack.yml
+    # 1 cpu node for nats
+    # 3 mem nodes for etcd
+    # 3 dat nodes for etcd
     cpu_count=1
     mem_count=3
     dat_count=3
     gp_count=$((worker_count - 7))
     cpu_labels='{"amp.type.mq": "true"}'
-    dat_labels='{"amp.type.kv": "true"}'
     mem_labels='{"amp.type.search": "true"}'
+    dat_labels='{"amp.type.kv": "true"}'
     gp_labels='{"amp.type.core": "true", "amp.type.user": "true"}'
   fi
   for _w in $WORKER_GROUP_LIST; do

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -23,6 +23,7 @@ services:
       MIN_MASTER_NODES: 2
       NETWORK_HOST: "_eth0_"
       UNICAST_HOSTS: "tasks.elasticsearch"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
     deploy:
       mode: replicated
       replicas: 3

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -12,11 +12,11 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.4.1
+    image: appcelerator/elasticsearch-amp:5.4.2
     networks:
       - default
     volumes:
-      - elasticsearch-data:/opt/elasticsearch-5.4.1/data
+      - elasticsearch-data:/opt/elasticsearch-5.4.2/data
     labels:
       io.amp.role: "infrastructure"
     environment:
@@ -27,6 +27,13 @@ services:
     deploy:
       mode: replicated
       replicas: 3
+      update_config:
+        parallelism: 1
+        delay: 45s
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 25s
       labels:
         io.amp.role: "infrastructure"
       placement:
@@ -51,7 +58,7 @@ services:
         - node.labels.amp.type.mq == true
 
   etcd:
-    image: appcelerator/etcd:3.1.8
+    image: appcelerator/etcd:3.1.9
     networks:
       default:
         aliases:
@@ -69,6 +76,13 @@ services:
     deploy:
       mode: replicated
       replicas: 3
+      update_config:
+        parallelism: 1
+        delay: 30s
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 25s
       labels:
         io.amp.role: "infrastructure"
       placement:

--- a/platform/stacks/ampmon-cluster.1.stack.yml
+++ b/platform/stacks/ampmon-cluster.1.stack.yml
@@ -33,7 +33,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.4.0
+    image: appcelerator/amp-nats-streaming:v0.5.0
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -21,6 +21,7 @@ services:
       io.amp.role: "infrastructure"
     environment:
       NETWORK_HOST: "_eth0_"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
     deploy:
       mode: replicated
       replicas: 1

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -31,7 +31,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.4.0
+    image: appcelerator/amp-nats-streaming:v0.5.0
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon-single.1.stack.yml
+++ b/platform/stacks/ampmon-single.1.stack.yml
@@ -12,11 +12,11 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.4.1
+    image: appcelerator/elasticsearch-amp:5.4.2
     networks:
       - default
     volumes:
-      - elasticsearch-data:/opt/elasticsearch-5.4.1/data
+      - elasticsearch-data:/opt/elasticsearch-5.4.2/data
     labels:
       io.amp.role: "infrastructure"
     environment:
@@ -49,7 +49,7 @@ services:
         - node.labels.amp.type.mq == true
 
   etcd:
-    image: appcelerator/etcd:3.1.8
+    image: appcelerator/etcd:3.1.9
     networks:
       default:
         aliases:

--- a/platform/stacks/ampmon.2.stack.yml
+++ b/platform/stacks/ampmon.2.stack.yml
@@ -25,7 +25,7 @@ services:
       io.amp.role: "infrastructure"
 
   kibana:
-    image: appcelerator/kibana:5.4.1
+    image: appcelerator/kibana:5.4.2
     networks:
       default:
         aliases:


### PR DESCRIPTION
- nats-streaming-server v0.5.0
- elasticsearch + kibana 5.4.2
- etcd 3.1.9
- better memory management for ES (Ref #1382 - elasticsearch out of memory)
- the kibana image now also runs with a non root user
- cluster mode for ES and etcd when at least 3 nodes are ready to host them
- update policy for etcd and ES