### PR TITLE
ampagent updates for AWS deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 script:
   - set -e
-  - ampmake clean build-base build-cli
+  - ampmake clean build-base build-local-plugin build-cli
   - ls -la bin/linux/amd64
   - amp cluster create --local-fast
   - TESTINCLUDE=platform/testing testrunner platform/tests

--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,10 @@ cleanall: clean cleanall-deps
 # When running in the amptools container, set DOCKER_CMD="sudo docker"
 DOCKER_CMD ?= "docker"
 
-build-base: install-deps protoc build-server build-gateway build-beat build-agent build-monit build-ampagent build-amp-local
-build: build-base buildall-cli
+build-base: install-deps protoc build-server build-gateway build-beat build-agent build-monit
+build-local-plugin: build-amp-local build-ampagent
+build-plugins: build-amp-local build-amp-aws build-ampagent
+build: build-base build-plugins buildall-cli
 
 # =============================================================================
 # BUILD CLI (`amp`)
@@ -309,10 +311,11 @@ clean-agent:
 # =============================================================================
 CPDIR := cluster/plugin
 CPAWSDIR := $(CPDIR)/aws
+CPAWSIMG := appcelerator/amp-aws:$(VERSION)
 
 .PHONY: build-amp-aws
 build-amp-aws:
-	@cd $(CPAWSDIR) && $(MAKE) image
+	@$(DOCKER_CMD) build --build-arg LDFLAGS=$(LDFLAGS) -t $(CPAWSIMG) $(CPAWSDIR)
 
 # WARNING:
 # If the environment variables for $KEYNAME and $REGION are not set, the

