### PR TITLE
Deployment of core services starts delay and timer once the image is pulled

### DIFF
--- a/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
@@ -18,8 +18,9 @@ services:
       - elasticsearch-data:/opt/elasticsearch/data
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "45s"
+      amp.service.stabilize.delay: "30s"
       amp.service.stabilize.timeout: "180s"
+      amp.service.pull.timeout: "120s"
     environment:
       MIN_MASTER_NODES: 2
       NETWORK_HOST: "_eth0_"

--- a/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.test.yml
@@ -11,10 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sfm", "65", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=60s" ]
+    command: ["curl", "--retry", "3", "--retry-connrefused", "--retry-delay", "5", "-sfm", "65", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=60s" ]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "90s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-elasticsearch-single.ampmon.yml
+++ b/cluster/agent/stacks/01-elasticsearch-single.ampmon.yml
@@ -18,8 +18,9 @@ services:
       - elasticsearch-data:/opt/elasticsearch/data
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "15s"
-      amp.service.stabilize.timeout: "35s"
+      amp.service.stabilize.delay: "8s"
+      amp.service.stabilize.timeout: "25s"
+      amp.service.pull.timeout: "120s"
     environment:
       NETWORK_HOST: "_eth0_"
       JAVA_HEAP_SIZE: "${ES_JAVA_HEAP_SIZE:-1024}"

--- a/cluster/agent/stacks/01-elasticsearch-single.test.yml
+++ b/cluster/agent/stacks/01-elasticsearch-single.test.yml
@@ -11,10 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sfm", "20", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=15s" ]
+    command: ["curl", "--retry", "2", "--retry-connrefused", "--retry-delay", "5", "-sfm", "20", "${AMP_STACK:-amp}_elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=15s" ]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "45s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
@@ -24,7 +24,7 @@ services:
       - "http://etcd:2379"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "20s"
+      amp.service.stabilize.delay: "10s"
       amp.service.stabilize.timeout: "40s"
     deploy:
       mode: replicated

--- a/cluster/agent/stacks/01-etcd-cluster.test.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.test.yml
@@ -17,6 +17,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "30s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-etcd-single.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-single.ampcore.yml
@@ -24,8 +24,8 @@ services:
       - "http://etcd:2379"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "6s"
-      amp.service.stabilize.timeout: "40s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "30s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-etcd-single.test.yml
+++ b/cluster/agent/stacks/01-etcd-single.test.yml
@@ -17,6 +17,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-nats.ampcore.yml
+++ b/cluster/agent/stacks/01-nats.ampcore.yml
@@ -15,8 +15,8 @@ services:
           - nats
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/01-nats.test.yml
+++ b/cluster/agent/stacks/01-nats.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/02-ampbeat.ampmon.yml
+++ b/cluster/agent/stacks/02-ampbeat.ampmon.yml
@@ -21,6 +21,5 @@ services:
         - node.labels.amp.type.core == true
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
-
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"

--- a/cluster/agent/stacks/03-kibana.ampmon.yml
+++ b/cluster/agent/stacks/03-kibana.ampmon.yml
@@ -22,8 +22,9 @@ services:
         - node.labels.amp.type.core == true
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "25s"
-      amp.service.stabilize.timeout: "40s"
+      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.timeout: "60s"
+      amp.service.pull.timeout: "120s"
     environment:
       ELASTICSEARCH_URL: "http://elasticsearch:9200"
       SERVICE_PORTS: 5601

--- a/cluster/agent/stacks/03-kibana.test.yml
+++ b/cluster/agent/stacks/03-kibana.test.yml
@@ -11,10 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sfm", "5", "${AMP_STACK:-amp}_kibana:5601/app/kibana#/discover"]
+    command: ["curl", "--retry", "3", "--retry-connrefused", "--retry-delay", "5", "-sfm", "5", "${AMP_STACK:-amp}_kibana:5601/app/kibana#/discover"]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "35s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/03-proxy.ampcore.yml
+++ b/cluster/agent/stacks/03-proxy.ampcore.yml
@@ -28,7 +28,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
+      amp.service.stabilize.delay: "3s"
       amp.service.stabilize.timeout: "30s"
     ports:
       - "80:80"

--- a/cluster/agent/stacks/03-proxy.test.yml
+++ b/cluster/agent/stacks/03-proxy.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "15s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
@@ -17,8 +17,8 @@ services:
       #- published: 9101
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-haproxy_exporter.test.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-nats_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-nats_exporter.ampmon.yml
@@ -17,8 +17,8 @@ services:
       #- published: 7777
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "60s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-nats_exporter.test.yml
+++ b/cluster/agent/stacks/04-nats_exporter.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-node_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-node_exporter.ampmon.yml
@@ -21,8 +21,8 @@ services:
     command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: global
       labels:

