### PR TITLE
Update core images

### DIFF
--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -97,6 +97,7 @@ func RunContainer(c cli.Interface, img string, dockerOpts docker, args []string,
 	dockerArgs := []string{
 		"run", "-t", "--rm", "--name", containerName,
 		"--network", "host",
+		"--label", "io.amp.role=infrastructure",
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-e", "GOPATH=/go",
 	}

--- a/cluster/ampagent/stacks/cluster/01-core.yml
+++ b/cluster/ampagent/stacks/cluster/01-core.yml
@@ -17,7 +17,7 @@ volumes:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.2.6
+    image: appcelerator/etcd:3.2.9
     networks:
       default:
     volumes:

--- a/cluster/ampagent/stacks/cluster/02-logs.yml
+++ b/cluster/ampagent/stacks/cluster/02-logs.yml
@@ -12,7 +12,7 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.5.0
+    image: appcelerator/elasticsearch-amp:5.6.3
     networks:
       - default
     volumes:
@@ -82,7 +82,7 @@ services:
       amp.service.stabilize.timeout: "20s"
 
   kibana:
-    image: appcelerator/kibana:5.5.0
+    image: appcelerator/kibana:5.6.3
     networks:
       - default
     deploy:

--- a/cluster/ampagent/stacks/cluster/03-metrics.yml
+++ b/cluster/ampagent/stacks/cluster/03-metrics.yml
@@ -112,7 +112,7 @@ services:
         - node.labels.amp.type.core == true
 
   nodes:
-    image: prom/node-exporter:v0.14.0
+    image: prom/node-exporter:v0.15.0
     networks:
       - default
     volumes:
@@ -122,7 +122,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     #ports:
     #  - "9100:9100"
-    command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
+    command: [ "--path.procfs", "/host/proc", "--path.sysfs", "/host/sys", "--collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"
@@ -134,7 +134,7 @@ services:
         io.amp.metrics.port: "9100"
 
   alertmanager:
-    image: prom/alertmanager:v0.8.0
+    image: prom/alertmanager:v0.9.1
     networks:
       - default
     volumes:
@@ -161,7 +161,7 @@ services:
              "-storage.path=/alertmanager",
              "-web.external-url=http://localhost:9093" ]
   grafana:
-    image: appcelerator/grafana-amp:1.2.5
+    image: appcelerator/grafana-amp:1.2.6
     networks:
       - default
     volumes:

--- a/cluster/ampagent/stacks/single/01-core.yml
+++ b/cluster/ampagent/stacks/single/01-core.yml
@@ -17,7 +17,7 @@ volumes:
 services:
 
   etcd:
-    image: appcelerator/etcd:3.2.6
+    image: appcelerator/etcd:3.2.9
     networks:
       default:
     volumes:

--- a/cluster/ampagent/stacks/single/02-logs.yml
+++ b/cluster/ampagent/stacks/single/02-logs.yml
@@ -12,7 +12,7 @@ volumes:
 services:
 
   elasticsearch:
-    image: appcelerator/elasticsearch-amp:5.5.0
+    image: appcelerator/elasticsearch-amp:5.6.3
     networks:
       - default
     volumes:
@@ -73,7 +73,7 @@ services:
       amp.service.stabilize.timeout: "20s"
 
   kibana:
-    image: appcelerator/kibana:5.5.0
+    image: appcelerator/kibana:5.6.3
     networks:
       - default
     deploy:

--- a/cluster/ampagent/stacks/single/03-metrics.yml
+++ b/cluster/ampagent/stacks/single/03-metrics.yml
@@ -112,7 +112,7 @@ services:
         - node.labels.amp.type.core == true
 
   nodes:
-    image: prom/node-exporter:v0.14.0
+    image: prom/node-exporter:v0.15.0
     networks:
       - default
     volumes:
@@ -122,7 +122,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     #ports:
     #  - "9100:9100"
-    command: [ "-collector.procfs", "/host/proc", "-collector.sysfs", "/host/sys", "-collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
+    command: [ "--path.procfs", "/host/proc", "--path.sysfs", "/host/sys", "--collector.filesystem.ignored-mount-points", "^/(sys|proc|dev|host|etc)($$|/)"]
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"
@@ -134,7 +134,7 @@ services:
         io.amp.metrics.port: "9100"
 
   alertmanager:
-    image: prom/alertmanager:v0.8.0
+    image: prom/alertmanager:v0.9.1
     networks:
       - default
     volumes:
@@ -161,7 +161,7 @@ services:
              "-storage.path=/alertmanager",
              "-web.external-url=http://localhost:9093" ]
   grafana:
-    image: appcelerator/grafana-amp:1.2.5
+    image: appcelerator/grafana-amp:1.2.6
     networks:
       - default
     volumes:

--- a/images/elasticsearch/Dockerfile
+++ b/images/elasticsearch/Dockerfile
@@ -3,7 +3,7 @@ FROM appcelerator/alpine:3.6.0
 RUN apk --no-cache add openjdk8-jre bind-tools
 
 ENV PATH /bin:/opt/elasticsearch/bin:$PATH
-ENV ELASTIC_VERSION 5.5.0
+ENV ELASTIC_VERSION 5.6.3
 
 RUN mkdir -p /opt/elasticsearch && adduser -D -h /opt/elasticsearch -s /sbin/nologin elastico && rm -rf /opt
 
@@ -17,7 +17,7 @@ RUN curl -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$
     rm /tmp/elasticsearch-$ELASTIC_VERSION.tar.gz && \
     mv /_config/* /opt/elasticsearch/config/ && rm -rf /_config && \
     mkdir -p /opt/elasticsearch/config/scripts && \
-    /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.5.0.0.zip && \
+    /opt/elasticsearch/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-${ELASTIC_VERSION}.0.zip && \
     chown -R elastico:elastico /opt/elasticsearch
 
 COPY /bin/docker-entrypoint.sh /bin/

--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM appcelerator/grafana:grafana-4.4.3
+FROM appcelerator/grafana:grafana-4.5.2
 ENV FORCE_HOSTNAME	auto
 ENV GRAFANA_PLUGIN_LIST  "grafana-piechart-panel"
 ENV ENABLE_AUTH_ANONYMOUS "true"

--- a/images/grafana/sut/Dockerfile
+++ b/images/grafana/sut/Dockerfile
@@ -1,4 +1,4 @@
-From appcelerator/alpine:3.5.2
+From appcelerator/alpine:3.6.0
 RUN apk --update add docker@community
 COPY ./test.sh /bin
 CMD ["/bin/test.sh"]

--- a/images/grafana/sut/test.sh
+++ b/images/grafana/sut/test.sh
@@ -28,7 +28,7 @@ r=0
 while [[ $r -lt 1 ]]; do
   ((i++))
   sleep 1
-  r=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/admin/stats 2>/dev/null | jq -r '.user_count')
+  r=$(curl -u $GRAFANA_USER:$GRAFANA_PASS $GRAFANA_HOST:3000/api/admin/stats 2>/dev/null | jq -r '.users')
   if [[ $i -gt 40 ]]; then break; fi
 done
 if [[ $r -lt 1 ]]; then

--- a/images/kibana/Dockerfile
+++ b/images/kibana/Dockerfile
@@ -3,8 +3,8 @@ FROM appcelerator/alpine:3.6.0
 RUN apk --no-cache add nodejs freetype-dev fontconfig-dev
 
 # Kibana installation
-ENV KIBANA_MAJOR 5.5
-ENV KIBANA_VERSION 5.5.0
+ENV KIBANA_MAJOR 5.6
+ENV KIBANA_VERSION 5.6.3
 RUN mkdir -p /opt/kibana && adduser -D -h /opt/kibana -s /sbin/nologin elastico && rm -rf /opt/kibana
 RUN curl -LO https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz \
     && tar xzf /kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz -C /opt \

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM appcelerator/prometheus:1.7.1
+FROM appcelerator/prometheus:1.8.0
 
 COPY promctl.alpine /bin/promctl
 COPY config/prometheus.yml  /etc/prometheus/prometheus.yml

--- a/tests/cli/logs/logs_test.sh
+++ b/tests/cli/logs/logs_test.sh
@@ -33,7 +33,7 @@ test_logs_node() {
 }
 
 test_logs_number() {
-  amp -k logs -n 2 | wc -l | grep -q "2"
+  amp -k logs -i -n 2 | wc -l | grep -q "2"
 }
 
 test_logs_raw() {


### PR DESCRIPTION
- update grafana to 4.5.2
- update elasticsearch / grafana to 5.6.3
- update etcd to 3.2.9
- update prometheus to 1.8.0
- update node-exporter to 0.15.0
- update alertmanager to 0.9.1
- don't show ampagent logs in `amp logs`

## verification
```
make build-ampagent build-cli
amp cluster create
amp -k user signup
amp -k logs
# should be empty
amp -k stack deploy -c ./examples/stacks/pinger/pinger.yml
amp -k logs
# pinger logs
# connect to dashboard.local.appcelerator.io and make sure the dashboard are showing
```