### PR TITLE
Custom AMI and ampadmin execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ platform/secrets/*
 # ampbeat
 cmd/ampbeat/build/
 cmd/ampbeat/ampbeat.full.yml
+
+examples/clusters/variables.yml

--- a/examples/clusters/README.md
+++ b/examples/clusters/README.md
@@ -7,7 +7,7 @@ It is compatible with regions us-east-1, us-east-2, us-west-2, eu-west-1 and ap-
 
 Alternatively it can be used through the aws plugin of AMP:
 
-    docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws:latest init --region us-west-2 --stackname STACKNAME --parameter KeyName=KEYNAME --parameter ConfigurationURL=https://raw.githubusercontent.com/appcelerator/amp/cloudformation-for-amp/examples/clusters --parameter OverlayNetworks=public --parameter DockerChannel=edge --template https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
+    docker run -it --rm -v ~/.aws:/root/.aws appcelerator/amp-aws:latest init --region us-west-2 --stackname STACKNAME --parameter KeyName=KEYNAME --parameter OverlayNetworks=ampnet --template https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml
 
 ## Content
 
@@ -15,13 +15,7 @@ The template will create the infrastructure (1 VPC, 3 subnets for HA on 3 datace
 Each autoscaling group run a userdata that initializes or join the swarm depending on the nature of the group and depending on the status of the swarm.
 The engine API of all managers are available from all nodes in the VPC, which allow to set the labels on the nodes.
 
-It is ready for the deployment of AMP, with the help of the CLI on one of the manager nodes:
-
-    amp -s localhost -p local
-
-or the development version:
-
-    amp -s localhost -p local --tag latest
+Once the nodes are up and running, it will run the appcelerator/ampadmin image to check the prerequisites, and setup AMP.
 
 ## Parameters
 
@@ -32,18 +26,18 @@ or the development version:
 | CoreWorkerSize | Number of worker nodes for core services | 3 | |
 | UserWorkerSize | Number of worker nodes for user services | 3 | |
 | MetricsWorkerSize | Number of worker nodes for metrics services | 1 | |
-| LinuxDistribution | AMI OS, Debian, Ubuntu or UbuntuLatest | Ubuntu | Debian |
+| LinuxDistribution | AMI OS, Debian, Ubuntu or Default | Default | Ubuntu |
 | ManagerInstanceType | Instance type for the manager nodes. Must be a valid EC2 HVM instance type | t2.small | m4.large |
 | CoreInstanceType | Instance type for the core worker nodes. Must be a valid EC2 HVM instance type | m4.large | c4.large |
 | UserInstanceType | Instance type for the user worker nodes. Must be a valid EC2 HVM instance type | t2.medium | m4.large |
 | MetricsInstanceType | Instance type for the metrics worker nodes. Must be a valid EC2 HVM instance type | t2.large | m4.large |
 | DrainManager | Should we drain services from the manager nodes? | false | true |
-| ConfigurationURL | URL for manager and worker userdata configuration | https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters | |
 | AufsVolumeSize | Size in GB of the EBS for the /var/lib/docker FS | 26 | 100 |
 | OverlayNetworks | name of overlay networks that should be created once swarm is initialized | ampnet | public storage search mq |
 | DockerChannel | channel for Docker installation | stable | edge |
 | DockerPlugins | space separated list of plugins to install | | rexray/ebs |
 | Sync | the stack will wait for all nodes to be up | true | false |
+| InstallApplication | install AMP | true | false |
 
 ## Output
 
@@ -54,3 +48,16 @@ The output of the stack lists the DNS name of the ELB in front of the manager no
 | VpcId | VPC ID |
 | DNSTarget | public facing endpoint for the cluster, It can be used for ssh access, https access to swarm services and configuration of the remote server in the CLI |
 | MetricsURL | URL for cluster health dashboard |
+
+## Custom AMI
+
+the default option for the AMI (Default) is a pre package AMI based on Ubuntu Xenial, with prerequisite packages already installed (in particular Docker).
+
+To build a new version of this image, run the build-ami.sh script. It may take more than 15 min to build the AMI. You'll also need to create a variables.yml file with a content similar to:
+
+```
+---
+ec2_key_name: "KEY_NAME"
+```
+
+Once done, copy the AMI Id in the cloudformation template (aws-swarm-asg.yml).

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-f14874e7
+      Default: ami-0de7db1b
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-noneyet
+      Default: ami-b83918dd
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-e60c1d9f
+      Default: ami-7627360f
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-8e5abef7
+      Default: ami-0397707a
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-nonyet
+      Default: ami-d88596bb
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
@@ -181,8 +181,8 @@ Parameters:
     Default: false
   ConfigurationURL:
     Type: String
-    Description: Deprecated, don't use
-    Default: https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters
+    Description: "Can be used to override the default userdata. Example: https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters"
+    Default: ""
   AufsVolumeSize:
     Type: Number
     Description: Size in GB of the EBS volume for the Docker AUFS storage on each node (mounted on /dev/xvdl)
@@ -210,9 +210,18 @@ Parameters:
     - true
     - false
     Default: true
+  InstallApplication:
+    Type: String
+    Description: If true, AMP will be installed. Expects Sync = true
+    AllowedValues:
+    - true
+    - false
+    Default: true
 
 Conditions:
   Sync: !Equals [ !Ref Sync, "true" ]
+  InstallApplication: !Equals [ !Ref InstallApplication, "true" ]
+  ConfigurationURL:  !Equals [ !Ref ConfigurationURL, "" ]
 
 Resources:
   Vpc:
@@ -805,6 +814,7 @@ Resources:
             repo_update: false
             repo_upgrade: none
             runcmd:
+              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
               - SYNC=${Sync} SIGNAL_URL="${MetricsWaitHandle}" LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
 
   CoreWaitHandle:
@@ -889,6 +899,7 @@ Resources:
             repo_update: false
             repo_upgrade: none
             runcmd:
+              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
               - SYNC=${Sync} SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
 
   UserWaitHandle:
@@ -973,7 +984,24 @@ Resources:
             repo_update: false
             repo_upgrade: none
             runcmd:
+              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
               - SYNC=${Sync} SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
+
+  ApplicationWaitHandle:
+    Type: "AWS::CloudFormation::WaitConditionHandle"
+
+  ApplicationWaitCondition:
+    Condition: InstallApplication
+    Type: "AWS::CloudFormation::WaitCondition"
+    DependsOn:
+      - ManagerWaitCondition
+      - CoreWaitCondition
+      - MetricsWaitCondition
+      - UserWaitCondition
+    Properties:
+      Handle: !Ref ApplicationWaitHandle
+      Timeout: 900
+      Count: 1
 
   ManagerWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -1031,7 +1059,9 @@ Resources:
            - !Ref PublicSubnet3
   ManagerAsgLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
-    DependsOn: ManagerWaitHandle
+    DependsOn:
+      - ManagerWaitHandle
+      - ApplicationWaitHandle
     Properties:
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref ClusterInstanceProfile
@@ -1056,7 +1086,8 @@ Resources:
             repo_update: false
             repo_upgrade: none
             runcmd:
-              - SYNC=${Sync} SIGNAL_URL="${ManagerWaitHandle}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/userdata-aws-manager || shutdown -h
+              - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/userdata-aws-manager && chmod +x /usr/local/bin/userdata-aws-manager || true
+              - SYNC=${Sync} SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationWaitHandle}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/userdata-aws-manager || shutdown -h
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -1174,13 +1205,15 @@ Metadata:
       DockerPlugins:
         default: Docker plugins
       ConfigurationURL:
-        default: InfraKit configuration base URL
+        default: Base URL for userdata scripts
       AufsVolumeSize:
         default: EBS Volume Size for Docker local storage
       LinuxDistribution:
         default: Linux Distribution
       Sync:
         default: Synchronous Deployment
+      InstallApplication:
+        default: Install Application
 
 Outputs:
   DNSTarget:

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -5,31 +5,31 @@ Mappings:
   AMI:
     # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170330
     # debian-jessie-amd64-hvm-2017-01-15
-    # Sydney
-    ap-southeast-2:
-      Ubuntu: ami-92e8e6f1
-      UbuntuLatest: ami-e94e5e8a
-      Debian: ami-0dcac96e
-    # Ireland
-    eu-west-1:
-      Ubuntu: ami-b5a893d3
-      UbuntuLatest: ami-6d48500b
-      Debian: ami-3291be54
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      UbuntuLatest: ami-d15a75c7
+      Default: ami-f14874e7
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      UbuntuLatest: ami-8b92b4ee
+      Default: ami-noneyet
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      UbuntuLatest: ami-835b4efa
+      Default: ami-e60c1d9f
       Debian: ami-fde96b9d
+    # Ireland
+    eu-west-1:
+      Ubuntu: ami-b5a893d3
+      Default: ami-8e5abef7
+      Debian: ami-3291be54
+    # Sydney
+    ap-southeast-2:
+      Ubuntu: ami-92e8e6f1
+      Default: ami-nonyet
+      Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
       cidr: 192.168.0.0/24
@@ -75,10 +75,11 @@ Parameters:
   LinuxDistribution:
     Type: String
     AllowedValues:
+    - Default
     - Ubuntu
-    - UbuntuLatest
     - Debian
-    Default: Ubuntu
+    Default: Default
+    Description: "the default is a pre packaged Ubuntu image, this is the recommended choice"
   ManagerInstanceType:
     Type: String
     AllowedValues:
@@ -180,10 +181,8 @@ Parameters:
     Default: false
   ConfigurationURL:
     Type: String
-    ConstraintDescription: must be an URL.
-    Description: URL for manager and worker userdata configuration
+    Description: Deprecated, don't use
     Default: https://raw.githubusercontent.com/appcelerator/amp/master/examples/clusters
-    AllowedPattern: "https?://[0-9a-z\\.-]+\\.[a-z\\.]{2,6}[/\\w\\.-]*/?"
   AufsVolumeSize:
     Type: Number
     Description: Size in GB of the EBS volume for the Docker AUFS storage on each node (mounted on /dev/xvdl)
