### PR TITLE
SU is able to remove non verified users

### DIFF
--- a/api/rpc/account/account.go
+++ b/api/rpc/account/account.go
@@ -326,16 +326,8 @@ func (s *Server) DeleteUser(ctx context.Context, in *DeleteUserRequest) (*empty.
 		return nil, status.Errorf(codes.FailedPrecondition, "User cannot be removed because they still own dashboards. Please remove all dashboards belonging to this user and try again.")
 	}
 
-	// Get requesting user
-	user, err := s.Accounts.GetUser(ctx, in.Name)
+	user, err := s.Accounts.DeleteUser(ctx, in.Name)
 	if err != nil {
-		return nil, convertError(err)
-	}
-	if user == nil {
-		return nil, status.Errorf(codes.NotFound, "user not found: %s", in.Name)
-	}
-
-	if err := s.Accounts.DeleteUser(ctx, in.Name); err != nil {
 		return nil, convertError(err)
 	}
 	if err := s.Mailer.SendAccountRemovedEmail(user.Email, user.Name); err != nil {

--- a/data/accounts/interface.go
+++ b/data/accounts/interface.go
@@ -63,7 +63,7 @@ type Interface interface {
 	DeleteNotVerifiedUser(ctx context.Context, name string) (err error)
 
 	// DeleteUser deletes a user by name
-	DeleteUser(ctx context.Context, name string) (err error)
+	DeleteUser(ctx context.Context, name string) (*User, error)
 
 	// CreateOrganization creates a new organization
 	CreateOrganization(ctx context.Context, name string, email string) (err error)


### PR DESCRIPTION
Fix #1577 

## How to test

:warning:  Use an `amplifier_yml` secret with a valid SendGrid key.

```
$ ampmake build
$ amp cluster create --registration=email --notifications=true
$ amp user signup --name user1 --email user1@email.amp --password password
[localhost:50101]
Hi user1! Please check your email to complete the signup process.
$ amp user signup --name user2 --email user2@email.amp --password password
[localhost:50101]
Hi user2! Please check your email to complete the signup process.
$ amp login --name su --password password
[localhost:50101]
Welcome back su!
$ amp user rm user2
[user su @ localhost:50101]
user2
```
