### PR TITLE
move from the local tag to the dev version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ script:
   - set -e
   - ampmake clean build-base build-cli
   - ls -la bin/linux/amd64
-  - amp cluster create --tag=local
+  - amp cluster create
   - TESTINCLUDE=platform/testing testrunner platform/tests
   - docker build -t appcelerator/amp-integration .
   - docker service create --detach=false --restart-condition=none --network ampnet --name integration appcelerator/amp-integration
   - docker logs -f $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}")
   - $(exit $(docker inspect $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}") --format "{{.State.ExitCode}}"))
-  - amp cluster rm --tag=local
+  - amp cluster rm
   #- ampmake lint
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ buildall-cli: $(AMPTARGET)
 # =============================================================================
 AMPL := amplifier
 AMPLBINARY=$(AMPL).alpine
-AMPLTAG := local
+AMPLTAG := $(VERSION)
 AMPLIMG := appcelerator/$(AMPL):$(AMPLTAG)
 AMPLTARGET := $(CMDDIR)/$(AMPL)/$(AMPLBINARY)
 AMPLDIRS := $(CMDDIR)/$(AMPL) api data $(COMMONDIRS)
@@ -191,7 +191,7 @@ clean-server:
 # =============================================================================
 GW := gateway
 GWBINARY=$(GW).alpine
-GWTAG := local
+GWTAG := $(VERSION)
 GWIMG := appcelerator/$(GW):$(GWTAG)
 GWTARGET := $(CMDDIR)/$(GW)/$(GWBINARY)
 GWDIRS := $(CMDDIR)/$(GW) api data $(COMMONDIRS)
@@ -221,7 +221,7 @@ clean-gateway:
 # =============================================================================
 MONIT := monitoring
 MONITBINARY=promctl.alpine
-MONITTAG := local
+MONITTAG := $(VERSION)
 MONITIMG := appcelerator/amp-prometheus:$(MONITTAG)
 MONITTARGET := $(MONIT)/$(MONITBINARY)
 MONITDIRS := $(MONIT)/promctl $(COMMONDIRS)
@@ -251,7 +251,7 @@ clean-monit:
 # =============================================================================
 BEAT := ampbeat
 BEATBINARY=$(BEAT).alpine
-BEATTAG := local
+BEATTAG := $(VERSION)
 BEATIMG := appcelerator/$(BEAT):$(BEATTAG)
 BEATTARGET := $(CMDDIR)/$(BEAT)/$(BEATBINARY)
 BEATDIRS := $(CMDDIR)/$(BEAT) api data $(COMMONDIRS)
@@ -281,7 +281,7 @@ clean-beat:
 # =============================================================================
 AGENT := agent
 AGENTBINARY=$(AGENT).alpine
-AGENTTAG := local
+AGENTTAG := $(VERSION)
 AGENTIMG := appcelerator/$(AGENT):$(AGENTTAG)
 AGENTTARGET := $(CMDDIR)/$(AGENT)/$(AGENTBINARY)
 AGENTDIRS := $(CMDDIR)/$(AGENT) agent api $(COMMONDIRS)
@@ -311,7 +311,7 @@ clean-agent:
 AMPBOOTDIR := platform
 AMPBOOTBIN := platform
 AMPBOOTIMG := appcelerator/amp-bootstrap
-AMPBOOTVER ?= local
+AMPBOOTVER ?= $(VERSION)
 AMPBOOTSRC := platform/bin/deploy platform/bin/dev $(shell find $(AMPBOOTDIR) -type f)
 
 .PHONY: build-bootstrap

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -29,7 +29,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.BoolVarP(&opts.notifications, "notifications", "n", false, "Enable/disable server notifications (default is 'false')")
 	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider (\"local\" (default) or \"aws\")")
 	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use '0.13.0-dev' for development)")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images")
 
 	// local options
 	flags.String("local-managers", "1", "Initial number of local manager nodes")

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -29,7 +29,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.BoolVarP(&opts.notifications, "notifications", "n", false, "Enable/disable server notifications (default is 'false')")
 	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider (\"local\" (default) or \"aws\")")
 	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use 'local' for development)")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images (use '0.13.0-dev' for development)")
 
 	// local options
 	flags.String("local-managers", "1", "Initial number of local manager nodes")

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -17,7 +17,7 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for bootstrap images, use 'local' for development")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for the amp-bootstrap image")
 	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
 	return cmd

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -17,7 +17,7 @@ func NewStatusCommand(c cli.Interface) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for bootstrap images (default is '0.12.0', use 'local' for development)")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for bootstrap images (use '0.13.0-dev' for development)")
 	return cmd
 }
 

