### PR TITLE
Monitoring service discovery and host labels

### DIFF
--- a/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
+++ b/cluster/agent/stacks/01-elasticsearch-cluster.ampmon.yml
@@ -38,6 +38,8 @@ services:
         window: 25s
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "9200"
+        io.amp.metrics.path: "/_prometheus/metrics"
       placement:
         constraints:
         - node.labels.amp.type.search == true

--- a/cluster/agent/stacks/01-elasticsearch-single.ampmon.yml
+++ b/cluster/agent/stacks/01-elasticsearch-single.ampmon.yml
@@ -29,6 +29,8 @@ services:
       replicas: 1
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "9200"
+        io.amp.metrics.path: "/_prometheus/metrics"
       placement:
         constraints:
         - node.labels.amp.type.search == true

--- a/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
@@ -38,6 +38,7 @@ services:
         window: 25s
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "2379"
       placement:
         constraints:
         - node.labels.amp.type.kv == true

--- a/cluster/agent/stacks/01-etcd-single.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-single.ampcore.yml
@@ -31,6 +31,7 @@ services:
       replicas: 1
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "2379"
       placement:
         constraints:
         - node.labels.amp.type.kv == true

--- a/cluster/agent/stacks/04-docker_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-docker_exporter.ampmon.yml
@@ -1,0 +1,24 @@
+version: "3.1"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+
+  docker-engine:
+    image: appcelerator/socat:latest
+    networks:
+      - default
+    #ports:
+    #  - "4999:4999"
+    labels:
+      io.amp.role: "infrastructure"
+      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.timeout: "20s"
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+        io.amp.metrics.port: "4999"

--- a/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
@@ -24,6 +24,8 @@ services:
       replicas: 1
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "9101"
+        io.amp.metrics.mode: "exporter"
       placement:
         constraints:
         - node.labels.amp.type.metrics == true

--- a/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
@@ -28,4 +28,4 @@ services:
         io.amp.metrics.mode: "exporter"
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true

--- a/cluster/agent/stacks/04-nats_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-nats_exporter.ampmon.yml
@@ -24,6 +24,8 @@ services:
       replicas: 1
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "7777"
+        io.amp.metrics.mode: "exporter"
       placement:
         constraints:
         - node.labels.amp.type.metrics == true

--- a/cluster/agent/stacks/04-nats_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-nats_exporter.ampmon.yml
@@ -28,4 +28,4 @@ services:
         io.amp.metrics.mode: "exporter"
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true

--- a/cluster/agent/stacks/04-node_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-node_exporter.ampmon.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
 
-  node_exporter:
+  nodes:
     image: prom/node-exporter:v0.14.0
     networks:
       - default
@@ -27,3 +27,4 @@ services:
       mode: global
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "9100"

--- a/cluster/agent/stacks/04-node_exporter.test.yml
+++ b/cluster/agent/stacks/04-node_exporter.test.yml
@@ -11,7 +11,7 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sf", "${AMP_STACK:-amp}_node_exporter:9100/metrics"]
+    command: ["curl", "-sf", "${AMP_STACK:-amp}_nodes:9100/metrics"]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:

--- a/cluster/agent/stacks/05-prometheus.ampmon.yml
+++ b/cluster/agent/stacks/05-prometheus.ampmon.yml
@@ -29,7 +29,7 @@ services:
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "5s"
-      amp.service.stabilize.timeout: "30s"
+      amp.service.stabilize.timeout: "45s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/06-alertmanager.ampmon.yml
+++ b/cluster/agent/stacks/06-alertmanager.ampmon.yml
@@ -33,7 +33,7 @@ services:
         io.amp.role: "infrastructure"
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true
     secrets:
       - source: alertmanager_yml
         target: alertmanager.yml

--- a/cluster/agent/stacks/06-alertmanager.test.yml
+++ b/cluster/agent/stacks/06-alertmanager.test.yml
@@ -25,6 +25,6 @@ services:
         io.amp.test:
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true
       restart_policy:
         condition: none

