### PR TITLE
Prevent organization removal when it still owns stacks or dashboads

### DIFF
--- a/cmd/amplifier/server/server.go
+++ b/cmd/amplifier/server/server.go
@@ -158,10 +158,12 @@ func registerStatsServer(amp *Amplifier, s *grpc.Server) {
 
 func registerAccountServer(amp *Amplifier, s *grpc.Server) {
 	account.RegisterAccountServer(s, &account.Server{
-		Accounts: amp.accounts,
-		Config:   amp.config,
-		Mailer:   amp.mailer,
-		Tokens:   amp.tokens,
+		Accounts:   amp.accounts,
+		Config:     amp.config,
+		Mailer:     amp.mailer,
+		Tokens:     amp.tokens,
+		Stacks:     amp.stacks,
+		Dashboards: amp.dashboards,
 	})
 }
 

--- a/platform/tests/team/resource/teardown.sh
+++ b/platform/tests/team/resource/teardown.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 amp stack rm pinger
+amp stack rm pi


### PR DESCRIPTION
Fix #1472 

This PR prevents the removal of organizations still holding resources (stacks, dashboards).

Smoke tests have been updated accordingly.
Added an integration test in `tests/integration/stacks/stacks_test.go`

## How to test
Check Travis build.