### PR TITLE
public AMI

### DIFF
--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-0de7db1b
+      Default: ami-b188b4a7
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-b83918dd
+      Default: ami-823b1ae7
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-7627360f
+      Default: ami-aeddccd7
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-0397707a
+      Default: ami-77e4030e
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-d88596bb
+      Default: ami-de889bbd
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -23,7 +23,8 @@ ec2_instance_type: "t2.small"
 iam_instance_profile: "amp-image-builder-role"
 
 ## Source AMI
-ec2_ami: "ami-17ba2a77"
+# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170619.1 in oregon
+ec2_ami: "ami-835b4efa"
 
 ## Security Group
 # should open port 80 (and optionally port 22 for debugging)

--- a/examples/clusters/roles/ami/tasks/ami.yml
+++ b/examples/clusters/roles/ami/tasks/ami.yml
@@ -34,10 +34,10 @@
 - debug: msg="New AMI {{ image_id }} in {{ ec2_region }}"
   changed_when: false
 
-#- name: Make AMI Public
-  #ec2_ami:
-    #image_id: "{{ image.image_id }}"
-    #state: present
-    #region: "{{ ec2_region }}"
-    #launch_permissions:
-      #group_names: ['all']
+- name: Make AMI Public
+  ec2_ami:
+    image_id: "{{ image.image_id }}"
+    state: present
+    region: "{{ ec2_region }}"
+    launch_permissions:
+      group_names: ['all']

--- a/examples/clusters/roles/ami/tasks/copy-ami.yml
+++ b/examples/clusters/roles/ami/tasks/copy-ami.yml
@@ -22,11 +22,11 @@
    - "{{ copies.results }}"
   changed_when: false
 
-#- name: Make Copies Public
-  #ec2_ami:
-    #image_id: "{{ item.image_id }}"
-    #region: "{{ item.item }}"
-    #state: present
-    #launch_permissions:
-      #group_names: ['all']
-  #with_items: "{{ copies.results }}"
+- name: Make Copies Public
+  ec2_ami:
+    image_id: "{{ item.image_id }}"
+    region: "{{ item.item }}"
+    state: present
+    launch_permissions:
+      group_names: ['all']
+  with_items: "{{ copies.results }}"


### PR DESCRIPTION
This PR fixes the limitation of PR #1482. The custom AMI is now public and can be used in any other AWS account.