--- a/cluster/agent/pkg/docker/stack/deploy_composefile.go
+++ b/cluster/agent/pkg/docker/stack/deploy_composefile.go
@@ -337,8 +337,8 @@ func deployServices(
 		var serviceID string
 
 		if service, exists := existingServiceMap[name]; exists {
-			fmt.Fprintf(out, "Updating service %s (id: %s)\n", name, service.ID)
-			fmt.Fprintf(out, "service: %+v\n", service)
+			fmt.Fprintf(out, "Updating service       %s (id: %s)\n", name, service.ID)
+			fmt.Fprintf(out, "service:               %+v\n", service)
 			imageName = service.Spec.TaskTemplate.ContainerSpec.Image
 			serviceID = service.ID
 
@@ -374,12 +374,14 @@ func deployServices(
 			if resp, err = apiClient.ServiceCreate(ctx, serviceSpec, createOpts); err != nil {
 				return errors.Wrapf(err, "failed to create service %s", name)
 			}
-			fmt.Fprintf(out, "service: %+v\n", resp)
+			fmt.Fprintf(out, "service:               %+v\n", resp)
 			serviceID = resp.ID
 			imageName = serviceSpec.TaskTemplate.ContainerSpec.Image
 		}
 
-		fmt.Fprintf(out, "image: %s\n", imageName)
+		fmt.Fprintf(out, "image:                 %s\n", imageName)
+		fmt.Fprintf(out, "Stabilization delay:   %s\n", stabilizeDelay)
+		fmt.Fprintf(out, "Stabilization timeout: %s\n", stabilizeTimeout)
 		done := make(chan bool)
 
 		// create a watcher for service/container events based on the service image

--- a/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
@@ -18,8 +18,8 @@ services:
       - elasticsearch-data:/opt/elasticsearch/data
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "15s"
-      amp.service.stabilize.timeout: "45s"
+      amp.service.stabilize.delay: "35s"
+      amp.service.stabilize.timeout: "90s"
     environment:
       MIN_MASTER_NODES: 2
       NETWORK_HOST: "_eth0_"

--- a/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
@@ -11,7 +11,7 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sfm", "30", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=20s" ]
+    command: ["curl", "-sfm", "55", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=50s" ]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:

--- a/cluster/agent/stacks/03-kibana.ampmon.yml
+++ b/cluster/agent/stacks/03-kibana.ampmon.yml
@@ -22,8 +22,8 @@ services:
         - node.labels.amp.type.core == true
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "10s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "25s"
+      amp.service.stabilize.timeout: "40s"
     environment:
       ELASTICSEARCH_URL: "http://elasticsearch:9200"
       SERVICE_PORTS: 5601

--- a/cluster/plugin/aws/Dockerfile
+++ b/cluster/plugin/aws/Dockerfile
@@ -12,8 +12,9 @@ COPY . ${DIR}
 WORKDIR ${DIR}
 RUN vndr
 
+ARG LDFLAGS="-s"
 # build
-RUN go build -o /tmp/aws cmd/main.go
+RUN go build -ldflags "$LDFLAGS" -o /tmp/aws cmd/main.go
 
 # =============================
 FROM alpine

--- a/cluster/plugin/aws/Makefile
+++ b/cluster/plugin/aws/Makefile
@@ -2,10 +2,13 @@
 
 PKG := github.com/appcelerator/amp/cluster/plugin/aws/cmd
 TARGET := bin/aws
+VERSION ?= $(shell cat ../../../VERSION)
+BUILD := $(shell git rev-parse HEAD | cut -c1-8)
 IMAGE := appcelerator/amp-aws
+export LDFLAGS := "-s -X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
 
 build:
-	go build -o $(TARGET) $(PKG)
+	go build -ldflags $(LDFLAGS) -o $(TARGET) $(PKG)
 
 vendor: vendor.conf
 	vndr
@@ -17,5 +20,5 @@ test:
 	go test -v -timeout 30m
 
 image:
-	docker build -t $(IMAGE) .
+	docker build --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE) .
 

--- a/cluster/plugin/aws/cmd/main.go
+++ b/cluster/plugin/aws/cmd/main.go
@@ -14,15 +14,21 @@ import (
 )
 
 var (
-	opts = &plugin.RequestOptions{
-		OnFailure: "DO_NOTHING",
-		Params:    []string{},
+	Version string
+	Build   string
+	opts    = &plugin.RequestOptions{
+		OnFailure:   "DO_NOTHING",
+		Params:      []string{},
 		TemplateURL: plugin.DefaultTemplateURL,
 	}
 
 	sess *session.Session
-	svc *cf.CloudFormation
+	svc  *cf.CloudFormation
 )
+
+func version(cmd *cobra.Command, args []string) {
+	fmt.Printf("Version: %s - Build: %s\n", Version, Build)
+}
 
 func initClient(cmd *cobra.Command, args []string) {
 	sess = session.Must(session.NewSession())
@@ -113,8 +119,8 @@ func info(cmd *cobra.Command, args []string) {
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "awsplugin",
-		Short: "init/update/destroy an AWS cluster in Docker swarm mode",
+		Use:              "awsplugin",
+		Short:            "init/update/destroy an AWS cluster in Docker swarm mode",
 		PersistentPreRun: initClient,
 	}
 	rootCmd.PersistentFlags().StringVarP(&opts.Region, "region", "r", "", "aws region")
@@ -131,9 +137,9 @@ func main() {
 	initCmd.Flags().StringVar(&opts.OnFailure, "onfailure", "ROLLBACK", "action to take if stack creation fails")
 
 	infoCmd := &cobra.Command{
-		Use: "info",
+		Use:   "info",
 		Short: "get information about the cluster",
-		Run: info,
+		Run:   info,
 	}
 
 	updateCmd := &cobra.Command{
@@ -148,7 +154,12 @@ func main() {
 		Run:   delete,
 	}
 
-	rootCmd.AddCommand(initCmd, infoCmd, updateCmd, destroyCmd)
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "version of the plugin",
+		Run:   version,
+	}
+	rootCmd.AddCommand(versionCmd, initCmd, infoCmd, updateCmd, destroyCmd)
 
 	_ = rootCmd.Execute()
 }

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	// replace latest by the version when releasing the plugin
 	DefaultTemplateURL = "https://s3.amazonaws.com/io-amp-binaries/templates/latest/aws-swarm-asg.yml"
 )
 

--- a/cluster/plugin/local/Makefile
+++ b/cluster/plugin/local/Makefile
@@ -20,5 +20,5 @@ test:
 	go test -v -timeout 30m
 
 image:
-	docker build -t $(IMAGE) .
+	docker build --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE) .
 

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-98366be3
+      Default: ami-c582a4be
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-35200050
+      Default: ami-0ee4c46b
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-47a8b33e
+      Default: ami-6736d11f
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-6b04ec12
+      Default: ami-2fc33756
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-84cbd4e7
+      Default: ami-d08a94b3
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
@@ -1332,7 +1332,7 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/userdata-aws-manager && chmod +x /usr/local/bin/userdata-aws-manager || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-manager || shutdown -h
+                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}+${MetricsWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-manager || shutdown -h
             - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], ApplicationSignalURL: !If [ InstallApplicationCond, !Ref ApplicationWaitHandle, "" ] }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -10,6 +10,7 @@ REGION=${REGION:-us-west-2}
 STACK_NAME=${STACK_NAME:-unset}
 VPC_ID=${VPC_ID:-unset}
 MANAGER_SIZE=${MANAGER_SIZE:-3}