@@ -803,22 +802,10 @@ Resources:
         Fn::Base64:
           !Sub |
             #cloud-config
-            repo_update: true
-            repo_upgrade: security
-            packages:
-              - ca-certificates
-              - jq
-              - curl
-              - unzip
-              - awscli
-              - sysstat
-              - iotop
-              - xfsprogs
-              - python-setuptools
+            repo_update: false
+            repo_upgrade: none
             runcmd:
-              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
-              - chmod +x /usr/local/bin/asg-init.sh
-              - SYNC=${Sync} SIGNAL_URL="${MetricsWaitHandle}" LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
+              - SYNC=${Sync} SIGNAL_URL="${MetricsWaitHandle}" LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
 
   CoreWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -899,22 +886,10 @@ Resources:
         Fn::Base64:
           !Sub |
             #cloud-config
-            repo_update: true
-            repo_upgrade: security
-            packages:
-              - ca-certificates
-              - jq
-              - curl
-              - unzip
-              - awscli
-              - sysstat
-              - iotop
-              - xfsprogs
-              - python-setuptools
+            repo_update: false
+            repo_upgrade: none
             runcmd:
-              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
-              - chmod +x /usr/local/bin/asg-init.sh
-              - SYNC=${Sync} SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
+              - SYNC=${Sync} SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
 
   UserWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -995,22 +970,10 @@ Resources:
         Fn::Base64:
           !Sub |
             #cloud-config
