### PR TITLE
amp service logs and amp stack logs are aliases of amp logs

### DIFF
--- a/cli/command/logs/logs.go
+++ b/cli/command/logs/logs.go
@@ -4,61 +4,65 @@ import (
 	"context"
 	"errors"
 	"io"
-
 	"strconv"
 
 	"github.com/appcelerator/amp/api/rpc/logs"
 	"github.com/appcelerator/amp/cli"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"google.golang.org/grpc/status"
 )
 
-type logsOptions struct {
-	follow         bool
-	includeAmpLogs bool
-	meta           bool
-	raw            bool
-	number         int64
-	msg            string
-	container      string
-	stack          string
-	node           string
+type LogsOptions struct {
+	Follow         bool
+	IncludeAmpLogs bool
+	Meta           bool
+	Raw            bool
+	Number         int64
+	Msg            string
+	Container      string
+	Stack          string
+	Node           string
+}
+
+func AddLogFlags(flags *pflag.FlagSet, opts *LogsOptions) {
+	flags.BoolVarP(&opts.Follow, "follow", "f", false, "Follow log output")
+	flags.BoolVarP(&opts.IncludeAmpLogs, "include", "i", false, "Include AMP logs")
+	flags.BoolVarP(&opts.Meta, "meta", "m", false, "Display entry metadata")
+	flags.Int64VarP(&opts.Number, "number", "n", 1000, "Number of results")
+	flags.StringVar(&opts.Msg, "msg", "", "Filter the message content by the given pattern")
+	flags.StringVar(&opts.Container, "container", "", "Filter by the given Container")
+	flags.StringVar(&opts.Node, "node", "", "Filter by the given node")
+	flags.BoolVarP(&opts.Raw, "raw", "r", false, "Display raw logs (no prefix)")
 }
 
 // NewLogsCommand returns a new instance of the logs command.
 func NewLogsCommand(c cli.Interface) *cobra.Command {
-	opts := logsOptions{}
+	opts := LogsOptions{}
 	cmd := &cobra.Command{
 		Use:   "logs [OPTIONS] SERVICE",
 		Short: "Fetch log entries matching provided criteria",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return getLogs(c, args, opts)
+			return GetLogs(c, args, opts)
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
-	flags.BoolVarP(&opts.includeAmpLogs, "include", "i", false, "Include AMP logs")
-	flags.BoolVarP(&opts.meta, "meta", "m", false, "Display entry metadata")
-	flags.Int64VarP(&opts.number, "number", "n", 1000, "Number of results")
-	flags.StringVar(&opts.msg, "msg", "", "Filter the message content by the given pattern")
-	flags.StringVar(&opts.container, "container", "", "Filter by the given container")
-	flags.StringVar(&opts.stack, "stack", "", "Filter by the given stack")
-	flags.StringVar(&opts.node, "node", "", "Filter by the given node")
-	flags.BoolVarP(&opts.raw, "raw", "r", false, "Display raw logs (no prefix)")
+	AddLogFlags(flags, &opts)
+	flags.StringVar(&opts.Stack, "stack", "", "Filter by the given stack")
 	return cmd
 }
 
-func getLogs(c cli.Interface, args []string, opts logsOptions) error {
+func GetLogs(c cli.Interface, args []string, opts LogsOptions) error {
 	request := logs.GetRequest{}
 	if len(args) > 0 {
 		request.Service = args[0]
 	}
-	request.Message = opts.msg
-	request.Container = opts.container
-	request.Stack = opts.stack
-	request.Node = opts.node
-	request.Size = opts.number
-	request.IncludeAmpLogs = opts.includeAmpLogs
+	request.Message = opts.Msg
+	request.Container = opts.Container
+	request.Stack = opts.Stack
+	request.Node = opts.Node
+	request.Size = opts.Number
+	request.IncludeAmpLogs = opts.IncludeAmpLogs
 
 	// Get logs from amplifier
 	ctx := context.Background()
@@ -71,13 +75,13 @@ func getLogs(c cli.Interface, args []string, opts logsOptions) error {
 		}
 	}
 	for _, entry := range r.Entries {
-		displayLogEntry(c, entry, opts.meta, opts.raw)
+		displayLogEntry(c, entry, opts.Meta, opts.Raw)
 	}
-	if !opts.follow {
+	if !opts.Follow {
 		return nil
 	}
 
-	// If follow is requested, get subsequent logs and stream it
+	// If Follow is requested, get subsequent logs and stream it
 	stream, err := lc.GetStream(ctx, &request)
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
@@ -94,7 +98,7 @@ func getLogs(c cli.Interface, args []string, opts logsOptions) error {
 				return errors.New(s.Message())
 			}
 		}
-		displayLogEntry(c, entry, opts.meta, opts.raw)
+		displayLogEntry(c, entry, opts.Meta, opts.Raw)
 	}
 	return nil
 }

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -1,85 +1,23 @@
 package service
 
 import (
-	"context"
-	"errors"
-	"io"
-
-	"github.com/appcelerator/amp/api/rpc/logs"
 	"github.com/appcelerator/amp/cli"
+	"github.com/appcelerator/amp/cli/command/logs"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/status"
 )
-
-type logsServiceOptions struct {
-	meta   bool
-	follow bool
-}
 
 // NewServiceLogsCommand returns a new instance of the service logs command.
 func NewServiceLogsCommand(c cli.Interface) *cobra.Command {
-	opts := logsServiceOptions{}
+	opts := logs.LogsOptions{}
 	cmd := &cobra.Command{
 		Use:     "logs [OPTIONS] SERVICE",
-		Short:   "Get all logs of a given service",
+		Short:   "Fetch log entries of given service matching provided criteria",
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return getLogs(c, args, opts)
+			return logs.GetLogs(c, args, opts)
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
-	flags.BoolVarP(&opts.meta, "meta", "m", false, "Display entry metadata")
+	logs.AddLogFlags(flags, &opts)
 	return cmd
-}
-
-func getLogs(c cli.Interface, args []string, opts logsServiceOptions) error {
-	request := logs.GetRequest{IncludeAmpLogs: false}
-	request.Service = args[0]
-
-	// Get logs from amplifier
-	ctx := context.Background()
-	conn := c.ClientConn()
-	lc := logs.NewLogsClient(conn)
-	r, err := lc.Get(ctx, &request)
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return errors.New(s.Message())
-		}
-	}
-	for _, entry := range r.Entries {
-		displayLogEntry(c, entry, opts.meta)
-	}
-	if !opts.follow {
-		return nil
-	}
-
-	// If follow is requested, get subsequent logs and stream it
-	stream, err := lc.GetStream(ctx, &request)
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return errors.New(s.Message())
-		}
-	}
-	for {
-		entry, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			if s, ok := status.FromError(err); ok {
-				return errors.New(s.Message())
-			}
-		}
-		displayLogEntry(c, entry, opts.meta)
-	}
-	return nil
-}
-
-func displayLogEntry(c cli.Interface, entry *logs.LogEntry, meta bool) {
-	if meta {
-		c.Console().Printf("%+v\n", entry)
-	} else {
-		c.Console().Printf("%s\n", entry.Msg)
-	}
 }

