### PR TITLE
enable AWS deployment with CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,13 +331,9 @@ push-bootstrap:
 CPDIR := cluster/plugin
 CPAWSDIR := $(CPDIR)/aws
 
-.PHONY: build-amp-aws-compiler
-build-amp-aws-compiler:
-	@cd $(CPAWSDIR) && $(MAKE) compiler
-
 .PHONY: build-amp-aws
-build-amp-aws: build-amp-aws-compiler
-	@cd $(CPAWSDIR) && $(MAKE) build
+build-amp-aws:
+	@cd $(CPAWSDIR) && $(MAKE) image
 
 # WARNING:
 # If the environment variables for $KEYNAME and $REGION are not set, the

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -27,7 +27,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	// during this refactoring.
 	flags.StringVar(&opts.name, "name", "", "Cluster Label")
 	flags.BoolVarP(&opts.notifications, "notifications", "n", false, "Enable/disable server notifications (default is 'false')")
-	//flags.StringVar(&opts.provider, "provider", "local", "Cluster provider (\"local\" (default) or \"aws\")")
+	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider (\"local\" (default) or \"aws\")")
 	flags.StringVarP(&opts.registration, "registration", "r", configuration.RegistrationNone, "Specify the registration policy (possible values are 'none' or 'email')")
 	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster images")
 

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultTemplateURL = "https://editions-us-east-1.s3.amazonaws.com/aws/edge/Docker.tmpl"
+	DefaultTemplateURL = "https://s3.amazonaws.com/io-amp-binaries/templates/v0.13.0/aws-swarm-asg.yml"
 )
 
 // RequestOptions stores raw request input options before transformation into a AWS SDK specific
@@ -174,4 +174,3 @@ func StackOutputToJSON(so []StackOutput) (string, error) {
 	}
 	return string(j), nil
 }
-


### PR DESCRIPTION
- enables the deployment on AWS with the CLI
- switch the default template to the AMP custom template instead of Docker for AWS