-            repo_update: true
-            repo_upgrade: security
-            packages:
-              - ca-certificates
-              - jq
-              - curl
-              - unzip
-              - awscli
-              - sysstat
-              - iotop
-              - xfsprogs
-              - python-setuptools
+            repo_update: false
+            repo_upgrade: none
             runcmd:
-              - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/asg-init.sh
-              - chmod +x /usr/local/bin/asg-init.sh
-              - SYNC=${Sync} SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} BASE_URL=${ConfigurationURL} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/asg-init.sh || shutdown -h
+              - SYNC=${Sync} SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} /usr/local/bin/userdata-aws-worker || shutdown -h
 
   ManagerWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -1090,22 +1053,10 @@ Resources:
         Fn::Base64:
           !Sub |
             #cloud-config
-            repo_update: true
-            repo_upgrade: security
-            packages:
-              - ca-certificates
-              - jq
-              - curl
-              - unzip
-              - awscli
-              - sysstat
-              - iotop
-              - xfsprogs
-              - python-setuptools
+            repo_update: false
+            repo_upgrade: none
             runcmd:
-              - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/asg-init.sh
-              - chmod +x /usr/local/bin/asg-init.sh
-              - SYNC=${Sync} SIGNAL_URL="${ManagerWaitHandle}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} BASE_URL=${ConfigurationURL} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/asg-init.sh || shutdown -h
+              - SYNC=${Sync} SIGNAL_URL="${ManagerWaitHandle}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl /usr/local/bin/userdata-aws-manager || shutdown -h
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:

--- a/examples/clusters/build-ami.sh
+++ b/examples/clusters/build-ami.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DIR="$(dirname $0)"
+cd "$DIR"
+DIR="$(pwd -P)"
+image="williamyeh/ansible:alpine3"
+image="appcelerator/ansible"
+
+if [[ ! -f $HOME/.aws/credentials ]]; then
+  echo "Please configure your aws credentials first"
+  exit 1
+fi
+docker run --rm -v "$DIR:/data" -v "$HOME/.aws:/root/.aws:ro" "$image" ansible-playbook /data/build-ami.yml