--- a/cli/command/stack/logs.go
+++ b/cli/command/stack/logs.go
@@ -1,14 +1,9 @@
 package stack
 
 import (
-	"context"
-	"errors"
-	"io"
-
-	"github.com/appcelerator/amp/api/rpc/logs"
 	"github.com/appcelerator/amp/cli"
+	"github.com/appcelerator/amp/cli/command/logs"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/status"
 )
 
 type logsStackOptions struct {
@@ -18,68 +13,18 @@ type logsStackOptions struct {
 
 // NewLogsCommand returns a new instance of the stack command.
 func NewLogsCommand(c cli.Interface) *cobra.Command {
-	opts := logsStackOptions{}
+	opts := logs.LogsOptions{}
 	cmd := &cobra.Command{
 		Use:     "logs [OPTIONS] STACK",
-		Short:   "Get all logs of a given stack",
+		Short:   "Fetch log entries of given stack matching provided criteria",
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return getLogs(c, args, opts)
+			opts.Stack = args[0]
+			args = nil
+			return logs.GetLogs(c, args, opts)
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
-	flags.BoolVarP(&opts.meta, "meta", "m", false, "Display entry metadata")
+	logs.AddLogFlags(flags, &opts)
 	return cmd
-}
-
-func getLogs(c cli.Interface, args []string, opts logsStackOptions) error {
-	request := logs.GetRequest{IncludeAmpLogs: false}
-	request.Stack = args[0]
-
-	// Get logs from amplifier
-	ctx := context.Background()
-	conn := c.ClientConn()
-	lc := logs.NewLogsClient(conn)
-	r, err := lc.Get(ctx, &request)
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return errors.New(s.Message())
-		}
-	}
-	for _, entry := range r.Entries {
-		displayLogEntry(c, entry, opts.meta)
-	}
-	if !opts.follow {
-		return nil
-	}
-
-	// If follow is requested, get subsequent logs and stream it
-	stream, err := lc.GetStream(ctx, &request)
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return errors.New(s.Message())
-		}
-	}
-	for {
-		entry, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			if s, ok := status.FromError(err); ok {
-				return errors.New(s.Message())
-			}
-		}
-		displayLogEntry(c, entry, opts.meta)
-	}
-	return nil
-}
-
-func displayLogEntry(c cli.Interface, entry *logs.LogEntry, meta bool) {
-	if meta {
-		c.Console().Printf("%+v\n", entry)
-	} else {
-		c.Console().Printf("%s\n", entry.Msg)
-	}
 }


