### PR TITLE
Local plugin pulls agent image before running it

### DIFF
--- a/cluster/plugin/local/Makefile
+++ b/cluster/plugin/local/Makefile
@@ -8,7 +8,7 @@ IMAGE := appcelerator/amp-local
 export LDFLAGS := "-s -X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
 
 build:
-	go build -o $(TARGET) $(PKG)
+	go build -ldflags $(LDFLAGS) -o $(TARGET) $(PKG)
 
 vendor: vendor.conf
 	vndr

--- a/cluster/plugin/local/cmd/main.go
+++ b/cluster/plugin/local/cmd/main.go
@@ -66,6 +66,10 @@ func delete(cmd *cobra.Command, args []string) {
 	log.Println("cluster deleted")
 }
 
+func version(cmd *cobra.Command, args []string) {
+	fmt.Printf("Version: %s - Build: %s\n", Version, Build)
+}
+
 func info(cmd *cobra.Command, args []string) {
 	// docker node inspect self -f '{{.Status.State}}'
 	ctx := context.Background()
@@ -107,6 +111,11 @@ func main() {
 	initCmd.PersistentFlags().BoolVar(&opts.SkipTests, "fast", false, "Skip tests while deploying the core services")
 	initCmd.PersistentFlags().BoolVar(&opts.NoMonitoring, "no-monitoring", false, "Don't deploy the monitoring core services")
 
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "version of the plugin",
+		Run:   version,
+	}
 	infoCmd := &cobra.Command{
 		Use:   "info",
 		Short: "get information about the cluster",
@@ -126,7 +135,7 @@ func main() {
 	}
 	destroyCmd.PersistentFlags().BoolVarP(&opts.ForceLeave, "force-leave", "", false, "force leave the swarm")
 
-	rootCmd.AddCommand(initCmd, infoCmd, updateCmd, destroyCmd)
+	rootCmd.AddCommand(initCmd, versionCmd, infoCmd, updateCmd, destroyCmd)
 
 	_ = rootCmd.Execute()
 }


### PR DESCRIPTION
Fix #1602 

For released version: the plugin will pull the version image (e.g. 0.14.0)
For dev: the plugin will try to pull, but will fall back to the locally built image (e.g. 0.14.0-dev)
If using a `latest` local plugin, it will download the latest ampagent (that can be useful when deploying a remote cluster with a dev version).

In all cases, core services images used for the deployment will be the same as the tag version of the ampagent.

### Verification

pull the appcelerator/amp-local:latest image
remove the appcelerator/ampagent:latest image
run amp-local
it should pull ampagent (if the image on DockerHub has been built with version latest, not retagged from a dev version)

run the appclelerator/amp-local:0.14.0-dev
it should use the locally built amp-agent image