--- a/examples/clusters/build-ami.yml
+++ b/examples/clusters/build-ami.yml
@@ -1,0 +1,8 @@
+---
+- name: run ec2 instance from source ami
+  hosts: localhost
+  connection: local
+  vars_files:
+    - variables.yml
+  roles:
+    - {role: ami, tags: build}

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -1,0 +1,43 @@
+---
+## Docker Channel
+# stable: use "https://get.docker.com"
+# edge: use "https://test.docker.com"
+docker_url: "https://get.docker.com"
+
+## AWS Region where the build should be done
+ec2_region: "us-west-2"
+
+## AWS Region where the AMI should be copied
+copy_regions: [ "us-east-1", "us-east-2", "eu-west-1", "ap-southeast-2" ]
+
+## ID of an existing VPC where the build should be done
+ec2_vpc_id: "vpc-40e21d26"
+
+## Key Name
+ec2_key_name: ""
+
+## Instance Type
+ec2_instance_type: "t2.small"
+
+## IAM Profile
+iam_instance_profile: "amp-image-builder-role"
+
+## Source AMI
+ec2_ami: "ami-17ba2a77"
+
+## Security Group
+# should open port 80 (and optionally port 22 for debugging)
+ec2_security_group: "amp-ami-builder-sg"
+
+## Subnet ID
+# should have a route table with an internet gateway
+ec2_vpc_subnet_id: "subnet-b267c8e9"
+
+## S3 bucket for file uploads
+s3_bucket: "amp-ami-builder"
+
+## AMI name
+image_name_prefix: ubuntu-xenial-docker
+
+## AMI description
+image_description: "Ubuntu Xenial image for AMP (github.com/appcelerator/amp)"

--- a/examples/clusters/roles/ami/tasks/ami.yml
+++ b/examples/clusters/roles/ami/tasks/ami.yml
@@ -1,0 +1,43 @@
+---
+- name: Build AMI name
+  set_fact:
+    image_name: "{{ image_name_prefix }}-{{ timestamp }}"
+  changed_when: false
+
+- name: "Register AMI from snapshot {{ root_snapshot_id }}"
+  ec2_ami:
+    architecture: x86_64
+    virtualization_type: hvm
+    root_device_name: /dev/sda1
+    device_mapping:
+      - device_name: /dev/sda1
+        size: 8
+        snapshot_id: "{{ root_snapshot_id }}"
+        delete_on_termination: true
+        volume_type: gp2
+    region: "{{ ec2_region }}"
+    wait: yes
+    name: "{{ image_name }}"
+    description: "{{ image_description }}"
+    tags:
+      Name: "{{ image_name }}"
+  register: image
+
+- debug: msg="{{ image }}"
+  changed_when: false
+
+- name: Get AMI ID
+  set_fact:
+    image_id: "{{ image.image_id }}"
+  changed_when: false
+
+- debug: msg="New AMI {{ image_id }} in {{ ec2_region }}"
+  changed_when: false
+
+#- name: Make AMI Public
+  #ec2_ami:
+    #image_id: "{{ image.image_id }}"
+    #state: present
+    #region: "{{ ec2_region }}"
+    #launch_permissions:
+      #group_names: ['all']

--- a/examples/clusters/roles/ami/tasks/copy-ami.yml
+++ b/examples/clusters/roles/ami/tasks/copy-ami.yml
@@ -1,0 +1,32 @@
+---
+- name: Copy AMI to other regions
+  ec2_ami_copy:
+    source_region: "{{ ec2_region }}"
+    region: "{{ item }}"
+    source_image_id: "{{ image_id }}"
+    encrypted: no
+    name: "{{ image_name_prefix }}"
+    description: "{{ image_description }}"
+    wait: yes
+    tags:
+      Name: "{{ image_name }}"
+      System: "Ubuntu"
+      CreationDate: "{{ timestamp }}"
+      CopyOf: "{{ image_id }}"
+  with_items:
+   - "{{ copy_regions }}"
+  register: copies
+
+- debug: msg="AMI {{ item.image_id }} copied in {{ item.item }}"
+  with_items:
+   - "{{ copies.results }}"
+  changed_when: false
+
+#- name: Make Copies Public
+  #ec2_ami:
+    #image_id: "{{ item.image_id }}"
+    #region: "{{ item.item }}"
+    #state: present
+    #launch_permissions:
+      #group_names: ['all']
+  #with_items: "{{ copies.results }}"

--- a/examples/clusters/roles/ami/tasks/main.yml
+++ b/examples/clusters/roles/ami/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- include: new-instance.yml
+- include: wait-for-instance.yml
+- include: snapshot.yml
+#- include: set-volumes.yml
+- include: ami.yml
+- include: copy-ami.yml
+- include: terminate.yml

