### PR TITLE
Stack files refactoring for amp-agent

### DIFF
--- a/cluster/agent/stacks/01-elasticsearch-cluster.amp.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.amp.yml
@@ -1,0 +1,42 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  elasticsearch-data:
+
+services:
+
+  elasticsearch:
+    image: appcelerator/elasticsearch-amp:5.4.2
+    networks:
+      - default
+    volumes:
+      - elasticsearch-data:/opt/elasticsearch-5.4.2/data
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "15s"
+      amp.service.stabilize.timeout: "45s"
+    environment:
+      MIN_MASTER_NODES: 2
+      NETWORK_HOST: "_eth0_"
+      UNICAST_HOSTS: "tasks.elasticsearch"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
+    deploy:
+      mode: replicated
+      replicas: 3
+      update_config:
+        parallelism: 1
+        delay: 45s
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 25s
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.search == true

--- a/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  elasticsearch:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "30", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=20s" ]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.user == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/01-elasticsearch-single.amp.yml
+++ b/cluster/agent/stacks/01-elasticsearch-single.amp.yml
@@ -1,0 +1,33 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  elasticsearch-data:
+
+services:
+
+  elasticsearch:
+    image: appcelerator/elasticsearch-amp:5.4.2
+    networks:
+      - default
+    volumes:
+      - elasticsearch-data:/opt/elasticsearch-5.4.2/data
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "10s"
+      amp.service.stabilize.timeout: "30s"
+    environment:
+      NETWORK_HOST: "_eth0_"
+      JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.search == true

--- a/cluster/agent/stacks/01-elasticsearch-single.test.yml
+++ b/cluster/agent/stacks/01-elasticsearch-single.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  elasticsearch:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "20", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=15s" ]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.user == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/01-etcd-cluster.amp.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.amp.yml
@@ -1,0 +1,43 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  etcd-data:
+
+services:
+
+  etcd:
+    image: appcelerator/etcd:3.1.9
+    networks:
+      default:
+    volumes:
+      - etcd-data:/data
+    environment:
+      SERVICE_NAME: "etcd"
+      MIN_SEEDS_COUNT: 3
+    command:
+      - "--advertise-client-urls"
+      - "http://etcd:2379"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "10s"
+      amp.service.stabilize.timeout: "30s"
+    deploy:
+      mode: replicated
+      replicas: 3
+      update_config:
+        parallelism: 1
+        delay: 30s
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 25s
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.kv == true

