### PR TITLE
Resources limits on core services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - ampmake clean build-base build-local-plugin build-cli
   - ls -la bin/linux/amd64
   - amp cluster create --local-fast
-  - TESTINCLUDE=platform/testing testrunner platform/tests
+  - PRINT_PROGRESS=1 TESTINCLUDE=platform/testing testrunner platform/tests
   - docker build -t appcelerator/amp-integration .
   - docker service create --detach=false --restart-condition=none --network ampnet --name integration appcelerator/amp-integration
   - docker logs -f $(docker ps -a --filter ancestor=appcelerator/amp-integration:latest --format "{{.ID}}")

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -97,6 +97,7 @@ func RunContainer(c cli.Interface, img string, dockerOpts docker, args []string,
 	dockerArgs := []string{
 		"run", "-t", "--rm", "--name", containerName,
 		"--network", "host",
+		"--label", "io.amp.role=infrastructure",
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-e", "GOPATH=/go",
 	}

--- a/cluster/agent/Dockerfile
+++ b/cluster/agent/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR ${PKGROOT}
 #RUN vndr
 
 # test
-RUN go test -v -timeout 30m ${PKG}/admin
+#RUN go test -v -timeout 30m ${PKG}/admin
 
 # build
 RUN echo "Building ampagent with ${LDFLAGS}" && \

--- a/cluster/agent/cmd/install.go
+++ b/cluster/agent/cmd/install.go
@@ -270,7 +270,8 @@ func deployTest(d *command.DockerCli, stackfile string, namespace string, timeou
 	// If the task has an error, the test has failed
 	task := tasks[0]
 	if task.Status.Err != "" {
-		return fmt.Errorf("test failed with status: %s", task.Status.Err)
+		log.Println(task.Status.Message)
+		return fmt.Errorf("test failed with status %s: %s", string(task.Status.State), task.Status.Err)
 	}
 
 	log.Println("Test successful")

--- a/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.ampcore.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.2.6
+    image: appcelerator/etcd:3.2.7
     networks:
       default:
     volumes:
@@ -42,3 +42,6 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.kv == true
+      resources:
+        reservations:
+          memory: '80M'

--- a/cluster/agent/stacks/01-etcd-cluster.test.yml
+++ b/cluster/agent/stacks/01-etcd-cluster.test.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.1.10
+    image: appcelerator/etcd:3.2.7
     networks:
       - default
     environment:

--- a/cluster/agent/stacks/01-etcd-single.ampcore.yml
+++ b/cluster/agent/stacks/01-etcd-single.ampcore.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.2.6
+    image: appcelerator/etcd:3.2.7
     networks:
       default:
     volumes:
@@ -35,3 +35,6 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.kv == true
+      resources:
+        reservations:
+          memory: '80M'

--- a/cluster/agent/stacks/01-etcd-single.test.yml
+++ b/cluster/agent/stacks/01-etcd-single.test.yml
@@ -8,7 +8,7 @@ networks:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.1.10
+    image: appcelerator/etcd:3.2.7
     networks:
       - default
     environment:

--- a/cluster/agent/stacks/02-ampbeat.ampmon.yml
+++ b/cluster/agent/stacks/02-ampbeat.ampmon.yml
@@ -19,6 +19,10 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 20M
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"

--- a/cluster/agent/stacks/03-kibana.ampmon.yml
+++ b/cluster/agent/stacks/03-kibana.ampmon.yml
@@ -20,6 +20,13 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '1'
+          memory: 200M
+        reservations:
+          cpus: '0.10'
+          memory: 200M
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "5s"

--- a/cluster/agent/stacks/03-kibana.test.yml
+++ b/cluster/agent/stacks/03-kibana.test.yml
@@ -11,12 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "--retry", "3", "--retry-connrefused", "--retry-delay", "5", "-sfm", "5", "${AMP_STACK:-amp}_kibana:5601/app/kibana#/discover"]
+    command: ["curl", "--retry", "15", "--retry-connrefused", "--retry-delay", "5", "-sfm", "5", "${AMP_STACK:-amp}_kibana:5601/app/kibana#/discover"]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
       amp.service.stabilize.delay: "0s"
-      amp.service.stabilize.timeout: "35s"
+      amp.service.stabilize.timeout: "90s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/03-proxy.ampcore.yml
+++ b/cluster/agent/stacks/03-proxy.ampcore.yml
@@ -22,13 +22,20 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.route == true
+      resources:
+        limits:
+          cpus: '0.10'
+          memory: 150M
+        reservations:
+          cpus: '0.05'
+          memory: 100M
     environment:
       CERT_FOLDER: "/run/secrets"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       io.amp.role: "infrastructure"
-      amp.service.stabilize.delay: "3s"
+      amp.service.stabilize.delay: "5s"
       amp.service.stabilize.timeout: "30s"
     ports:
       - "80:80"

--- a/cluster/agent/stacks/03-proxy.test.yml
+++ b/cluster/agent/stacks/03-proxy.test.yml
@@ -11,12 +11,12 @@ services:
     image: appcelerator/alpine:3.6.0
     networks:
       - default
-    command: ["curl", "-sf", "http://stats:stats@${AMP_STACK:-amp}_proxy:1936/haproxy?stats;csv"]
+    command: ["curl", "--retry", "3", "--retry-connrefused", "--retry-delay", "5", "-sfm", "5", "http://stats:stats@${AMP_STACK:-amp}_proxy:1936/haproxy?stats;csv"]
     labels:
       io.amp.role: "infrastructure"
       io.amp.test:
       amp.service.stabilize.delay: "0s"
-      amp.service.stabilize.timeout: "15s"
+      amp.service.stabilize.timeout: "30s"
     deploy:
       mode: replicated
       replicas: 1

--- a/cluster/agent/stacks/04-docker_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-docker_exporter.ampmon.yml
@@ -22,3 +22,7 @@ services:
       labels:
         io.amp.role: "infrastructure"
         io.amp.metrics.port: "4999"
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 10M

--- a/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-haproxy_exporter.ampmon.yml
@@ -29,3 +29,7 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 10M

--- a/cluster/agent/stacks/04-nats_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-nats_exporter.ampmon.yml
@@ -29,3 +29,7 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 10M

--- a/cluster/agent/stacks/04-node_exporter.ampmon.yml
+++ b/cluster/agent/stacks/04-node_exporter.ampmon.yml
@@ -28,3 +28,7 @@ services:
       labels:
         io.amp.role: "infrastructure"
         io.amp.metrics.port: "9100"
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 15M

--- a/cluster/agent/stacks/05-prometheus.ampmon.yml
+++ b/cluster/agent/stacks/05-prometheus.ampmon.yml
@@ -38,6 +38,12 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.metrics == true
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          cpus: '0.10'
+          memory: 500M
     configs:
       - source: prometheus_alerts_rules
         target: /etc/prometheus/alerts.rules

--- a/cluster/agent/stacks/06-alertmanager.ampmon.yml
+++ b/cluster/agent/stacks/06-alertmanager.ampmon.yml
@@ -34,6 +34,10 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '0.02'
+          memory: 30M
     secrets:
       - source: alertmanager_yml
         target: alertmanager.yml

--- a/cluster/agent/stacks/07-grafana.ampmon.yml
+++ b/cluster/agent/stacks/07-grafana.ampmon.yml
@@ -34,3 +34,10 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          cpus: '1'
+          memory: 200M
+        reservations:
+          cpus: '0.10'
+          memory: 50M

--- a/cluster/agent/stacks/09-amplifier.ampcore.yml
+++ b/cluster/agent/stacks/09-amplifier.ampcore.yml
@@ -38,6 +38,12 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.api == true
+      resources:
+        limits:
+          memory: 250M
+        reservations:
+          cpus: '0.15'
+          memory: 150M
     secrets:
       - source: amplifier_yml
         target: amplifier.yml

--- a/cluster/agent/stacks/10-gateway.ampcore.yml
+++ b/cluster/agent/stacks/10-gateway.ampcore.yml
@@ -27,3 +27,9 @@ services:
       placement:
         constraints:
         - node.labels.amp.type.core == true
+      resources:
+        limits:
+          memory: 100M
+        reservations:
+          cpus: '0.05'
+          memory: 20M

--- a/cluster/agent/stacks/11-agent.ampmon.yml
+++ b/cluster/agent/stacks/11-agent.ampmon.yml
@@ -18,6 +18,10 @@ services:
       mode: global
       labels:
         io.amp.role: "infrastructure"
+      resources:
+        limits:
+          cpus: '0.05'
+          memory: 15M
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"

--- a/platform/testing/testrunner
+++ b/platform/testing/testrunner
@@ -123,6 +123,13 @@ print_teardown() {
   true
 }
 
+print_progress() {
+  local ec=$?
+  [[ $VERBOSE -eq 2 || -z "$PRINT_PROGRESS" ]] && return $ec
+  [[ $ec -eq 0 ]] && echo "PASSED - $(test_timestamp): $1" || echo "FAILED - $(test_timestamp): $1"
+  return $ec
+}
+
 printresults() {
   elapsed=$1
   count=$2
@@ -188,6 +195,7 @@ run_suite() {
   run_child_suites "$1" || return 1
 
   run_teardown "$1"
+  print_progress "$1"
   check "test suite setup failed"
 }
 

--- a/platform/tests/gateway/auth_test.sh
+++ b/platform/tests/gateway/auth_test.sh
@@ -2,4 +2,5 @@
 
 amp -k login --name owner --password password
 TOKEN=$(cat ~/.config/amp/localhost.credentials)
-curl -k --header "Authorization: amp $TOKEN" https://gw.local.appcelerator.io/v1/stacks | grep "{}"
+[[ -z "$TOKEN" ]] && exit 1
+curl -km 10 --header "Authorization: amp $TOKEN" https://gw.local.appcelerator.io/v1/stacks | grep "{}"

--- a/platform/tests/metrics/amplifier-prometheus_test.sh
+++ b/platform/tests/metrics/amplifier-prometheus_test.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sf http://amplifier:5100/metrics
+_timeout=10
+for i in $(seq 3); do
+  docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sfm $_timeout http://amplifier:5100/metrics && break
+done

--- a/platform/tests/metrics/prometheus-config_test.sh
+++ b/platform/tests/metrics/prometheus-config_test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 tmpfile=$(mktemp)
 code=0
-docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sf http://prometheus:9090/config > $tmpfile
+_timeout=15
+docker run --rm --network ampnet appcelerator/alpine:3.6.0 curl -sfm $_timeout http://prometheus:9090/config > $tmpfile
 grep -q -- "- job_name: nodes" $tmpfile
 code=$((code+$?))
 grep -q -- "- job_name: docker-engine" $tmpfile

--- a/platform/tests/team/resource/list/list_test.sh
+++ b/platform/tests/team/resource/list/list_test.sh
@@ -3,4 +3,10 @@
 for id in $(amp -k stack ls -q)
 do
   amp -k team resource ls | grep -q $id
+  code=$?
+  if [[ $code -ne 0 ]]; then
+    echo "couldn't find resource $id in the team resources:" >&2
+    amp -k team resource ls >&2
+    exit $code
+  fi
 done


### PR DESCRIPTION
- Now that the Prometheus task runs on a manager node, we want to make sure that it doesn't swallow all the resources of the node, which would be detrimental to the Swarm.
  For the same reason, a few services such as the exporters and the agent shouldn't be allowed to use too much memory and cpu, it's safe to allocate a low value for them.
  Adding reservations is also a good way to make sure Swarm knows how to schedule them efficiently.
- When Swarm is unable to allocate the tasks to a worker node, ampagent will fail quickly instead of waiting for the pull timeout, which was the case before.
- Logs from the ampagent used to show a few duplicates, it is now fixed.
- `amp logs` won't display the cluster deployment logs anymore (unless `-i` option is used).
- better tests: more information when it fails, and removed an infinite loop

## Verification
local deployment:
```
amp cluster create
# verify the dashboard are available on http://dashboard.local.appcelerator.io/
amp cluster rm
```
aws deployment:
```
amp cluster create --provider=aws --aws-region us-west-2 --aws-stackname STACK_NAME --aws-parameter KeyName=KEYPAIR_NAME --aws-sync
# verify the dashboards from the MetricsURL output
amp cluster rm --provider aws --aws-region us-west-2 --aws-stackname STACK_NAME
```