--- a/examples/clusters/roles/ami/tasks/new-instance.yml
+++ b/examples/clusters/roles/ami/tasks/new-instance.yml
@@ -1,0 +1,47 @@
+---
+- debug: msg="New instance on VPC {{ ec2_vpc_id }} and region {{ ec2_region }}"
+  changed_when: false
+
+- name: Set timestamp
+  set_fact:
+    timestamp: "{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}"
+  changed_when: false
+
+- name: Upload managers userdata
+  s3:
+    bucket: "{{ s3_bucket }}"
+    object: "scripts/userdata-aws-manager"
+    src: userdata-aws-manager
+    mode: put
+- name: Upload workers userdata
+  s3:
+    bucket: "{{ s3_bucket }}"
+    object: "scripts/userdata-aws-worker"
+    src: userdata-aws-worker
+    mode: put
+
+- name: Run instance
+  ec2:
+    region: "{{ ec2_region }}"
+    key_name: "{{ ec2_key_name }}"
+    instance_type: "{{ ec2_instance_type }}"
+    instance_profile_name: "{{ iam_instance_profile }}"
+    image: "{{ ec2_ami }}"
+    wait: yes
+    group: "{{ ec2_security_group }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    user_data: "{{ lookup('template', 'userdata.j2') }}"
+    assign_public_ip: yes
+    instance_tags:
+        Name: amp-ubuntu-ami-build
+        Project: amp-ami-builder
+  register: ec2_instance
+
+- name: Instance ID
+  set_fact:
+    instance_id: "{{ ec2_instance.instance_ids[0] }}"
+    public_ip: "{{ ec2_instance.instances[0].public_ip }}"
+  changed_when: false
+
+- debug: msg="instance {{ instance_id }} listening on {{ public_ip }}"
+  changed_when: false

--- a/examples/clusters/roles/ami/tasks/set-volumes.yml
+++ b/examples/clusters/roles/ami/tasks/set-volumes.yml
@@ -1,0 +1,41 @@
+---
+- name: Get original root volume
+  ec2_vol_facts:
+    region: "{{ ec2_region }}"
+    filters:
+      attachment.instance-id: "{{ instance_id }}"
+      attachment.status: "attached"
+      attachment.device: "/dev/sda1"
+  register: original_volume
+
+- name: Get new root volume
+  ec2_vol_facts:
+    region: "{{ ec2_region }}"
+    filters:
+      attachment.instance-id: "{{ instance_id }}"
+      attachment.status: "attached"
+      attachment.device: "/dev/xvdf"
+  register: new_volume
+
+- name: Volume ID
+  set_fact:
+    original_volume_id: "{{ original_volume.volumes.0.id }}"
+    new_volume_id: "{{ new_volume.volumes.0.id }}"
+
+- name: Detach volumes
+  ec2_vol:
+    region: "{{ ec2_region }}"
+    id: "{{ item }}"
+    instance: ""
+  with_items:
+    - "{{ original_volume_id }}"
+    - "{{ new_volume_id }}"
+
+- name: Attach new volume
+  ec2_vol:
+    region: "{{ ec2_region }}"
+    id: "{{ new_volume_id }}"
+    state: "present"
+    instance: "{{ instance_id }}"
+    device_name: "/dev/sda1"
+    delete_on_termination: yes

--- a/examples/clusters/roles/ami/tasks/snapshot.yml
+++ b/examples/clusters/roles/ami/tasks/snapshot.yml
@@ -1,0 +1,14 @@
+---
+- name: "Snapshot root volume"
+  ec2_snapshot:
+    region: "{{ ec2_region }}"
+    instance_id: "{{ instance_id }}"
+    device_name: /dev/sda1
+    wait: yes
+  register: root_snapshot
+
+- debug: msg="{{ root_snapshot }}"
+
+- name: Set snapshot ID
+  set_fact:
+    root_snapshot_id: "{{ root_snapshot.snapshot_id }}"

--- a/examples/clusters/roles/ami/tasks/terminate.yml
+++ b/examples/clusters/roles/ami/tasks/terminate.yml
@@ -1,0 +1,17 @@
+---
+- name: Terminate instance
+  ec2:
+    state: 'absent'
+    region: "{{ ec2_region }}"
+    instance_ids: "{{ ec2_instance.instance_ids }}"
+
+- name: Cleanup managers userdata
+  s3:
+    bucket: "{{ s3_bucket }}"
+    object: "scripts/userdata-aws-manager"
+    mode: delobj
+- name: Cleanup workers userdata
+  s3:
+    bucket: "{{ s3_bucket }}"
+    object: "scripts/userdata-aws-worker"
+    mode: delobj

--- a/examples/clusters/roles/ami/tasks/wait-for-instance.yml
+++ b/examples/clusters/roles/ami/tasks/wait-for-instance.yml
@@ -1,0 +1,34 @@
+---
+- name: Wait for status signal (up to 600 sec)
+  wait_for:
+    delay: 120
+    timeout: 600
+    host: "{{ public_ip }}"
+    port: 80
+    state: started
+  changed_when: false
+
+- name: Get the build status
+  uri:
+    url: "http://{{ public_ip }}"
+    follow_redirects: safe
+    return_content: yes
+  register: status
+  changed_when: false
+  ignore_errors: true
+
+- debug: msg="status URL returned {{ status.content }}"
+  changed_when: false
+
+- name: Check UserData status
+  fail:
+  when: "'SUCCESS' not in status.content"
+  changed_when: false
+
+- name: Stop the instance
+  ec2:
+    region: "{{ ec2_region }}"
+    instance_id: "{{ instance_id }}"
+    state: stopped
+    wait: True
+  changed_when: false

