### PR TITLE
Remove org reference in commands

### DIFF
--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -49,9 +49,9 @@ func list(c cli.Interface, opts listStackOptions) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, cli.Padding, ' ', 0)
-	fmt.Fprintln(w, "ID\tNAME\tSERVICES\tFAILED SERVICES\tSTATUS\tOWNER\tORGANIZATION")
+	fmt.Fprintln(w, "ID\tNAME\tSERVICES\tFAILED SERVICES\tSTATUS\tOWNER")
 	for _, entry := range reply.Entries {
-		fmt.Fprintf(w, "%s\t%s\t%d/%d\t%d\t%s\t%s\t%s\n", entry.Stack.Id, entry.Stack.Name, entry.RunningServices, entry.TotalServices, entry.FailedServices, entry.Status, entry.Stack.Owner.User, entry.Stack.Owner.Organization)
+		fmt.Fprintf(w, "%s\t%s\t%d/%d\t%d\t%s\t%s\n", entry.Stack.Id, entry.Stack.Name, entry.RunningServices, entry.TotalServices, entry.FailedServices, entry.Status, entry.Stack.Owner.User)
 	}
 	w.Flush()
 	return nil

--- a/cli/command/whoami/whoami.go
+++ b/cli/command/whoami/whoami.go
@@ -30,11 +30,11 @@ func whoami(c cli.Interface) error {
 		return []byte{}, nil
 	})
 	if claims, ok := pToken.Claims.(*auth.AuthClaims); ok {
-		if claims.ActiveOrganization != "" {
-			c.Console().Printf("Logged in as organization: %s (on behalf of user %s)\n", claims.ActiveOrganization, claims.AccountName)
-		} else {
-			c.Console().Printf("Logged in as user: %s\n", claims.AccountName)
-		}
+		//if claims.ActiveOrganization != "" {
+		//	c.Console().Printf("Logged in as organization: %s (on behalf of user %s)\n", claims.ActiveOrganization, claims.AccountName)
+		//} else {
+		c.Console().Printf("Logged in as user: %s\n", claims.AccountName)
+		//}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1524 

`amp whoami` and `amp stack ls` commands no longer have `org` reference