--- a/cluster/agent/stacks/07-grafana.ampmon.yml
+++ b/cluster/agent/stacks/07-grafana.ampmon.yml
@@ -21,7 +21,7 @@ services:
       VIRTUAL_HOST: "http://dashboard.*,https://dashboard.*"
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "6s"
+      amp.service.stabilize.delay: "8s"
       amp.service.stabilize.timeout: "60s"
       amp.service.pull.timeout: "120s"
     deploy:
@@ -31,4 +31,4 @@ services:
         io.amp.role: "infrastructure"
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true

--- a/cluster/agent/stacks/07-grafana.test.yml
+++ b/cluster/agent/stacks/07-grafana.test.yml
@@ -25,6 +25,6 @@ services:
         io.amp.test:
       placement:
         constraints:
-        - node.labels.amp.type.metrics == true
+        - node.labels.amp.type.core == true
       restart_policy:
         condition: none

--- a/cluster/agent/stacks/09-amplifier.ampcore.yml
+++ b/cluster/agent/stacks/09-amplifier.ampcore.yml
@@ -32,6 +32,7 @@ services:
       mode: global
       labels:
         io.amp.role: "infrastructure"
+        io.amp.metrics.port: "5100"
       restart_policy:
         condition: on-failure
       placement:

--- a/cluster/agent/stacks/09-amplifier.test.yml
+++ b/cluster/agent/stacks/09-amplifier.test.yml
@@ -25,6 +25,6 @@ services:
         io.amp.test:
       placement:
         constraints:
-        - node.labels.amp.type.core == true
+        - node.labels.amp.type.metrics == true
       restart_policy:
         condition: none

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-598ebb22
+      Default: ami-f2526889
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-60bf9f05
+      Default: ami-002d0e65
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-8d24c7f5
+      Default: ami-a47897dc
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-b66494cf
+      Default: ami-81cc33f8
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-a3677fc0
+      Default: ami-68f7ec0b
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
@@ -66,12 +66,6 @@ Parameters:
     MinValue: 1
     MaxValue: 1000
     Description: "A good starting point is 3 nodes"
-  MetricsWorkerSize:
-    Type: Number
-    Default: 1
-    MinValue: 1
-    MaxValue: 1
-    Description: "single node only for now"
   LinuxDistribution:
     Type: String
     AllowedValues:
@@ -124,7 +118,7 @@ Parameters:
     - r4.2xlarge
     - r4.4xlarge
     ConstraintDescription: Must be a valid EC2 HVM instance type.
-    Default: t2.small
+    Default: t2.large
     Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
   CoreWorkerInstanceType:
     Type: String
@@ -171,29 +165,6 @@ Parameters:
     - r4.4xlarge
     ConstraintDescription: Must be a valid EC2 HVM instance type.
     Default: t2.medium
-    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
-  MetricsWorkerInstanceType:
-    Type: String
-    AllowedValues:
-    - t2.nano
-    - t2.micro
-    - t2.small
-    - t2.medium
-    - t2.large
-    - m3.medium
-    - m4.large
-    - m4.xlarge
-    - m4.2xlarge
-    - c4.large
-    - c4.xlarge
-    - c4.2xlarge
-    - c4.4xlarge
-    - r4.large
-    - r4.xlarge
-    - r4.2xlarge
-    - r4.4xlarge
-    ConstraintDescription: Must be a valid EC2 HVM instance type.
-    Default: t2.large
     Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
   DrainManager:
     Type: String
@@ -480,11 +451,6 @@ Resources:
         IpProtocol: tcp
         FromPort: '2375'
         ToPort: '2375'
-      - SourceSecurityGroupId:
-          !Ref MetricsSecurityGroup
-        IpProtocol: tcp
-        FromPort: '2375'
-        ToPort: '2375'
       # docker swarm join
       - CidrIp:
           Fn::FindInMap:
@@ -707,66 +673,12 @@ Resources:
     Properties:
       GroupDescription: Monitoring services security group
       SecurityGroupIngress:
-      # node communication
-      - CidrIp:
-          Fn::FindInMap:
-          - VpcCidrs
-          - vpc
-          - cidr
-        IpProtocol: tcp
-        FromPort: '7946'
-        ToPort: '7946'
-      - CidrIp:
-          Fn::FindInMap:
-          - VpcCidrs
-          - vpc
-          - cidr
-        IpProtocol: udp
-        FromPort: '7946'
-        ToPort: '7946'
-      # overlay network traffic
-      - CidrIp:
-          Fn::FindInMap:
-          - VpcCidrs
-          - vpc
-          - cidr
-        IpProtocol: udp
-        FromPort: '4789'
-        ToPort: '4789'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '443'
-        ToPort: '443'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '3000'
-        ToPort: '3000'
       - CidrIp: 0.0.0.0/0
         IpProtocol: tcp
         FromPort: '9090'
         ToPort: '9090'
-      - CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: '50101'
-        ToPort: '50101'
       VpcId:
         Ref: Vpc
-  MetricsSelfIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId:
-        Ref: MetricsSecurityGroup
-      IpProtocol: -1
-      SourceSecurityGroupId:
-        Ref: MetricsSecurityGroup
 
   ClusterRole:
     Type: AWS::IAM::Role
@@ -976,90 +888,6 @@ Resources:
         Enabled: 'true'
         Timeout: '60'
 
-  MetricsWaitHandle:
-    Type: "AWS::CloudFormation::WaitConditionHandle"
-
-  MetricsWaitCondition:
-    Type: "AWS::CloudFormation::WaitCondition"
-    DependsOn: MetricsWorkerAutoScalingGroup
-    Properties:
-      Handle: !Ref MetricsWaitHandle
-      Timeout: 600
-      Count: !Ref MetricsWorkerSize
-
-  MetricsWorkerAutoScalingGroup:
-    Type: AWS::AutoScaling::AutoScalingGroup
-    DependsOn:
-      - PublicSubnet1
-      - PublicSubnet2
-      - PublicSubnet3
-      - ManagerWaitCondition
-    UpdatePolicy:
-      AutoScalingRollingUpdate:
-        MaxBatchSize: 1
-        MinInstancesInService: 0
-        PauseTime: PT30S
-        WaitOnResourceSignals: false
-    Properties:
-      DesiredCapacity: !Ref MetricsWorkerSize
-      HealthCheckGracePeriod: 300
-      HealthCheckType: EC2
-      LaunchConfigurationName: !Ref MetricsWorkerAsgLaunchConfig
-      MaxSize: 5
-      MinSize: 0
-      Tags:
-      - Key: Name
-        PropagateAtLaunch: true
-        Value:
-          Fn::Join:
-          - '-'
-          - - Ref: AWS::StackName
-            - worker
-            - metrics
-      - Key: amp.clusterid
-        PropagateAtLaunch: true
-        Value: !Ref AWS::StackName
-      - Key: SwarmRole
-        PropagateAtLaunch: true
-        Value: worker
-      VPCZoneIdentifier:
-      - Fn::Join:
-        - ','
-        -  - !Ref PublicSubnet1
-           - !Ref PublicSubnet2
-           - !Ref PublicSubnet3
-  MetricsWorkerAsgLaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
-    DependsOn:
-      - MetricsWaitHandle
-    Properties:
-      AssociatePublicIpAddress: true
-      IamInstanceProfile: !Ref ClusterInstanceProfile
-      ImageId:
-        Fn::FindInMap:
-        - AMI
-        - Ref: AWS::Region
-        - Ref: LinuxDistribution
-      InstanceType: !Ref MetricsWorkerInstanceType
-      KeyName: !Ref KeyName
-      SecurityGroups:
-        - Ref: MetricsSecurityGroup
-      BlockDeviceMappings:
-        - DeviceName: /dev/sdl
-          Ebs:
-            VolumeSize: !Ref AufsVolumeSize
-            DeleteOnTermination: true
-      UserData:
-        Fn::Base64:
-          !Sub
-            - |
-              #cloud-config
-              repo_update: false
-              repo_upgrade: none
-              runcmd:
-                - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${MetricsWaitHandle}" LABELS="amp.type.metrics=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
-            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
   CoreWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
 
@@ -1241,7 +1069,6 @@ Resources:
     DependsOn:
       - ManagerWaitCondition
       - CoreWaitCondition
-      - MetricsWaitCondition
       - UserWaitCondition
     Properties:
       Handle: !Ref ApplicationWaitHandle