### PR DESCRIPTION
Remove code duplication in CLI logs command.

## How to test
```
$ ampmake build
$ amp logs --help

Usage:	amp logs [OPTIONS] SERVICE

Fetch log entries matching provided criteria

Options:
      --container string   Filter by the given Container
  -f, --follow             Follow log output
  -h, --help               Print usage
  -i, --include            Include AMP logs
  -k, --insecure           Control whether amp verifies the server's certificate chain and host name
  -m, --meta               Display entry metadata
      --msg string         Filter the message content by the given pattern
      --node string        Filter by the given node
  -n, --number int         Number of results (default 1000)
  -r, --raw                Display raw logs (no prefix)
  -s, --server string      Specify server (host:port)
$ amp service logs --help

Usage:	amp service logs [OPTIONS] SERVICE

Fetch log entries of given service matching provided criteria

Options:
      --container string   Filter by the given Container
  -f, --follow             Follow log output
  -h, --help               Print usage
  -i, --include            Include AMP logs
  -k, --insecure           Control whether amp verifies the server's certificate chain and host name
  -m, --meta               Display entry metadata
      --msg string         Filter the message content by the given pattern
      --node string        Filter by the given node
  -n, --number int         Number of results (default 1000)
  -r, --raw                Display raw logs (no prefix)
  -s, --server string      Specify server (host:port)
$ amp stack logs --help

Usage:	amp stack logs [OPTIONS] STACK

Fetch log entries of given stack matching provided criteria

Options:
      --container string   Filter by the given Container
  -f, --follow             Follow log output
  -h, --help               Print usage
  -i, --include            Include AMP logs
  -k, --insecure           Control whether amp verifies the server's certificate chain and host name
  -m, --meta               Display entry metadata
      --msg string         Filter the message content by the given pattern
      --node string        Filter by the given node
  -n, --number int         Number of results (default 1000)
  -r, --raw                Display raw logs (no prefix)
  -s, --server string      Specify server (host:port)
```
