### PR TITLE
Multiple args cmd

### DIFF
--- a/cli/command/team/resource/add.go
+++ b/cli/command/team/resource/add.go
@@ -1,7 +1,8 @@
 package resource
 
 import (
-	"fmt"
+	"errors"
+	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/resource"
 	"github.com/appcelerator/amp/cli"
@@ -21,7 +22,7 @@ func NewAddTeamResCommand(c cli.Interface) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add [OPTIONS] RESOURCE-ID",
 		Short:   "Add resource to team",
-		PreRunE: cli.ExactArgs(1),
+		PreRunE: cli.AtLeastArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addTeamRes(c, cmd, args, opts)
 		},
@@ -33,6 +34,7 @@ func NewAddTeamResCommand(c cli.Interface) *cobra.Command {
 }
 
 func addTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts addTeamResOptions) error {
+	var errs []string
 	org, err := cli.ReadOrg(c.Server())
 	if !cmd.Flag("org").Changed {
 		switch {
@@ -56,13 +58,19 @@ func addTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts addTeam
 
 	conn := c.ClientConn()
 	client := resource.NewResourceClient(conn)
-	request := &resource.AddToTeamRequest{
-		ResourceId:       args[0],
-		OrganizationName: opts.org,
-		TeamName:         opts.team,
+	for _, resource := range args {
+		request := &resource.AddToTeamRequest{
+			ResourceId:       resource,
+			OrganizationName: opts.org,
+			TeamName:         opts.team,
+		}
+		if _, err := client.AddToTeam(context.Background(), request); err != nil {
+			errs = append(errs, grpc.ErrorDesc(err))
+			continue
+		}
 	}
-	if _, err := client.AddToTeam(context.Background(), request); err != nil {
-		return fmt.Errorf("%s", grpc.ErrorDesc(err))
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	if err := cli.SaveOrg(opts.org, c.Server()); err != nil {
 		return err
@@ -70,6 +78,6 @@ func addTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts addTeam
 	if err := cli.SaveTeam(opts.team, c.Server()); err != nil {
 		return err
 	}
-	c.Console().Println("Resource has been added to team.")
+	c.Console().Println("Resource(s) have been added to team.")
 	return nil
 }

--- a/cli/command/team/resource/add.go
+++ b/cli/command/team/resource/add.go
@@ -58,9 +58,9 @@ func addTeamRes(c cli.Interface, cmd *cobra.Command, args []string, opts addTeam
 
 	conn := c.ClientConn()
 	client := resource.NewResourceClient(conn)
-	for _, resource := range args {
+	for _, res := range args {
 		request := &resource.AddToTeamRequest{
-			ResourceId:       resource,
+			ResourceId:       res,
 			OrganizationName: opts.org,
 			TeamName:         opts.team,
 		}

--- a/platform/tests/org/member/add/add_test.sh
+++ b/platform/tests/org/member/add/add_test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-amp org member add user | grep -q "Member has been added to organization."
+amp org member add user | grep -q "Member(s) have been added to organization."
+amp org member add user1 user2 | grep -q "Member(s) have been added to organization."

--- a/platform/tests/org/member/remove/remove_test.sh
+++ b/platform/tests/org/member/remove/remove_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+amp org member rm user | grep -q "user"

--- a/platform/tests/org/member/role/role_test.sh
+++ b/platform/tests/org/member/role/role_test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+amp org member add user
 amp org member role --member=user --role=owner | grep -q "Member role has been changed."

--- a/platform/tests/org/member/setup.sh
+++ b/platform/tests/org/member/setup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 amp user signup --name user --password password --email email@user.amp --autologin=false
+amp user signup --name user1 --password password --email email@user1.amp --autologin=false
+amp user signup --name user2 --password password --email email@user2.amp --autologin=false

--- a/platform/tests/org/member/teardown.sh
+++ b/platform/tests/org/member/teardown.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-amp login --name user --password password
-amp user rm user
 amp login --name su --password password
+amp user rm user user1 user2

--- a/platform/tests/team/member/add/add_test.sh
+++ b/platform/tests/team/member/add/add_test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-amp team member add user | grep -q "Member has been added to team."
+amp team member add user | grep -q "Member(s) have been added to team."
+amp team member add user1 user2 | grep -q "Member(s) have been added to team."

--- a/platform/tests/team/member/setup.sh
+++ b/platform/tests/team/member/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 amp user signup --name user --password password --email email@user.amp --autologin=false
-amp org member add user
+amp user signup --name user1 --password password --email email@user1.amp --autologin=false
+amp user signup --name user2 --password password --email email@user2.amp --autologin=false
+amp org member add user user1 user2

--- a/platform/tests/team/member/teardown.sh
+++ b/platform/tests/team/member/teardown.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-amp login --name user --password password
-amp user rm user
 amp login --name su --password password
+amp user rm user user1 user2

--- a/platform/tests/team/resource/add/add_test.sh
+++ b/platform/tests/team/resource/add/add_test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-ResId=$(amp stack ls -q)
-amp team resource add --org=org --team=team $ResId |  grep -q "Resource has been added to team."
+amp team resource add --org=org --team=team $(amp stack ls -q) |  grep -q "Resource(s) have been added to team."

--- a/platform/tests/team/resource/permission/permission_test.sh
+++ b/platform/tests/team/resource/permission/permission_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-ResId=$(amp stack ls -q)
-amp team resource perm $ResId write | grep -q "Permission level has been changed."
-amp team resource ls | grep -q "TEAM_WRITE"
+for id in $(amp stack ls -q)
+do
+  amp team resource perm $id write | grep -q "Permission level has been changed."
+  amp team resource ls | grep -q "TEAM_WRITE"
+done

--- a/platform/tests/team/resource/setup.sh
+++ b/platform/tests/team/resource/setup.sh
@@ -2,4 +2,4 @@
 
 amp org switch org
 amp stack up -c examples/stacks/pinger/pinger.yml
-echo "done"
+amp stack up -c examples/stacks/pinger/pinger.yml pi


### PR DESCRIPTION
closes #1459 
closes #1460 
closes #1461  

The commands `amp org member add`, `amp team member add` and `amp team resource add` now accept more than one argument.
Smoke tests have been updated accordingly