### PR TITLE
raise the application installation timeout

### DIFF
--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Swarm cluster with autoscaling groups
+Description: Swarm cluster with autoscaling groups v0.14.0-dev
 
 Mappings:
   AMI:
@@ -1245,7 +1245,7 @@ Resources:
       - UserWaitCondition
     Properties:
       Handle: !Ref ApplicationWaitHandle
-      Timeout: 900
+      Timeout: 1800
       Count: 1
 
   ManagerWaitHandle:


### PR DESCRIPTION
The timeout for the AMP stack deployment was too close to the real deployment time, resulting in deployment failure from time to time.
Doubling this timeout (backported in 0.13.0).