### PR TITLE
Updated visualizer image in UI stack example

### DIFF
--- a/examples/stacks/ui/ui.stack.yml
+++ b/examples/stacks/ui/ui.stack.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   visualizer:
-    image: manomarks/visualizer
+    image: dockersamples/visualizer
     networks:
       - default
     environment:


### PR DESCRIPTION
Resolves #1514 

The UI stack example now references the updated visualizer image from [hub](https://hub.docker.com/r/dockersamples/visualizer/tags/)