### PR TITLE
Remove default org from CLI information

### DIFF
--- a/cmd/amp/commands.go
+++ b/cmd/amp/commands.go
@@ -142,11 +142,11 @@ func info(c cli.Interface) {
 			return []byte{}, nil
 		})
 		if claims, ok := pToken.Claims.(*auth.AuthClaims); ok {
-			if claims.ActiveOrganization != "" {
-				fmt.Fprintf(c.Err(), "[user %s in organization %s @ %s]\n", claims.AccountName, claims.ActiveOrganization, s)
-			} else {
-				fmt.Fprintf(c.Err(), "[user %s @ %s]\n", claims.AccountName, s)
-			}
+			//if claims.ActiveOrganization != "" {
+			//	fmt.Fprintf(c.Err(), "[user %s in organization %s @ %s]\n", claims.AccountName, claims.ActiveOrganization, s)
+			//} else {
+			fmt.Fprintf(c.Err(), "[user %s @ %s]\n", claims.AccountName, s)
+			//}
 		}
 	}
 }


### PR DESCRIPTION
Ref #1524 

The default organization is no longer displayed on the CLI information. 
#### Before
```
$ amp whoami 
[user neha1 in organization default @ localhost:50101]
Logged in as user: neha1
```
#### After
```
$ amp whoami 
[user neha1 @ localhost:50101]
Logged in as user: neha1
```