### PR TITLE
Handle case insensitive values for CLI command args/options

### DIFF
--- a/cli/command/org/member/role.go
+++ b/cli/command/org/member/role.go
@@ -2,8 +2,8 @@ package member
 
 import (
 	"errors"
-
 	"fmt"
+	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/account"
 	"github.com/appcelerator/amp/cli"
@@ -55,7 +55,8 @@ func changeOrgMemRole(c cli.Interface, cmd *cobra.Command, opts changeMemOrgOpti
 		opts.role = c.Console().GetInput("organization role")
 	}
 	orgRole := accounts.OrganizationRole_ORGANIZATION_MEMBER
-	switch opts.role {
+	role := strings.ToLower(opts.role)
+	switch role {
 	case "owner":
 		orgRole = accounts.OrganizationRole_ORGANIZATION_OWNER
 	case "member":

--- a/cli/command/team/resource/permission.go
+++ b/cli/command/team/resource/permission.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/appcelerator/amp/api/rpc/resource"
 	"github.com/appcelerator/amp/cli"
@@ -60,7 +61,8 @@ func changeOrgMemRole(c cli.Interface, cmd *cobra.Command, opts changeTeamResPer
 		}
 	}
 	permissionLevel := accounts.TeamPermissionLevel_TEAM_READ
-	switch opts.permissionLevel {
+	permLevel := strings.ToLower(opts.permissionLevel)
+	switch permLevel {
 	case "read":
 		permissionLevel = accounts.TeamPermissionLevel_TEAM_READ
 	case "write":

--- a/platform/tests/org/member/role/role_test.sh
+++ b/platform/tests/org/member/role/role_test.sh
@@ -2,3 +2,4 @@
 
 amp -k org member add user
 amp -k org member role --member=user --role=owner | grep -q "Member role has been changed."
+amp -k org member role --member=user1 --role=OWNER | grep -q "Member role has been changed."

--- a/platform/tests/team/resource/permission/permission_test.sh
+++ b/platform/tests/team/resource/permission/permission_test.sh
@@ -4,4 +4,6 @@ for id in $(amp -k stack ls -q)
 do
   amp -k team resource perm $id write | grep -q "Permission level has been changed."
   amp -k team resource ls | grep -q "TEAM_WRITE"
+  amp -k team resource perm $id READ | grep -q "Permission level has been changed."
+  amp -k team resource ls | grep -q "TEAM_READ"
 done


### PR DESCRIPTION
resolves #1505 

Organization member role and Team resource permission level now accept case-insensitive values.

### Test
Smoke tests have been updated