--- a/cluster/agent/stacks/01-etcd-cluster.test.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.test.yml
@@ -1,0 +1,30 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  etcd:
+    image: appcelerator/etcd:3.1.9
+    networks:
+      - default
+    environment:
+      ETCDCTL_API: 3
+    command: ["sh", "-c", "etcdctl --endpoints http://${AMP_STACK:-amp}_etcd:2379 endpoint health | grep -qw healthy"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/01-etcd-single.amp.yml
+++ b/cluster/agent/stacks/01-etcd-single.amp.yml
@@ -1,0 +1,36 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  etcd-data:
+
+services:
+
+  etcd:
+    image: appcelerator/etcd:3.1.9
+    networks:
+      default:
+    volumes:
+      - etcd-data:/data
+    environment:
+      SERVICE_NAME: "etcd"
+      MIN_SEEDS_COUNT: 1
+    command:
+      - "--advertise-client-urls"
+      - "http://etcd:2379"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.kv == true

--- a/cluster/agent/stacks/01-etcd-single.test.yml
+++ b/cluster/agent/stacks/01-etcd-single.test.yml
@@ -1,0 +1,30 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  etcd:
+    image: appcelerator/etcd:3.1.9
+    networks:
+      - default
+    environment:
+      ETCDCTL_API: 3
+    command: ["sh", "-c", "etcdctl --endpoints http://${AMP_STACK:-amp}_etcd:2379 endpoint health | grep -qw healthy"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/01-nats.amp.yml
+++ b/cluster/agent/stacks/01-nats.amp.yml
@@ -1,0 +1,27 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  nats:
+    image: appcelerator/amp-nats-streaming:v0.5.0
+    networks:
+      default:
+        aliases:
+          - nats
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.mq == true

--- a/cluster/agent/stacks/01-nats.test.yml
+++ b/cluster/agent/stacks/01-nats.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  nats:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "5", "${AMP_STACK:-amp}_nats:8222/subsz"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/01-pinger.yml
+++ b/cluster/agent/stacks/01-pinger.yml
@@ -1,9 +1,0 @@
-version: "3"
-
-services:
-  pinger:
-    image: subfuzion/pinger
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure

--- a/cluster/agent/stacks/02-ampbeat.amp.yml
+++ b/cluster/agent/stacks/02-ampbeat.amp.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  ampbeat:
+    image: appcelerator/ampbeat:${TAG:-0.12.0}
+    networks:
+      - default
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"

--- a/cluster/agent/stacks/03-kibana.amp.yml
+++ b/cluster/agent/stacks/03-kibana.amp.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  kibana:
+    image: appcelerator/kibana:5.4.2
+    networks:
+      - default
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.mapping: "kibana:5601"
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "10s"
+      amp.service.stabilize.timeout: "30s"
+    environment:
+      ELASTICSEARCH_URL: "http://elasticsearch:9200"
+      SERVICE_PORTS: 5601
+      VIRTUAL_HOST: "http://kibana.*,https://kibana.*"

--- a/cluster/agent/stacks/03-kibana.test.yml
+++ b/cluster/agent/stacks/03-kibana.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  kibana:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "5", "${AMP_STACK:-amp}_kibana:5601/app/kibana#/discover"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/04-haproxy_exporter.amp.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.amp.yml
@@ -1,0 +1,29 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  haproxy_exporter:
+    image: prom/haproxy-exporter:v0.7.1
+    command: ["-haproxy.scrape-uri", "http://stats:stats@proxy:1936/haproxy?stats;csv"]
+    networks:
+      - default
+    #ports:
+      #- target: 9101
+      #- published: 9101
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true

--- a/cluster/agent/stacks/04-haproxy_exporter.test.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  haproxy_exporter:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "5", "${AMP_STACK:-amp}_haproxy_exporter:9101/metrics"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/04-nats_exporter.amp.yml
+++ b/cluster/agent/stacks/04-nats_exporter.amp.yml
@@ -1,0 +1,29 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  nats_exporter:
+    image: appcelerator/prometheus-nats-exporter:latest
+    networks:
+      - default
+    command: ["-varz", "-routez", "-connz", "-subz", "nats,http://nats:8222"]
+    #ports:
+      #- target: 7777
+      #- published: 7777
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true

--- a/cluster/agent/stacks/04-nats_exporter.test.yml
+++ b/cluster/agent/stacks/04-nats_exporter.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  nats_exporter:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "${AMP_STACK:-amp}_nats_exporter:7777/metrics"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/04-node_exporter.amp.yml
+++ b/cluster/agent/stacks/04-node_exporter.amp.yml
@@ -1,0 +1,29 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  node_exporter:
+    image: prom/node-exporter:v0.14.0
+    networks:
+      - default
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - "9100:9100"
+    command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"

--- a/cluster/agent/stacks/04-node_exporter.test.yml
+++ b/cluster/agent/stacks/04-node_exporter.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  node_exporter:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "${AMP_STACK:-amp}_node_exporter:9100/metrics"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/05-prometheus.amp.yml
+++ b/cluster/agent/stacks/05-prometheus.amp.yml
@@ -1,0 +1,44 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  prometheus-data:
+
+secrets:
+  prometheus_alerts_rules:
+    external: true
+
+services:
+
+  prometheus:
+    image: appcelerator/amp-prometheus:${TAG:-0.12.0}
+    networks:
+      - default
+    volumes:
+      - prometheus-data:/prometheus
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      SERVICE_PORTS: 9090
+      VIRTUAL_HOST: "http://alerts.*,https://alerts.*"
+    ports:
+      - "9090:9090"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "8s"
+      amp.service.stabilize.timeout: "30s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+    secrets:
+      - source: prometheus_alerts_rules
+        target: alerts.rules
+        mode: 0400

--- a/cluster/agent/stacks/05-prometheus.test.yml
+++ b/cluster/agent/stacks/05-prometheus.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  prometheus:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "${AMP_STACK:-amp}_prometheus:9090/status"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/06-alertmanager.amp.yml
+++ b/cluster/agent/stacks/06-alertmanager.amp.yml
@@ -1,0 +1,43 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  alertmanager-data:
+
+secrets:
+  alertmanager_yml:
+    external: true
+
+services:
+
+  alertmanager:
+    image: prom/alertmanager:v0.7.1
+    networks:
+      - default
+    volumes:
+      - alertmanager-data:/alertmanager
+    ports:
+      - "9093:9093"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+    secrets:
+      - source: alertmanager_yml
+        target: alertmanager.yml
+        mode: 0400
+    command: [ "-config.file=/run/secrets/alertmanager.yml",
+             "-storage.path=/alertmanager",
+             "-web.external-url=http://localhost:9093" ]

--- a/cluster/agent/stacks/06-alertmanager.test.yml
+++ b/cluster/agent/stacks/06-alertmanager.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  alertmanager:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "${AMP_STACK:-amp}_alertmanager:9093/metrics"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/07-grafana.amp.yml
+++ b/cluster/agent/stacks/07-grafana.amp.yml
@@ -1,0 +1,33 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  grafana-data:
+
+services:
+
+  grafana:
+    image: appcelerator/grafana-amp:1.2.3
+    networks:
+      - default
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      SERVICE_PORTS: 3000
+      VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "10s"
+      amp.service.stabilize.timeout: "30s"
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true

--- a/cluster/agent/stacks/07-grafana.test.yml
+++ b/cluster/agent/stacks/07-grafana.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  grafana:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sfm", "6", "${AMP_STACK:-amp}_grafana:3000/api/org"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.metrics == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/08-proxy.amp.yml
+++ b/cluster/agent/stacks/08-proxy.amp.yml
@@ -1,0 +1,40 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+secrets:
+  certificate_atomiq:
+    external: true
+
+services:
+
+  proxy:
+    image: dockercloud/haproxy
+    networks:
+      - default
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.route == true
+    environment:
+      CERT_FOLDER: "/run/secrets"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "20s"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "1936:1936"
+    secrets:
+      - source: certificate_atomiq
+        target: cert0.pem
+        mode: 0400

--- a/cluster/agent/stacks/08-proxy.test.yml
+++ b/cluster/agent/stacks/08-proxy.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  proxy:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "http://stats:stats@${AMP_STACK:-amp}_proxy:1936/haproxy?stats;csv"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.route == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/09-amplifier.amp.yml
+++ b/cluster/agent/stacks/09-amplifier.amp.yml
@@ -1,0 +1,46 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+secrets:
+  amplifier_yml:
+    external: true
+  certificate_atomiq:
+    external: true
+
+services:
+
+  amplifier:
+    image: appcelerator/amplifier:${TAG:-0.12.0}
+    networks:
+      - default
+    environment:
+      REGISTRATION: ${REGISTRATION:-email}
+      NOTIFICATIONS: ${NOTIFICATIONS:-true}
+    ports:
+      - "50101:50101"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "6s"
+      amp.service.stabilize.timeout: "30s"
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints:
+        - node.labels.amp.type.api == true
+    secrets:
+      - source: amplifier_yml
+        target: amplifier.yml
+        mode: 0400
+      - source: certificate_atomiq
+        target: cert0.pem
+        mode: 0400

--- a/cluster/agent/stacks/09-amplifier.test.yml
+++ b/cluster/agent/stacks/09-amplifier.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  amplifier:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "http://${AMP_STACK:-amp}_amplifier:5100/metrics"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none

--- a/cluster/agent/stacks/10-gateway.amp.yml
+++ b/cluster/agent/stacks/10-gateway.amp.yml
@@ -1,0 +1,29 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  gateway:
+    image: appcelerator/gateway:${TAG:-0.12.0}
+    networks:
+      - default
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "30s"
+    environment:
+      SERVICE_PORTS: 80
+      VIRTUAL_HOST: "https://gw.*,http://gw.*"
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true

--- a/cluster/agent/stacks/11-agent.amp.yml
+++ b/cluster/agent/stacks/11-agent.amp.yml
@@ -1,0 +1,27 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  ampagent:
+
+services:
+
+  agent:
+    image: appcelerator/agent:${TAG:-0.12.0}
+    networks:
+      - default
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "30s"
+    volumes:
+      - ampagent:/containers
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/cluster/agent/stacks/12-portal.amp.yml
+++ b/cluster/agent/stacks/12-portal.amp.yml
@@ -1,0 +1,28 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  portal:
+    image: appcelerator/portal:latest
+    networks:
+      - default
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+    environment:
+      SERVICE_PORTS: "80"
+      VIRTUAL_HOST: "http://portal.*,https://portal.*,http://cloud.*,http://local.*,https://cloud.*,https://local.*"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "30s"

--- a/cluster/agent/stacks/12-portal.test.yml
+++ b/cluster/agent/stacks/12-portal.test.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  portal:
+    image: appcelerator/alpine:3.6.0
+    networks:
+      - default
+    command: ["curl", "-sf", "http://${AMP_STACK:-amp}_portal/"]
+    labels:
+      io.amp.role: "infrastructure"
+      io.amp.test:
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.test:
+      placement:
+        constraints:
+        - node.labels.amp.type.core == true
+      restart_policy:
+        condition: none


### PR DESCRIPTION
- AMP services are now deployed with one stack per service (*.amp.yml)
- a test stack file for each service that can be tested from another container (*.test.yml)
- labels defined at the service level for easier orchestration:
  - amp.service.stabilize.delay
  - amp.service.stabilize.timeout