### PR TITLE
Agent options

### DIFF
--- a/cluster/agent/cmd/install.go
+++ b/cluster/agent/cmd/install.go
@@ -104,7 +104,6 @@ func install(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			time.Sleep(10 * time.Second)
 		}
 	}
 	return nil

--- a/cluster/plugin/local/plugin.go
+++ b/cluster/plugin/local/plugin.go
@@ -150,7 +150,7 @@ func RunAgent(ctx context.Context, c *client.Client, action string, opts *Reques
 	reader, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {
 		// don't exit, if not in the registry we may still want to run the container with a local image
-		fmt.Printf("ImagePull failed, which is fine if using a development version: %f", err)
+		fmt.Println("ampagent image pull failed, which is expected on a development version")
 	} else {
 		// wait for the image to be pulled
 		data := make([]byte, 1000, 1000)


### PR DESCRIPTION
options from the CLI for tag, registration and notifications were ignored by the local deployment plugin, because expected as command line options, but passed as env variables instead.

Changed the local plugin to expect env variables.

Also removed a 10 sec sleep between all services, which should speed up the deployment.