@@ -1318,6 +1145,7 @@ Resources:
       KeyName: !Ref KeyName
       SecurityGroups:
         - Ref: ManagerSecurityGroup
+        - Ref: MetricsSecurityGroup
       BlockDeviceMappings:
         - DeviceName: /dev/sdl
           Ebs:
@@ -1332,7 +1160,7 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/userdata-aws-manager && chmod +x /usr/local/bin/userdata-aws-manager || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}+${MetricsWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-manager || shutdown -h
+                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" LABELS="amp.type.api=true amp.type.route=true amp.type.metrics=true" /usr/local/bin/userdata-aws-manager || shutdown -h
             - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], ApplicationSignalURL: !If [ InstallApplicationCond, !Ref ApplicationWaitHandle, "" ] }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
@@ -1418,8 +1246,6 @@ Metadata:
       - CoreWorkerInstanceType
       - UserWorkerSize
       - UserWorkerInstanceType
-      - MetricsWorkerSize
-      - MetricsWorkerInstanceType
       - DrainManager
     - Label:
         default: Docker Configuration
@@ -1443,16 +1269,12 @@ Metadata:
         default: Number of Swarm workers for AMP core services?
       UserWorkerSize:
         default: Number of Swarm workers for AMP user services?
-      MetricsWorkerSize:
-        default: Number of Swarm workers for AMP monitoring services?
       ManagerInstanceType:
         default: Swarm manager instance type?
       CoreWorkerInstanceType:
         default: Swarm worker instance type for core services?
       UserWorkerInstanceType:
         default: Swarm worker instance type for user services?
-      MetricsWorkerInstanceType:
-        default: Swarm worker instance type for monitoring services?
       DrainManager:
         default: Drain manager nodes?
       OverlayNetworks:

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -3,6 +3,7 @@
 SYNC=${SYNC:-false}
 SYSTEM_PRUNE=${SYSTEM_PRUNE:-false}
 #SIGNAL_URL=
+LABELS=${LABELS:-amp.type.api=true amp.type.route=true amp.type.metrics=true}
 #APP_SIGNAL_URL=
 CHANNEL=${CHANNEL:-stable}
 #PLUGINS=
