### PR TITLE
Adding uninstall command

### DIFF
--- a/cluster/agent/cmd/main.go
+++ b/cluster/agent/cmd/main.go
@@ -31,6 +31,7 @@ func main() {
 	rootCmd.AddCommand(NewChecksCommand())
 	rootCmd.AddCommand(NewInstallCommand())
 	rootCmd.AddCommand(NewMonitorCommand())
+	rootCmd.AddCommand(NewUninstallCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Error: %s\n", err)

--- a/cluster/agent/cmd/uninstall.go
+++ b/cluster/agent/cmd/uninstall.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/appcelerator/amp/cluster/agent/pkg/docker"
+	"github.com/appcelerator/amp/cluster/agent/pkg/docker/stack"
+	"github.com/docker/docker/pkg/term"
+	"github.com/spf13/cobra"
+)
+
+func NewUninstallCommand() *cobra.Command {
+	uninstallCmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall amp services from swarm environment",
+		RunE:  uninstall,
+	}
+	return uninstallCmd
+}
+
+func uninstall(cmd *cobra.Command, args []string) error {
+	stdin, stdout, stderr := term.StdStreams()
+	dockerCli := docker.NewDockerCli(stdin, stdout, stderr)
+
+	namespace := "amp"
+	if len(args) > 0 {
+		namespace = args[0]
+	}
+
+	opts := stack.RemoveOptions{
+		Namespaces: []string{namespace},
+	}
+
+	if err := stack.Remove(dockerCli, opts); err != nil {
+		return err
+	}
+
+	if err := removeVolumes(); err != nil {
+		return err
+	}
+
+	return removeInitialNetworks()
+}


### PR DESCRIPTION
Related to #1591 

Adding an `uninstall` command to `ampctl` that:
 - Remove the `amp` (or given namespace) stack,
 - Remove the `ampnet` network.

## How to test
```
$ cd cluster/agent
$ make
$ bin/ampctl install
$ bin/ampctl uninstall
$ docker stack ls
$ docker network ls
```