### PR TITLE
aws plugin cli pretty print output

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -90,17 +90,11 @@ func create(c cli.Interface, cmd *cobra.Command) error {
 				for _, val := range slice {
 					opt := fmt.Sprintf("--%s", name)
 					args = append(args, opt, val)
-
-					// TODO: just for testing, remove when finished
-					fmt.Println(opt, val)
 				}
 
 			} else {
 				opt := fmt.Sprintf("--%s", name)
 				args = append(args, opt, f.Value.String())
-
-				// TODO: just for testing, remove when finished
-				fmt.Println(opt, f.Value.String())
 			}
 
 		}

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -176,16 +175,3 @@ func StackOutputToJSON(so []StackOutput) (string, error) {
 	return string(j), nil
 }
 
-// PrettyPrintOutput converts JSON output string to human readable format
-func PrettyPrintOutput(jsonOut string) error {
-	dec := json.NewDecoder(strings.NewReader(jsonOut))
-	var outList StackOutputList
-	if err := dec.Decode(&outList); err != nil {
-		return err
-	}
-	for _, out := range outList.Output {
-		fmt.Printf("%s: %s\n", out.Description, out.OutputValue)
-	}
-
-	return nil
-}


### PR DESCRIPTION
#1467 should be merged first.

This PR adds JSON decoding support to the CLI for AWS plugin output when a cluster is created.

## Verification

```
$ REGION=us-west-2
$ KEYNAME=tony-mac-2017
$ STACKNAME=tony-tmp-stack-info-1
$ TEMPLATE=https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
$ amp cluster create --provider aws --aws-region $REGION --aws-stackname $STACKNAME --aws-template $TEMPLATE --aws-parameter KeyName=$KEYNAME --aws-parameter OverlayNetworks=ampnet --aws-parameter DockerChannel=edge --aws-sync
VPC ID: vpc-006f9066
URL for cluster health dashboard: tony-tmp-ManagerE-P8PKC50I8869-2064614226.us-west-2.elb.amazonaws.com:9090
public facing endpoint for the cluster: tony-tmp-ManagerE-P8PKC50I8869-2064614226.us-west-2.elb.amazonaws.com
```

If you run the command again, this will cause an error since the stackname is already in use. Currently, the error response is not JSON, so you will see the following raw output followed by the error until the plugin is updated:

```
/06/29 04:14:54 AlreadyExistsException: Stack [tony-tmp-stack-4] already exists
	status code: 400, request id: 8107ad7a-5c81-11e7-a588-b953d3a93b37
Error: json: cannot unmarshal number into Go value of type aws.StackOutputListError: exit status 1
```
