### PR TITLE
Improving elasticsearch error reporting with more detailed information

### DIFF
--- a/api/rpc/logs/logs.go
+++ b/api/rpc/logs/logs.go
@@ -90,7 +90,7 @@ func (s *Server) Get(ctx context.Context, in *GetRequest) (*GetReply, error) {
 	// Perform ES request
 	searchResult, err := request.Query(masterQuery).Do(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		return nil, status.Errorf(codes.Internal, elasticsearch.FormatError(err))
 	}
 
 	// Build reply

--- a/pkg/elasticsearch/elasticsearch.go
+++ b/pkg/elasticsearch/elasticsearch.go
@@ -2,6 +2,8 @@ package elasticsearch
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"gopkg.in/olivere/elastic.v5"
@@ -95,4 +97,20 @@ func (es *Elasticsearch) Index(ctx context.Context, esIndex string, esType strin
 		return err
 	}
 	return nil
+}
+
+// FormatError formats an elastic.Error
+func FormatError(err error) string {
+	e, ok := err.(*elastic.Error)
+	if !ok {
+		return "Unable to cast to elastic.Error"
+	}
+	if len(e.Details.RootCause) == 0 {
+		return e.Error()
+	}
+	details, err := json.MarshalIndent(e.Details.RootCause[0], "", "    ")
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("%s\n%s", e.Error(), string(details))
 }


### PR DESCRIPTION
Add context information to elasticsearch errors.

Example:
- Before
```
$ amp logs amp_amplifier
[user su in organization so @ localhost:50101]
Error: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]
```
- After
```
$ amp logs amp_amplifier
[user su in organization so @ localhost:50101]
Error: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]
{
    "type": "query_shard_exception",
    "reason": "No mapping found for [time_idd] in order to sort on",
    "index": "ampbeat-2017.07.11"
}
```

## How to test
Check Travis build.
