### PR TITLE
a service deploy failure stops the AMP core stack deployment

### DIFF
--- a/cluster/agent/cmd/install.go
+++ b/cluster/agent/cmd/install.go
@@ -201,7 +201,9 @@ func deployExpectingState(d *command.DockerCli, stackfile string, namespace stri
 	}
 
 	err := stack.Deploy(context.Background(), d, opts)
-	log.Printf("Service has reached expected state (%s)\n", string(expectedState))
+	if err == nil {
+		log.Printf("Service has reached expected state (%s)\n", string(expectedState))
+	}
 	return err
 }
 


### PR DESCRIPTION
Fix #1615 

When deploying the AMP stack, a service failing (timeout for instance) will stop the deployment in error.

## How to test

On a dev version of the CLI, remove a core service image, and run the cluster deployment:
```
$ docker image rm appcelerator/ampbeat:0.14.0-dev
$ amp cluster create --local-fast
```
The deployment should stop after the ampbeat service deployment failure