+#CLUSTER_SIZE=
 DRAIN_MANAGER=${DRAIN_MANAGER:-false}
 OVERLAY_NETWORKS=${OVERLAY_NETWORKS:-ampnet}
 #MIRROR_REGISTRIES=
@@ -383,17 +384,36 @@ _signal_aws() {
 # wait for all nodes to be up and running (and labeled)
 _wait_for_full_swarm() {
   local _timeout=360
+  local _timeout_label=60
   local _label
   local _label_prefix="amp.type."
   local _labels="api route metrics mq kv search core user"
   local _expected_label_count
   local _current_labels
   local _current_label_count
+  local _size
+
+  if [[ -n "$CLUSTER_SIZE" ]]; then
+    echo "Waiting for all nodes to join the swarm" >&2
+    # the var can be in the form "N+M+O"
+    CLUSTER_SIZE=$((CLUSTER_SIZE))
+    SECONDS=0
+    while [[ $SECONDS -lt $_timeout ]]; do
+      _size=$(docker node ls -q | wc -l)
+      if [[ $_size -ge $CLUSTER_SIZE ]]; then
+        echo "All nodes have joined after $SECONDS sec" >&2
+        break
+      fi
+      sleep 1
+    done
+  else
+    echo "No knowledge of the swarm size, skipping the wait for the nodes" >&2
+  fi
 
   _expected_label_count=$(echo $_labels | wc -w)
   echo "waiting for all scheduling labels to be defined on the swarm..." >&2
   SECONDS=0
-  while [[ $SECONDS -lt $_timeout ]]; do
+  while [[ $SECONDS -lt $_timeout_label ]]; do
     _current_label_count=0
     _current_labels="$(for n in $(docker node ls -q); do docker node inspect $n --pretty | grep amp.type | sed -e 's/.*\(amp.type.*\) *=.*$/\1/'; done | sort | uniq)"
     for _label in $_labels; do
@@ -401,11 +421,16 @@ _wait_for_full_swarm() {
     done
     if [[ $_current_label_count -eq $_expected_label_count ]]; then
       echo "All labels were found after $SECONDS sec" >&2
-      return 0
+      break
     fi
+    sleep 1
   done
-  echo "label search timed out ($SECONDS sec)" >&2
-  return 1
+  if [[ $_current_label_count -lt $_expected_label_count ]]; then
+    echo "label search timed out ($SECONDS sec)" >&2
+    return 1
+  fi
+
+  
 }
 
 _setup() {


### PR DESCRIPTION
Ref #1614 
- logs of ampagent more helpful (for estimation of timeouts)
- tuned timeouts for AWS deployment
- updated AMI and Cloudformation template
- update in Makefile for amp-aws plugin (now part of the `build-plugins` target)

Warning: now the `build-base` target won't build the deployment plugin. To be able to deploy locally, you have to `make build-base build-local-plugin build-cli`. To be able to deploy on AWS, replace `build-local-plugin` with `build-plugins`.

## Verification
```
amp cluster create --provider aws --aws-region us-west-2 --aws-stackname STACK_NAME --aws-parameter KeyName=KEY_NAME --aws-sync
```