--- a/examples/clusters/roles/ami/templates/userdata.j2
+++ b/examples/clusters/roles/ami/templates/userdata.j2
@@ -1,0 +1,30 @@
+#cloud-config
+repo_update : true
+repo_upgrade: security
+packages:
+  - ca-certificates
+  - jq
+  - curl
+  - unzip
+# aws cli to discover other nodes
+  - awscli
+# system monitoring tools
+  - sysstat
+  - iotop
+# xfs for the FS mounted on /var/lib/docker
+  - xfsprogs
+# setuptools needed for the installation of the cfn tools (including cfn-signal)
+  - python-setuptools
+runcmd:
+  - _ok () { cd /tmp ; echo SUCCESS > index.html ; /usr/bin/python3 -m http.server 80 ; }
+  - _ko () { cd /tmp ; echo FAIL > index.html ; /usr/bin/python3 -m http.server 80 ; }
+  - python -c "import pkg_resources" || curl -sf 'https://bootstrap.pypa.io/ez_setup.py' | python
+  - curl -sSf 'https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz' | tar xzf -
+  - (cd aws-cfn-bootstrap-* && python setup.py install) || _ko 
+  - rm -rf aws-cfn-bootstrap-*
+  - wget -qO- "{{docker_url}}" | sh || _ko
+  - echo "vm.max_map_count = 262144" > "/etc/sysctl.d/99-amp.conf" # prerequisite for elasticsearch
+  - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-manager" /usr/local/bin/userdata-aws-manager || _ko
+  - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-worker" /usr/local/bin/userdata-aws-worker || _ko
+  - chmod u+x /usr/local/bin/userdata-aws-worker /usr/local/bin/userdata-aws-manager
+  - _ok

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -24,22 +24,26 @@ _init_system(){
 _install_docker(){
   local _release=$(lsb_release -is)
   local _host
-  case $CHANNEL in
-  stable) _host="get.docker.com" ;;
-  edge|beta|test) _host="test.docker.com" ;;
-  experimental) _host="experimental.docker.com" ;;
-  *) return 1 ;;
-  esac
-  echo "installing Docker from $_host" >&2
-  wget -qO- "https://$_host/" | sh || return 1
-  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu
-  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin 
+  # on Debian style systems, this checks that docker-ce is installed
+  grep -A1 docker-ce /var/lib/dpkg/status | grep -q "installed$"
+  if [[ $? -ne 0 ]]; then
+    case $CHANNEL in
+    stable) _host="get.docker.com" ;;
+    edge|beta|test) _host="test.docker.com" ;;
+    experimental) _host="experimental.docker.com" ;;
+    *) return 1 ;;
+    esac
+    echo "installing Docker from $_host" >&2
+    wget -qO- "https://$_host/" | sh || return 1
+  fi
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu 2>/dev/null
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin  2>/dev/null
   if [[ $(_init_system) = "systemd" ]]; then
     systemctl enable docker.service
-    systemctl start docker.service
+    docker version -f {{.Server.Version}} &>/dev/null || systemctl start docker.service
   else
     chkconfig docker on
-    service docker start
+    docker version -f {{.Server.Version}} &>/dev/null || service docker start
   fi
   docker version >&2
 }
@@ -61,6 +65,7 @@ _expose_remote_api() {
   systemd)
     mkdir -p "$(dirname $SYSTEMD_DOCKER_OVERRIDE)"
     echo "exposing the engine API" >&2
+    [[ -f "$SYSTEMD_DOCKER_OVERRIDE" ]] && cp -p "$SYSTEMD_DOCKER_OVERRIDE" "$SYSTEMD_DOCKER_OVERRIDE.bak" && echo "Warning: an existing $SYSTEMD_DOCKER_OVERRIDE was found, it has been backed up" >&2
     cat > "$SYSTEMD_DOCKER_OVERRIDE" <<EOF
 [Service]
 ExecStart=
