### PR TITLE
Update team create success message

### DIFF
--- a/cli/command/team/create.go
+++ b/cli/command/team/create.go
@@ -61,6 +61,6 @@ func createTeam(c cli.Interface, cmd *cobra.Command, args []string, opts createT
 	if err := cli.SaveTeam(team, c.Server()); err != nil {
 		return err
 	}
-	c.Console().Println("Team has been created in the organization.")
+	c.Console().Println("Team has been created.")
 	return nil
 }

--- a/cli/command/team/get.go
+++ b/cli/command/team/get.go
@@ -58,7 +58,7 @@ func getTeam(c cli.Interface, cmd *cobra.Command, args []string, opts getTeamOpt
 		}
 	}
 	c.Console().Printf("Team: %s\n", reply.Team.Name)
-	c.Console().Printf("Organization: %s\n", opts.org)
+	//c.Console().Printf("Organization: %s\n", opts.org)
 	c.Console().Printf("Created On: %s\n", time.ConvertTime(reply.Team.CreateDt))
 	return nil
 }

--- a/platform/tests/team/create/create_test.sh
+++ b/platform/tests/team/create/create_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #amp -k team create team --org=org | grep -q "Team has been created in the organization."
-amp -k team create team | grep -q "Team has been created in the organization."
+amp -k team create team | grep -q "Team has been created."

--- a/platform/tests/team/get/get_test.sh
+++ b/platform/tests/team/get/get_test.sh
@@ -2,4 +2,4 @@
 
 amp -k team get team | grep -q "Team: team"
 #amp -k team get team | grep -q "Organization: org"
-amp -k team get team | grep -q "Organization: default"
+#amp -k team get team | grep -q "Organization: default"


### PR DESCRIPTION
- Updated success message for `amp team create` command.
- Removed `org` field in `amp team get` command.