@@ -348,10 +349,13 @@ _label_node(){
   local _publicip
   _self=$(docker node inspect self -f '{{.ID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  echo "applying label PublicIP=$_publicip" >&2
   echo "applying labels amp.type.api and amp.type.route" >&2
-  docker node update --label-add "PublicIP=$_publicip" "$_self" || return 1
-  docker node update --label-add "amp.type.api=true" "$_self" || return 1
-  docker node update --label-add "amp.type.route=true" "$_self"
+  docker node update --label-add "PublicIP=$_publicip" "$_self" >/dev/null || return 1
+  for _label in $LABELS; do
+    echo "applying label $_label" >&2
+    docker node update --label-add "${_label}" "$_self" >/dev/null || return 1
+  done
 }
 
 _drain_node(){

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -222,7 +222,7 @@ _label_node(){
   _self=$(docker info -f '{{.Swarm.NodeID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
   echo "applying label PublicIP=$_publicip" >&2
-  docker -H "$_manager" node update --label-add "PublicIP=$_publicip" "$_self" || return 1
+  docker -H "$_manager" node update --label-add "PublicIP=$_publicip" "$_self" >/dev/null || return 1
   for _label in $LABELS; do
     echo "applying label $_label" >&2
     docker -H "$_manager" node update --label-add "${_label}" "$_self" >/dev/null || return 1

--- a/images/socat/Dockerfile
+++ b/images/socat/Dockerfile
@@ -1,0 +1,7 @@
+# based on https://github.com/bvis/docker-socat
+FROM alpine:3.6
+ENV IN "9323"
+ENV OUT "4999"
+RUN apk add --no-cache socat
+COPY entrypoint.sh /bin/
+ENTRYPOINT /bin/entrypoint.sh

--- a/images/socat/build
+++ b/images/socat/build
@@ -1,0 +1,1 @@
+docker build -t appcelerator/socat .

--- a/images/socat/entrypoint.sh
+++ b/images/socat/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# if IN is already a host:port addr, we'll use it directly
+# else, get the gateway, which is where the docker metrics are available
+echo "$IN" | grep -q ":"
+if [[ $? -ne 0 ]]; then
+  gw=$(ip route | grep "default via" | awk '{print $3}')
+  [[ -z "$gw" ]] && exit 1
+  IN="${gw}:$IN"
+fi
+
+echo "forwarding $IN to $OUT" >&2
+exec socat -d -d TCP-L:$OUT,fork TCP:$IN

--- a/monitoring/config/prometheus.tpl
+++ b/monitoring/config/prometheus.tpl
@@ -1,5 +1,3 @@
-{{ $dockerPort := .DockerEngineMetricsPort -}}
-{{ $systemPort := .SystemMetricsPort -}}
 global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
@@ -56,30 +54,4 @@ scrape_configs:
         target_label: {{ .TargetLabel }}
 {{- end }}
 {{- end }}
-{{- end }}
-{{/* Docker Engine metrics */}}
-{{- if .Hostnames }}
-  - job_name: 'docker-engine'
-    static_configs:
-      - targets:
-{{- range .Hostnames }}
-        - '{{ . }}:{{ $dockerPort }}'
-{{- end }}
-    relabel_configs:
-      - source_labels: [__address__]
-        regex: (.*):.*
-        replacement: $1
-        target_label: instance
-{{/* System metrics */}}
-  - job_name: 'nodes'
-    static_configs:
-      - targets:
-{{- range .Hostnames }}
-        - '{{ . }}:{{ $systemPort }}'
-{{- end }}
-    relabel_configs:
-      - source_labels: [__address__]
-        regex: (.*):.*
-        replacement: $1
-        target_label: instance
 {{- end }}

--- a/platform/tests/metrics/prometheus-config_test.sh
+++ b/platform/tests/metrics/prometheus-config_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+tmpfile=$(mktemp)
+code=0
+docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sf http://prometheus:9090/config > $tmpfile
+grep -q -- "- job_name: nodes" $tmpfile
+code=$((code+$?))
+grep -q -- "- job_name: docker-engine" $tmpfile
+code=$((code+$?))
+grep -q -- "taskname: amp_amplifier." $tmpfile
+code=$((code+$?))
+grep -q -- "- amp_haproxy_exporter:9101" $tmpfile
+code=$((code+$?))
+[[ $code -ne 0 ]] && (echo "$code issues found in prometheus configuration file" ; cat $tmpfile)
+rm $tmpfile
+exit $code

--- a/platform/tests/metrics/prometheus-targets_test.sh
+++ b/platform/tests/metrics/prometheus-targets_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+tmpfile=$(mktemp)
+code=1
+SECONDS=0
+TIMEOUT=25
+while [[ $code -ne 0 ]]; do
+  [[ $SECONDS -gt $TIMEOUT ]] && break
+  code=0
+  docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sf http://prometheus:9090/targets > $tmpfile
+  countstate=$(grep -wc "State" $tmpfile)
+  countup=$(grep -wc "up" $tmpfile)
+  [[ $countstate -eq $countup && $countup -gt 0 ]] && break
+  code=1
+done
+[[ $code -ne 0 ]] && (echo "issue with prometheus targets" ; cat $tmpfile)
+rm $tmpfile
+exit $code


### PR DESCRIPTION
Fix #1641 (Alerting and node identification)

The prometheus configuration now includes more information, in particular labels with the name of the host and the task id of the container. This allows to present useful information in dashboards and alerts, instead of the IP:port of the container.

Fix #1647 (Monitoring service discovery)

Labels set in the stack files are watched by Prometheus to discover the services and build its configuration file.
Moving Prometheus to a manager node, since we need access to the Swarm annotations, this is a compromise. This means that the cloud deployment doesn't need an instance dedicated for Prometheus, one less instance group (of a single instance) is deployed.

New service relaying the docker engine metrics through a global container. The code is now more generic and is not specific to Docker for Mac.

Added tests on Prometheus configuration.

This also brings Docker 17.06.1-ce instead of Docker 17.06.0-ce.

## Verification

build the prometheus image ```make build-monit build-ampagent```
deploy amp ```amp cluster create```
Check the dashboard on dashboard.local.appcelerator.io, the instance name in the legends is now an IP instead of IP:port or container IP.