--- a/cluster/agent/stacks/04-node_exporter.test.yml
+++ b/cluster/agent/stacks/04-node_exporter.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/05-prometheus.ampmon.yml
+++ b/cluster/agent/stacks/05-prometheus.ampmon.yml
@@ -28,7 +28,7 @@ services:
       - "9090:9090"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "8s"
+      amp.service.stabilize.delay: "5s"
       amp.service.stabilize.timeout: "30s"
     deploy:
       mode: replicated

--- a/cluster/agent/stacks/05-prometheus.test.yml
+++ b/cluster/agent/stacks/05-prometheus.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/06-alertmanager.ampmon.yml
+++ b/cluster/agent/stacks/06-alertmanager.ampmon.yml
@@ -24,8 +24,8 @@ services:
       - "9093:9093"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "60s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "30s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/06-alertmanager.test.yml
+++ b/cluster/agent/stacks/06-alertmanager.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/07-grafana.ampmon.yml
+++ b/cluster/agent/stacks/07-grafana.ampmon.yml
@@ -21,8 +21,9 @@ services:
       VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "10s"
+      amp.service.stabilize.delay: "6s"
       amp.service.stabilize.timeout: "60s"
+      amp.service.pull.timeout: "120s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/07-grafana.test.yml
+++ b/cluster/agent/stacks/07-grafana.test.yml
@@ -11,10 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sfm", "6", "${AMP_STACK:-amp}_grafana:3000/api/org"]
+    command: ["curl", "--retry", "3", "--retry-connrefused", "--retry-delay", "5", "-sfm", "6", "${AMP_STACK:-amp}_grafana:3000/api/org"]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "45s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/09-amplifier.ampcore.yml
+++ b/cluster/agent/stacks/09-amplifier.ampcore.yml
@@ -26,7 +26,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "6s"
+      amp.service.stabilize.delay: "4s"
       amp.service.stabilize.timeout: "30s"
     deploy:
       mode: global

--- a/cluster/agent/stacks/09-amplifier.test.yml
+++ b/cluster/agent/stacks/09-amplifier.test.yml
@@ -15,6 +15,8 @@ services:
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
+      amp.service.stabilize.delay: "0s"
+      amp.service.stabilize.timeout: "20s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/10-gateway.ampcore.yml
+++ b/cluster/agent/stacks/10-gateway.ampcore.yml
@@ -14,7 +14,7 @@ services:
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.timeout: "20s"
     environment:
       SERVICE_PORTS: 80
       VIRTUAL_HOST: "https://gw.*,http://gw.*"

--- a/cluster/agent/stacks/11-agent.ampmon.yml
+++ b/cluster/agent/stacks/11-agent.ampmon.yml
@@ -20,8 +20,8 @@ services:
         io.amp.role: "infrastructure"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
     volumes:
       - ampagent:/containers
       - /var/run/docker.sock:/var/run/docker.sock

--- a/cluster/agent/stacksamples/12-portal.ampcore.yml
+++ b/cluster/agent/stacksamples/12-portal.ampcore.yml
@@ -24,5 +24,5 @@ services:
       VIRTUAL_HOST: "http://portal.*,https://portal.*,http://cloud.*,http://local.*,https://cloud.*,https://local.*"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"


### PR DESCRIPTION
Fix #1630 

- Start the stabilize delay and timeout once the image has been pulled
- Fails early if the image does not exist
- When a test stack was failing, ampagent waited for the timeout, which is a loss of time. Skipping this now
- Set stabilization time for test stacks to 0 second (a stopped task can't be more stable)

The deployment is not dependent anymore on the speed of the network, and won't fail because the pull of the image took longer than usual (up to a limit). This allow to reduce the stabilize delay and the stabilize timeout, which leads to a faster deployment on systems where the image is already pulled.

## Verification

Tested successfully on an AWS deployment (deploying a dev version on AWS requires a few steps that should be explained elsewhere).

To test locally:
```
$ make build-ampagent
$ amp cluster create
# remove a big image
$ docker image rm appcelerator/kibana:5.5.0
$ amp cluster create --local-fast
# remove a local image
$ docker image rm appcelerator/ampbeat:0.15.0-dev
$ amp cluster create --local-fast
# this last deployment should fail because the image can't be pulled
```