### PR TITLE
deploy script won't fail if there's a non core broken service

### DIFF
--- a/platform/bin/servicescheck
+++ b/platform/bin/servicescheck
@@ -5,7 +5,7 @@ INTERVAL="${2:-2}"
 [[ "$DOCKERHOST" = "m1" ]] && amps="docker run -it --rm --network=hostnet docker --host=m1" || amps="docker --host=$DOCKERHOST"
 
 check() {
-  list=$($amps service ls)
+  list=$($amps service ls | grep "\samp_")
   result=$(echo "$list" | awk '{ print $4 }' | tail -n +2)
 
   read -ra replicas <<< $result
@@ -21,9 +21,9 @@ check() {
 
 dumplogs() {
   uptime
-  $amps service ls
+  $amps service ls | grep "\samp_"
 
-  list=$($amps service ls)
+  list=$($amps service ls | grep "\samp_")
   result=$(echo "$list" | awk '{ print $2 }' | tail -n +2)
 
   read -ra services <<< $result
@@ -48,6 +48,6 @@ while true; do
   # heartbeat trace so CI builds don't time out
   if [ $(($SECONDS - $trace)) -gt 10 ]; then
     trace=$SECONDS
-    $amps service ls
+    $amps service ls | grep "\samp_"
   fi
 done


### PR DESCRIPTION
Fix #1299 
Ref #1510 
Ref #1513

If there's an existing service with failing tasks on the local node where the `amp cluster create` is executed, the cluster creation fails. This PR fixes it by ignoring the non core services at the service check step.

## Verification

create a broken service:
```
docker service create --name broken_service alpine:3.6 /bin/false
```
This would prevent the creation of the cluster with AMP 0.12.0.

```
make build-cli
amp cluster create
```
The deployment should not fail anymore.
Don't forget to remove the test service:
```
docker service rm broken_service
```