### PR TITLE
Fix ES alerts on multi nodes clusters

### DIFF
--- a/examples/monitoring/prometheus_alerts.rules
+++ b/examples/monitoring/prometheus_alerts.rules
@@ -18,7 +18,7 @@ ALERT Availability
 
 # elasticsearch
 ALERT ElasticsearchClusterStatus
-  IF es_cluster_status < 1
+  IF es_cluster_status > 1
   FOR 1m
   ANNOTATIONS {
    summary = "elasticsearch cluster status",


### PR DESCRIPTION
On clusters where ES has more than one replicas, alerts are falsely triggered.
Fixes the cluster status (es_cluster_status = 1 means YELLOW, es_cluster_status = 0 means GREEN).