### PR TITLE
Leverage Swarm events in pre deployment checks

### DIFF
--- a/cluster/agent/Makefile
+++ b/cluster/agent/Makefile
@@ -20,5 +20,8 @@ image:
 	docker build -t $(IMAGE) .
 
 run:
-	docker run -it --rm -v /var/run/docker:/var/run/docker $(IMAGE) monitor
+	docker run -t --rm -v /var/run/docker:/var/run/docker:ro $(IMAGE) monitor
+
+run-checks:
+	docker run -t --rm -v /var/run/docker:/var/run/docker:ro -v /var/run/docker.sock:/var/run/docker.sock:ro appcelerator/ampagent check -a
 

--- a/cluster/agent/cmd/checks.go
+++ b/cluster/agent/cmd/checks.go
@@ -9,6 +9,7 @@ import (
 
 type CheckOptions struct {
 	version    bool
+	labels     bool
 	scheduling bool
 	all        bool
 }
@@ -22,6 +23,7 @@ func NewChecksCommand() *cobra.Command {
 		Run:   checks,
 	}
 	checkCmd.Flags().BoolVar(&checksOpts.version, "version", false, "check Docker version")
+	checkCmd.Flags().BoolVar(&checksOpts.labels, "labels", false, "check all required labels are defined on the swarm")
 	checkCmd.Flags().BoolVar(&checksOpts.scheduling, "scheduling", false, "check Docker service scheduling")
 	checkCmd.Flags().BoolVarP(&checksOpts.all, "all", "a", false, "all tests")
 
@@ -30,17 +32,27 @@ func NewChecksCommand() *cobra.Command {
 
 func checks(cmd *cobra.Command, args []string) {
 	if checksOpts.version || checksOpts.all {
-		out, err := adm.VerifyDockerVersion()
-		if err != nil {
+		if err := adm.VerifyDockerVersion(); err != nil {
+			log.Println("Version test: FAIL")
 			log.Fatal(err)
+		} else {
+			log.Println("Version test: PASS")
 		}
-		log.Println(out)
+	}
+	if checksOpts.labels || checksOpts.all {
+		if err := adm.VerifyLabels(); err != nil {
+			log.Println("Labels test: FAIL")
+			log.Fatal(err)
+		} else {
+			log.Println("Labels test: PASS")
+		}
 	}
 	if checksOpts.scheduling || checksOpts.all {
-		out, err := adm.VerifyServiceScheduling()
-		if err != nil {
+		if err := adm.VerifyServiceScheduling(); err != nil {
+			log.Println("Labels test: FAIL")
 			log.Fatal(err)
+		} else {
+			log.Println("Labels test: PASS")
 		}
-		log.Println(out)
 	}
 }


### PR DESCRIPTION
Use the SwarmKit events to validate service task creation and task stability

## Verification
on a swarm manager node,
```
cd cluster/agent
make image
docker run --rm -v /var/run/docker:/var/run/docker:ro -v /var/run/docker.sock:/var/run/docker.sock:ro appcelerator/ampagent check -a
```
it should output something similar to:
```
2017/07/07 06:46:03 Docker engine version 17.06.0-ce
2017/07/07 06:46:03 passed - api version = 1.3

2017/07/07 06:46:03 creating network amptest
2017/07/07 06:46:03 creating service check-server
2017/07/07 06:46:04 expected event count reached
2017/07/07 06:46:04 Task creation events successfuly read
2017/07/07 06:46:04 creating service check-client
2017/07/07 06:46:06 expected event count reached
2017/07/07 06:46:06 Task creation events successfuly read
2017/07/07 06:46:12 timeout reached while waiting for events
2017/07/07 06:46:12 No dropped task
2017/07/07 06:46:17 Counting request success rate
2017/07/07 06:46:17 Removing service check-client (qwnxx1vou9kecndrjoto2gjos)
2017/07/07 06:46:19 Removing service check-server (y0f581wi1o3asknlu31xn05c0)
2017/07/07 06:46:21 removing network amptest (kdwaqni6btdr2sod0ucrlpbcx)
2017/07/07 06:46:21 passed - 1105 connections / 1105 success
```