### PR TITLE
Display connection error in amp version

### DIFF
--- a/cli/command/version/version.go
+++ b/cli/command/version/version.go
@@ -29,7 +29,11 @@ func (v Version) IsConnected() bool {
 // ServerError Return the server connection error if any
 func (v Version) ServerError() string {
 	if v.Error != nil {
-		return strings.TrimSpace(v.Error.Error())
+		err := strings.TrimSpace(v.Error.Error())
+		if strings.Contains(err, "certificate") {
+			return fmt.Sprintf("%s\n\nLooks like a certificate error. Try using `amp -k` to connect to the remote server.", err)
+		}
+		return err
 	}
 	return ""
 }
@@ -54,7 +58,8 @@ Server:         {{if .IsConnected}}
  Version:       {{.Server.Version}}
  Build:         {{.Server.Build}}
  Go version:    {{.Server.GoVersion}}
- OS/Arch:       {{.Server.Os}}/{{.Server.Arch}}{{else}}not connected ({{.ServerError}}){{end}}`
+ OS/Arch:       {{.Server.Os}}/{{.Server.Arch}}{{else}}not connected
+ Error:         {{.ServerError}}{{end}}`
 
 // NewVersionCommand returns a new instance of the version command.
 func NewVersionCommand(c cli.Interface) *cobra.Command {


### PR DESCRIPTION
Fix #1477 

## How to test
```
$ amp version
[user user @ localhost:50101]

Client:
 Version:       v0.12.0-dev
 Build:         8c676df8
 Server:        localhost:50101
 Go version:    go1.8.3
 OS/Arch:       linux/amd64

Server:         not connected
 Error:         unable to establish grpc connection: x509: certificate is valid for *.local.appcelerator.io, not localhost

Looks like a certificate error. Try using `amp -k` to connect to the remote server.
$ amp -k version
[user su @ localhost:50101]
Client:
 Version:       v0.12.0-dev
 Build:         50c381eb
 Server:        localhost:50101
 Go version:    go1.8.3
 OS/Arch:       linux/amd64

Server:         
 Version:       v0.12.0-dev
 Build:         50c381eb
 Go version:    go1.8.3
 OS/Arch:       linux/amd64
```