@@ -98,11 +103,20 @@ _sanity_check(){
 # installs the cfn tools, to be able to signal AWS that the application part of the deployment is done
 _install_helpers(){
   [[ "x$SYNC" != "xtrue" ]] && return 0
+  [[ -x /usr/local/bin/cfn-signal ]] && return 0
   python -c "import pkg_resources" || curl https://bootstrap.pypa.io/ez_setup.py | python
   curl -sSf https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar xzf -
   (cd aws-cfn-bootstrap-[0-9.]* && python setup.py install) || return 1
   rm -rf aws-cfn-bootstrap-[0-9.]*
   [[ -x /usr/local/bin/cfn-signal ]]
+}
+
+_stop_docker(){
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl stop docker.service &>/dev/null
+  else
+    service docker stop &>/dev/null
+  fi
 }
 
 _mount_docker_volume(){
@@ -284,6 +298,7 @@ _label_node(){
   local _publicip
   _self=$(docker node inspect self -f '{{.ID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  echo "applying labels amp.type.api and anp.type.route" >&2
   docker node update --label-add "PublicIP=$_publicip" "$_self" || return 1
   docker node update --label-add "amp.type.api=true" "$_self" || return 1
   docker node update --label-add "amp.type.route=true" "$_self"
@@ -305,23 +320,29 @@ _get_node_ip(){
 
 _smoke_test(){
   local reachability
+  echo "smoke tests...">&2
   SECONDS=0
   while [[ $SECONDS -lt 10 ]]; do
-    docker node ls &>/dev/null || return 1
+    sleep 1
+    docker node ls &>/dev/null || continue
     reachability=$(docker node inspect self -f '{{.ManagerStatus.Reachability}}')
     [[ "x$reachability" = "xreachable" ]] && return 0
-    sleep 1
   done
+  echo "smoke tests fail:" >&2
+  docker node ls >&2
+  docker node inspect self -f '{{.ManagerStatus.Reachability}}' >&2
   return 1
 }
 
 _signal_aws() {
   [[ "x$SYNC" != "xtrue" ]] && return 0
+  [[ -x /usr/local/bin/cfn-signal ]] || return 1
   /usr/local/bin/cfn-signal --stack "${STACK_NAME}" --region "${REGION}" --success true "${SIGNAL_URL}"
 }
 
 _sanity_check || exit 1
 _install_helpers || exit 1
+_stop_docker
 _mount_docker_volume $DOCKER_DEVICE || exit 1
 _system_prerequisites || exit 1
 nodeip=$(_get_node_ip)

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -2,6 +2,7 @@
 
 SYNC=${SYNC:-false}
 #SIGNAL_URL=
+#APP_SIGNAL_URL=
 CHANNEL=${CHANNEL:-stable}
 #PLUGINS=
 REGION=${REGION:-us-west-2}
@@ -336,8 +337,45 @@ _smoke_test(){
 
 _signal_aws() {
   [[ "x$SYNC" != "xtrue" ]] && return 0
+  _url=$1
   [[ -x /usr/local/bin/cfn-signal ]] || return 1
-  /usr/local/bin/cfn-signal --stack "${STACK_NAME}" --region "${REGION}" --success true "${SIGNAL_URL}"
+  if [[ -z "$_url" ]]; then
+    echo "_signal_aws was called without any URL" >&2
+    return 1
+  fi
+  /usr/local/bin/cfn-signal --stack "${STACK_NAME}" --region "${REGION}" --success true "$_url"
+}
+
+# wait for all nodes to be up and running (and labeled)
+_wait_for_full_swarm() {
+  local _timeout=360
+  local _label
+  local _label_prefix="amp.type."
+  local _labels="api route metrics mq kv search core user"
+  local _expected_label_count
+  local _current_labels
+  local _current_label_count
+
+  _expected_label_count=$(echo $_labels | wc -w)
+  echo "waiting for all scheduling labels to be defined on the swarm..." >&2
+  SECONDS=0
+  while [[ $SECONDS -lt $_timeout ]]; do
+    _current_label_count=0
+    _current_labels="$(for n in $(docker node ls -q); do docker node inspect $n --pretty | grep amp.type | sed -e 's/.*\(amp.type.*\) *=.*$/\1/'; done | sort | uniq)"
+    for _label in $_labels; do
+      echo $_current_labels | grep -q "${_label_prefix}${_label}" && ((++_current_label_count))
+    done
+    if [[ $_current_label_count -eq $_expected_label_count ]]; then
+      echo "All labels were found after $SECONDS sec" >&2
+      return 0
+    fi
+  done
+  echo "label search timed out ($SECONDS sec)" >&2
+  return 1
+}
+
+_setup() {
+  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock appcelerator/ampadmin
 }
 
 _sanity_check || exit 1
@@ -364,4 +402,9 @@ fi
 _label_node || exit 1
 _drain_node || exit 1
 _smoke_test || exit 1
-_signal_aws
+_signal_aws "${SIGNAL_URL}" || exit 1
+if [[ "x$nodeip" = "x$leader" ]]; then
+  _wait_for_full_swarm || exit 1
+  _setup || exit 1
+  _signal_aws "${APP_SIGNAL_URL}"
+fi

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -22,22 +22,26 @@ _init_system(){
 _install_docker(){
   local _release=$(lsb_release -is)
   local _host
-  case $CHANNEL in
-  stable) _host="get.docker.com" ;;
-  edge|beta|test) _host="test.docker.com" ;;
-  experimental) _host="experimental.docker.com" ;;
-  *) return 1 ;;
-  esac
-  echo "installing Docker from $_host" >&2
-  wget -qO- "https://$_host/" | sh || return 1
-  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu
-  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin 
+  # on Debian style systems, this checks that docker-ce is installed
+  grep -A1 docker-ce /var/lib/dpkg/status | grep -q "installed$"
+  if [[ $? -ne 0 ]]; then
+    case $CHANNEL in
+    stable) _host="get.docker.com" ;;
+    edge|beta|test) _host="test.docker.com" ;;
+    experimental) _host="experimental.docker.com" ;;
+    *) return 1 ;;
+    esac
+    echo "installing Docker from $_host" >&2
+    wget -qO- "https://$_host/" | sh || return 1
+  fi
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu 2>/dev/null
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin  2>/dev/null
   if [[ $(_init_system) = "systemd" ]]; then
     systemctl enable docker.service