--- a/cli/command/cluster/status.go
+++ b/cli/command/cluster/status.go
@@ -17,7 +17,7 @@ func NewStatusCommand(c cli.Interface) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
-	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for bootstrap images (use '0.13.0-dev' for development)")
+	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for the amp-bootstrap image")
 	return cmd
 }
 

--- a/cmd/amp/Dockerfile
+++ b/cmd/amp/Dockerfile
@@ -1,5 +1,0 @@
-FROM appcelerator/amp-bootstrap:local
-
-COPY amp.alpine /usr/local/bin/amp
-ENTRYPOINT [ "amp" ]
-

--- a/platform/bin/deploy
+++ b/platform/bin/deploy
@@ -526,13 +526,13 @@ bootstrap_cluster() {
     ok
   fi
 
-  if [[ -n "$registryurl" && "x$TAG" = "xlocal" ]]; then
+  if [[ -n "$registryurl" ]] && echo "$TAG" | grep -q -- "-dev"; then
     echo "push images to cluster"
     for image in amplifier gateway ampbeat agent; do
-      pushimage "${registryurl}" "appcelerator/${image}:${TAG:-local}"
+      pushimage "${registryurl}" "appcelerator/${image}:${TAG}"
     done
   else
-    echo "image push to cluster is ignored (tag=${TAG:-latest})"
+    echo "image push to cluster is ignored (tag=${TAG})"
   fi
 }
 

--- a/platform/build
+++ b/platform/build
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-TAGS=( latest 0.12.0 )
+TAGS=( latest 0.13.0 )
 OWNER=appcelerator
 IMAGE="${1:-amp-bootstrap}"
 
-# This is now built by the amp Makefile with the tag `:local`
+# This is now built by the amp Makefile with the tag `:$(VERSION)`
 #docker build -t ${OWNER}/${IMAGE} .
 
 for tag in "${TAGS[@]}"

--- a/platform/stacks/portal.stack.yml
+++ b/platform/stacks/portal.stack.yml
@@ -9,7 +9,7 @@ networks:
 services:
 
   portal:
-    image: appcelerator/portal:${TAG:-0.12.0}
+    image: appcelerator/portal:latest
     networks:
       - default
     deploy:

--- a/platform/tests/stacks/create/create_test.sh
+++ b/platform/tests/stacks/create/create_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-amp -k stack up -c platform/stacks/visualizer.stack.yml
+amp -k stack up -c examples/stacks/ui/ui.stack.yml visualizer
 amp -k stack ls 2>/dev/null | grep -q "\svisualizer\s"

--- a/platform/tests/stacks/up/up_test.sh
+++ b/platform/tests/stacks/up/up_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 test_stack_up() {
-  amp -k stack up -c platform/stacks/visualizer.stack.yml
+  amp -k stack up -c examples/stacks/ui/ui.stack.yml visualizer
   amp -k stack ls 2>/dev/null | grep -Eq "visualizer"
 }

--- a/platform/tests/version_test.sh
+++ b/platform/tests/version_test.sh
@@ -3,7 +3,7 @@
 # not finding the version is an error
 test_has_version() {
   result=$(amp -k version)
-  version="v[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}"
+  version="[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}"
   echo $result | grep -E "Version:[[:space:]]+$version"
 }
 


### PR DESCRIPTION
Fix #1331 (amp cluster create error on dev version)

When using the AMP CLI compiled from the repo (dev version, as opposed to the downloadable released versions), it used to reference the `local` tag of core services images, as well as the amp-bootstrap image.
From now on, it will use the dev version (0.13.0-dev as of today) instead.
As an exception, the portal image is now deployed from the `latest` tag, as it's not part of the repo anymore.

### Verification
```
# remove all of the previous local images, for instance with:
docker image ls | grep -w local | awk '{print $1 ":local"}' | xargs docker image rm
# build the 0.13.0-dev images:
ampmake build
# create the cluster
amp cluster create
# check the version of the service
docker ps --format '{{.Image}}'
# there should be no local image
```