### PR TITLE
Filter tasks with -a option

### DIFF
--- a/platform/tests/service/ps/ps_test.sh
+++ b/platform/tests/service/ps/ps_test.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
 amp -k service ps pinger_pinger 2>/dev/null | grep -o -w -E -q '[[:alnum:]]{25}'
+
+amp -k service ps pinger_pinger 2>/dev/null | grep -Evq 'SHUTDOWN'
+
+amp -k service ps pinger_pinger -a 2>/dev/null | grep -E -i 'RUNNING|SHUTDOWN'


### PR DESCRIPTION
resolves #1575 

`amp service ps` command now takes a `-a`/`--all` option.  Using this option, all the tasks of the service will be listed, irrespective of their current state.
Without this option, only the tasks with `Running` status are listed.

```
$ amp -k service ps pinger_pinger
[user neha @ localhost:50101]
ID                          IMAGE                     DESIRED STATE   CURRENT STATE   NODE ID                     ERROR
2zw7z53mqr9buphacbkhlusvt   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
bx5nm21q0od2d3ediqqidm1qf   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
iabidlj1i8enhj8gqtdzoguhv   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
id09rzw4b37naajms8rxzaaeh   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
iwsu3x0nsamllgmvlw00bqoyh   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
mphy0cmwkvbdfkze99fs3xz52   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
tg27c8acbozb5usrkvhth21f6   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
uqvployz5q5tokp7v3wd65dgu   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
v3km7ing6lh7qbb6uhw2j0cnm   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
zrhm3bvexaepg7hfrjaate27b   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx 

$ amp -k service ps pinger_pinger -a
[user neha @ localhost:50101]
ID                          IMAGE                     DESIRED STATE   CURRENT STATE   NODE ID                     ERROR
2zw7z53mqr9buphacbkhlusvt   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
4rcsyxpvwcoswlb9wh2ra8b3s   subfuzion/pinger:latest   SHUTDOWN        SHUTDOWN        z4xmn8ndsekbrwr2n3ezno2hx   
bx5nm21q0od2d3ediqqidm1qf   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
iabidlj1i8enhj8gqtdzoguhv   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
id09rzw4b37naajms8rxzaaeh   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
iwsu3x0nsamllgmvlw00bqoyh   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
mphy0cmwkvbdfkze99fs3xz52   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
mvv0rjz00tr0n2vkwiw9qg2uq   subfuzion/pinger:latest   SHUTDOWN        SHUTDOWN        z4xmn8ndsekbrwr2n3ezno2hx   
qeejoovnjuv32ds7f6iw29wq9   subfuzion/pinger:latest   SHUTDOWN        SHUTDOWN        z4xmn8ndsekbrwr2n3ezno2hx   
tg27c8acbozb5usrkvhth21f6   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
uqvployz5q5tokp7v3wd65dgu   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
v3km7ing6lh7qbb6uhw2j0cnm   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx   
zrhm3bvexaepg7hfrjaate27b   subfuzion/pinger:latest   RUNNING         RUNNING         z4xmn8ndsekbrwr2n3ezno2hx 
```