-    systemctl start docker.service
+    docker version -f {{.Server.Version}} &>/dev/null || systemctl start docker.service
   else
     chkconfig docker on
-    service docker start
+    docker version -f {{.Server.Version}} &>/dev/null || service docker start
   fi
   docker version >&2
 }
@@ -70,11 +74,20 @@ _sanity_check(){
 # installs the cfn tools, to be able to signal AWS that the application part of the deployment is done
 _install_helpers(){
   [[ "x$SYNC" != "xtrue" ]] && return 0
+  [[ -x /usr/local/bin/cfn-signal ]] && return 0
   python -c "import pkg_resources" || curl https://bootstrap.pypa.io/ez_setup.py | python
   curl -sSf https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar xzf -
   (cd aws-cfn-bootstrap-[0-9.]* && python setup.py install) || return 1
   rm -rf aws-cfn-bootstrap-[0-9.]*
   [[ -x /usr/local/bin/cfn-signal ]]
+}
+
+_stop_docker(){
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl stop docker.service &>/dev/null
+  else
+    service docker stop &>/dev/null
+  fi
 }
 
 _mount_docker_volume(){
@@ -183,9 +196,11 @@ _label_node(){
   local _publicip
   _self=$(docker info -f '{{.Swarm.NodeID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  echo "applying label PublicIP=$_publicip" >&2
   docker -H "$_manager" node update --label-add "PublicIP=$_publicip" "$_self" || return 1
   for _label in $LABELS; do
-    docker -H "$_manager" node update --label-add "${_label}" "$_self" || return 1
+    echo "applying label $_label" >&2
+    docker -H "$_manager" node update --label-add "${_label}" "$_self" >/dev/null || return 1
   done
 }
 
@@ -203,16 +218,20 @@ _smoke_test(){
     [[ "x$_state" = "xactive" ]] && return 0
     sleep 1
   done
+  echo "smoke tests fail:" >&2
+  docker info -f '{{.Swarm.LocalNodeState}}' >&2
   return 1
 }
 
 _signal_aws() {
   [[ "x$SYNC" != "xtrue" ]] && return 0
+  [[ -x /usr/local/bin/cfn-signal ]] || return 1
   /usr/local/bin/cfn-signal --stack "${STACK_NAME}" --region "${REGION}" --success true "${SIGNAL_URL}"
 }
 
 _sanity_check || exit 1
 _install_helpers || exit 1
+_stop_docker
 _mount_docker_volume $DOCKER_DEVICE || exit 1
 _system_prerequisites || exit 1
 nodeip=$(_get_node_ip)

--- a/images/ansible/Dockerfile
+++ b/images/ansible/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.6
+
+RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edgetesting http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+RUN apk --update add ca-certificates sudo ansible@edge py-boto@edge py-boto3@edgetesting && \
+    rm -rf /var/cache/apk/*
+
+CMD [ "ansible-playbook", "--version" ]

--- a/images/ansible/docker-compose.test.yml
+++ b/images/ansible/docker-compose.test.yml
@@ -1,0 +1,5 @@
+version: '2'
+services:
+  sut:
+    build: .
+    image: appcelerator/ansible


### PR DESCRIPTION
- custom built AMI for AMP
  - the system package installation (as well as Docker) is now done once at AMI build
  - upstream repo issues won't affect the creation of a stack
  - quicker boot
  - it is used when the `LinuxDistribution` parameter is set to `Default` (this is now the default)
  - to build it, read the README.md file
- new stack parameter: `InstallApplication` (defaults to `true`)
  - when true, will wait for the full cluster to be up and will run a appcelerator/ampadmin container
  - a new WaitCondition is linked to the end of this phase, the stack creation will wait for it

Limitations:
the custom built image is only available from the appc account, it should be public so that other accounts can use it, but it requires more work to get there.