### PR TITLE
Minor agent cli refactor to streamline default and to funnel errors to top level

### DIFF
--- a/cluster/agent/cmd/checks.go
+++ b/cluster/agent/cmd/checks.go
@@ -20,7 +20,7 @@ func NewChecksCommand() *cobra.Command {
 	checkCmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run validation tests on the cluster",
-		Run:   checks,
+		RunE:   checks,
 	}
 	checkCmd.Flags().BoolVar(&checksOpts.version, "version", false, "check Docker version")
 	checkCmd.Flags().BoolVar(&checksOpts.labels, "labels", false, "check all required labels are defined on the swarm")
@@ -29,7 +29,7 @@ func NewChecksCommand() *cobra.Command {
 	return checkCmd
 }
 
-func checks(cmd *cobra.Command, args []string) {
+func checks(cmd *cobra.Command, args []string) error {
 	// if zero tests have been explicitely asked, run them all
 	if !checksOpts.version && !checksOpts.labels && !checksOpts.scheduling {
 		checksOpts.all = true
@@ -37,7 +37,7 @@ func checks(cmd *cobra.Command, args []string) {
 	if checksOpts.version || checksOpts.all {
 		if err := adm.VerifyDockerVersion(); err != nil {
 			log.Println("Version test: FAIL")
-			log.Fatal(err)
+			return err
 		} else {
 			log.Println("Version test: PASS")
 		}
@@ -45,7 +45,7 @@ func checks(cmd *cobra.Command, args []string) {
 	if checksOpts.labels || checksOpts.all {
 		if err := adm.VerifyLabels(); err != nil {
 			log.Println("Labels test: FAIL")
-			log.Fatal(err)
+			return err
 		} else {
 			log.Println("Labels test: PASS")
 		}
@@ -53,9 +53,11 @@ func checks(cmd *cobra.Command, args []string) {
 	if checksOpts.scheduling || checksOpts.all {
 		if err := adm.VerifyServiceScheduling(); err != nil {
 			log.Println("Labels test: FAIL")
-			log.Fatal(err)
+			return err
 		} else {
 			log.Println("Labels test: PASS")
 		}
 	}
+
+	return nil
 }

--- a/cluster/agent/cmd/main.go
+++ b/cluster/agent/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -20,31 +19,20 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "ampctl",
 		Short: "Run commands in target amp cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// perform checks and install by default when no sub-command is specified
+			if err := checks(cmd, args); err != nil {
+				return err
+			}
+			return install(cmd, args)
+		},
 	}
 
 	rootCmd.AddCommand(NewChecksCommand())
 	rootCmd.AddCommand(NewInstallCommand())
 	rootCmd.AddCommand(NewMonitorCommand())
 
-	// if no arg has been provided, execute check and install
-	if len(os.Args[1:]) == 0 {
-		rootCmd.SetArgs([]string{"check"})
-		err := rootCmd.Execute()
-		if err != nil {
-			log.Println(err)
-			os.Exit(-1)
-		}
-		rootCmd.SetArgs([]string{"install"})
-		err = rootCmd.Execute()
-		if err != nil {
-			log.Println(err)
-			os.Exit(-1)
-		}
-	} else {
-		err := rootCmd.Execute()
-		if err != nil {
-			log.Println(err)
-			os.Exit(-1)
-		}
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Error: %s\n", err)
 	}
 }

--- a/cluster/agent/cmd/monitor.go
+++ b/cluster/agent/cmd/monitor.go
@@ -3,33 +3,25 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	sk "github.com/appcelerator/amp/cluster/agent/swarm"
 	"github.com/docker/swarmkit/api"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/status"
 )
 
 func NewMonitorCommand() *cobra.Command {
 	monitorCmd := &cobra.Command{
 		Use:   "monitor",
 		Short: "Monitor swarm events",
-		Run:   monitor,
+		RunE:   monitor,
 	}
 	return monitorCmd
 }
 
-func monitor(cmd *cobra.Command, args []string) {
+func monitor(cmd *cobra.Command, args []string) error {
 	c, conn, err := sk.Dial(sk.DefaultSocket())
 	if err != nil {
-		s, ok := status.FromError(err)
-		if ok {
-			fmt.Println("Error: ", s)
-		} else {
-			fmt.Println("Error:", err)
-		}
-		os.Exit(-1)
+		return err
 	}
 
 	// this is just to prove things are working...
@@ -49,17 +41,17 @@ func monitor(cmd *cobra.Command, args []string) {
 	in := sk.NewWatchRequest(watchEntries, nil, true)
 	w, err := watcher.Watch(ctx, in)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
+		return err
 	}
 
 	for {
 		msg, err := w.Recv()
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(-1)
+			return err
 		}
 
 		fmt.Println(msg.String())
 	}
+
+	return nil
 }


### PR DESCRIPTION
Related: https://github.com/appcelerator/amp/pull/1570

Simplifies code for default handling; also ensures all commands return an error which gets logged by the root handler.