### PR TITLE
Cluster mode detection for AMP deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ cleanall: clean cleanall-deps
 # When running in the amptools container, set DOCKER_CMD="sudo docker"
 DOCKER_CMD ?= "docker"
 
-build-base: install-deps protoc build-server build-gateway build-beat build-agent build-bootstrap build-monit
+build-base: install-deps protoc build-server build-gateway build-beat build-agent build-bootstrap build-monit build-ampagent
 build: build-base buildall-cli
 
 # =============================================================================
@@ -360,17 +360,16 @@ test-amp-aws: build-amp-aws
 	@cd $(CPAWSDIR) && $(MAKE) test
 
 # =============================================================================
-# BUILD AMPADMIN (`ampadmin`)
+# BUILD AMPAGENT (`ampagent`)
 # =============================================================================
-AMPADMINDIR := cluster/ampadmin
+AMPAGENTDIR := cluster/agent
+AMPAGENTTAG := $(VERSION)
+AMPAGENTIMG := appcelerator/ampagent:$(AMPAGENTTAG)
 
-.PHONY: build-ampadmin
-build-ampadmin: build-ampadmin
-	@cd $(AMPADMINDIR) && $(MAKE) build
-
-.PHONY: test-ampadmin
-test-ampadmin:
-	@cd $(AMPADMINDIR) && $(MAKE) test
+.PHONY: build-ampagent
+build-ampagent:
+	@echo "build $(AMPAGENTDIR)"
+	@$(DOCKER_CMD) build -t $(AMPAGENTIMG) $(AMPAGENTDIR)
 
 # =============================================================================
 # Quality checks

--- a/cluster/agent/Dockerfile
+++ b/cluster/agent/Dockerfile
@@ -37,6 +37,7 @@ ENV SWARM_SOCKET "/var/run/docker/swarm/control.sock"
 
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 COPY --from=build /tmp/bin/ /bin
+COPY ./stacks /stacks
 
 ENTRYPOINT [ "/bin/ampctl" ]
 

--- a/cluster/agent/Makefile
+++ b/cluster/agent/Makefile
@@ -2,7 +2,8 @@
 
 PKG := github.com/appcelerator/amp/cluster/agent/cmd
 TARGET := bin/ampctl
-IMAGE := appcelerator/ampagent
+VERSION ?= latest
+IMAGE := appcelerator/ampagent:$(VERSION)
 
 build:
 	go build -o $(TARGET) $(PKG)
@@ -14,7 +15,7 @@ clean:
 	rm -f $(TARGET)
 
 test:
-	go test -v -timeout 30m
+	go test -v -timeout 30m $(PKG)/../admin
 
 image:
 	docker build -t $(IMAGE) .

--- a/cluster/agent/admin/admin_checks.go
+++ b/cluster/agent/admin/admin_checks.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"log"
 	"regexp"
-	"strconv"
 	"time"
 
 	sk "github.com/appcelerator/amp/cluster/agent/swarm"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/swarmkit/api"
 	"golang.org/x/net/context"
@@ -22,8 +22,8 @@ import (
 
 const (
 	DefaultURL        = "unix:///var/run/docker.sock"
-	DefaultVersion    = "1.29"
-	minimumApiVersion = 1.29
+	DefaultVersion    = "1.30"
+	minimumApiVersion = "1.30"
 	testNetwork       = "amptest"
 )
 
@@ -43,12 +43,9 @@ func VerifyDockerVersion() error {
 	}
 	version, err := c.ServerVersion(context.Background())
 	log.Printf("Docker engine version %s\n", version.Version)
-	apiVersion, err := strconv.ParseFloat(version.APIVersion, 32)
-	if err != nil {
-		return err
-	}
-	if apiVersion < minimumApiVersion {
-		log.Printf("minimum expected: %.3g, observed: %.3g", minimumApiVersion, apiVersion)
+	apiVersion := version.APIVersion
+	if versions.LessThan(apiVersion, minimumApiVersion) {
+		log.Printf("minimum expected: %.s, observed: %.s", minimumApiVersion, apiVersion)
 		return errors.New("Docker engine doesn't meet the requirements (API Version)")
 	}
 	return nil


### PR DESCRIPTION
- add ampagent in the main Makefile
- cluster mode check before core services deployment (Fix #1545)