### PR TITLE
Updating fmt rule in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ test-amp-envoy: build-amp-envoy
 # =============================================================================
 # Quality checks
 # =============================================================================
-CHECKDIRS := agent api cli cmd data tests cluster $(COMMONDIRS)
+CHECKDIRS := agent api cli cmd data monitoring tests $(COMMONDIRS)
 CHECKSRCS := $(shell find $(CHECKDIRS) -type f \( -name '*.go' -and -not -name '*.pb.go' -and -not -name '*.pb.gw.go'  \))
 
 # format and simplify if possible (https://golang.org/cmd/gofmt/#hdr-The_simplify_command)

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"github.com/appcelerator/amp/cluster/plugin/aws"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/mitchellh/go-homedir"
-	"encoding/json"
 )
 
 // Supported plugin providers used by the factory function `NewPlugin`


### PR DESCRIPTION
Updating Makefile `fmt` rule

## How to test
```
$ ampmake fmt
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM appcelerator/amptools
 ---> 80b3c35826d7
Step 2/2 : RUN sed -i "s/sudoer:x:[0-9]*:[0-9]*/sudoer:x:1000:1000/" /etc/passwd
 ---> Using cache
 ---> 700e610bdde0
Successfully built 700e610bdde0
Successfully tagged amptools:latest
$ git status
On branch fmt-rule
Your branch is up-to-date with 'origin/fmt-rule'.
nothing to commit, working directory clean
```