### PR TITLE
Fix email notification on user signup

### DIFF
--- a/data/accounts/store.go
+++ b/data/accounts/store.go
@@ -248,7 +248,7 @@ func (s *Store) CreateUser(ctx context.Context, name string, email string, passw
 	if err := s.storage.Create(ctx, path.Join(usersRootKey, name), user, nil, 0); err != nil {
 		return nil, err
 	}
-	return s.secureUser(ctx, user), nil
+	return user, nil
 }
 
 // VerifyUser verifies a user account


### PR DESCRIPTION
fix #1650 

- Add a few logs in amplifier related to user creation
- CreateUser returns the user with its email (it was obfuscated), allowing to send the email notification

## Verification

```
ampmake build-server
# create the amplifier_yml secret with a valid sendgrid key
amp -k user signup --name u1650 --email YOUR_EMAIL
# check your email
```