### PR TITLE
Fix typo in stack remove code

### DIFF
--- a/api/rpc/stack/stack.go
+++ b/api/rpc/stack/stack.go
@@ -136,7 +136,7 @@ func (s *Server) Remove(ctx context.Context, in *RemoveRequest) (*RemoveReply, e
 		return nil, convertError(dockerErr)
 	}
 	if storageErr != nil {
-		return nil, convertError(dockerErr)
+		return nil, convertError(storageErr)
 	}
 
 	log.Infof("Stack %s removed", in.Stack)


### PR DESCRIPTION
Fix #1468 

## How to test
```
$ ampmake build
$ amp cluster create -t local
$ amp stack deploy -c examples/stacks/pinger/pinger.yml
$ amp stack rm pinger
```

Should succeed.