### PR TITLE
Delete AMP stack on cluster creation failure

### DIFF
--- a/cluster/plugin/local/Makefile
+++ b/cluster/plugin/local/Makefile
@@ -4,7 +4,7 @@ PKG := github.com/appcelerator/amp/cluster/plugin/local/cmd
 TARGET := bin/amp-local
 VERSION ?= $(shell cat ../../../VERSION)
 BUILD := $(shell git rev-parse HEAD | cut -c1-8)
-IMAGE := appcelerator/amp-local
+IMAGE := appcelerator/amp-local:$(VERSION)
 export LDFLAGS := "-s -X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
 
 build:


### PR DESCRIPTION
fixes #1632 

Handles Interrupt signals in the amp agent during cluster creation and ensures the AMP stack is deleted whenever it fails.

#### To Test

1. Hit `Ctrl+C` during `amp cluster create`. In another terminal window, run `docker service ls` command. You will see that no AMP services are running.
2. When using the dev version of the CLI, remove one image from the local cache (appcelerator/ampbeat:0.15.0-dev for instance) and run `amp cluster create`. It should fail and rollback the deployment.