### PR TITLE
pass stackname as argument to AWS cluster deletion

### DIFF
--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -24,6 +24,12 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 
 	// local options
 	flags.Bool("local-force-leave", false, "Force leave the swarm")
+
+	// aws options
+	flags.String("aws-region", "", "Region to use to delete the instance")
+	flags.String("aws-stackname", "", "Name of the AWS stack to be deleted")
+	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+
 	return cmd
 }
 

--- a/cluster/plugin/aws/plugin.go
+++ b/cluster/plugin/aws/plugin.go
@@ -175,3 +175,13 @@ func StackOutputToJSON(so []StackOutput) (string, error) {
 	}
 	return string(j), nil
 }
+
+// ListStack lists the stacks based on the filter on stack status
+func ListStack(ctx context.Context, svc *cf.CloudFormation) (*cf.ListStacksOutput, error) {
+	statusFilter := []string{cf.StackStatusCreateFailed, cf.StackStatusCreateInProgress, cf.ChangeSetStatusCreateComplete, cf.StackStatusRollbackInProgress, cf.StackStatusRollbackFailed, cf.StackStatusDeleteInProgress}
+	input := &cf.ListStacksInput{
+		StackStatusFilter: aws.StringSlice(statusFilter),
+	}
+
+	return svc.ListStacksWithContext(ctx, input)
+}


### PR DESCRIPTION
Resolves #1629 

Pass `stackname` and `region` as arguments when removing cluster on AWS
Also added `--aws-sync` option to the command

### To test
```
$ make build-cli build-amp-aws

$ amp cluster create --provider aws --aws-region=$REGION --aws-stackname=amp-test --aws-parameter KeyName=$KEYNAME 
[localhost:50101]
/08/24 18:14:42 stack created: amp-test
2017/08/24 18:14:42 "arn:aws:cloudformation:us-west-2:654814900965:stack/nv-test/1bffb7e0-88f8-11e7-9fa9-503ac9ec24fd"

$ amp cluster rm --provider aws --aws-region=$REGION --aws-stackname=amp-test
2017/08/24 18:14:52 stack deleted: amp-test
```