### PR TITLE
Build and Version cannot be overridden

### DIFF
--- a/cmd/amp/main.go
+++ b/cmd/amp/main.go
@@ -23,15 +23,17 @@ var (
 func main() {
 	// Initial configuration (before processing environment and flags)
 	cfg = &cli.Configuration{
-		Version: Version,
-		Build:   Build,
-		Server:  cli.DefaultAddress + cli.DefaultPort,
+		Server: cli.DefaultAddress + cli.DefaultPort,
 	}
 
 	// Read the cli config
 	if err := cli.ReadClientConfig(cfg); err != nil {
 		log.Fatalln(err)
 	}
+
+	// Build and Version cannot be overridden
+	cfg.Build = Build
+	cfg.Version = Version
 
 	// Set terminal emulation based on platform as required.
 	stdin, stdout, stderr := term.StdStreams()


### PR DESCRIPTION
Fix #1474 

## How to test
`.config/amp/amp.yml`
```
Version: 0.11.0
Build: randomstring
Server: localhost:50101
```
```
$ amp version
[user su @ localhost:50101]


Client:
 Version:       v0.12.0-dev
 Build:         bd0d31ad
 Server:        localhost:50101
 Go version:    go1.8.3
 OS/Arch:       linux/amd64

Server:
 Version:       v0.12.0-dev
 Build:         bd0d31ad
 Go version:    go1.8.3
 OS/Arch:       linux/amd64
```