### PR TITLE
stack events displayed by amp CLI / aws plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ build: build-base build-plugins buildall-cli
 # =============================================================================
 AMP := amp
 AMPTARGET := bin/$(GOOS)/$(GOARCH)/$(AMP)
-AMPDIRS := $(CMDDIR)/$(AMP) cli $(COMMONDIRS)
+PLUGINDIRS := cluster/plugin/aws/plugin cluster/plugin/local/plugin
+AMPDIRS := $(CMDDIR)/$(AMP) cli $(COMMONDIRS) $(PLUGINDIRS)
 AMPSRC := $(shell find $(AMPDIRS) -type f -name '*.go')
 AMPPKG := $(REPO)/$(CMDDIR)/$(AMP)
 

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/appcelerator/amp/cli"
@@ -227,6 +228,47 @@ type awsPlugin struct {
 	plugin
 }
 
+func decodeAwsPluginOutput(c cli.Interface, d *json.Decoder) error {
+	var po aws.PluginOutput
+	err := d.Decode(&po)
+	if err != nil {
+		return err
+	}
+	// if there's an event, that's the relevant information
+	if po.Event != nil {
+		e := po.Event
+		status := e.ResourceStatus
+		if e.ResourceStatusReason != "" {
+			status = fmt.Sprintf("%s (%s)", e.ResourceStatus, e.ResourceStatusReason)
+		}
+		c.Console().Printf("%-31s %-28s %s\n", e.Timestamp, e.LogicalResourceId, status)
+		if e.ResourceType == "AWS::CloudFormation::Stack" && (e.ResourceStatus == "ROLLBACK_COMPLETE" || e.ResourceStatus == "DELETE_COMPLETE") {
+			return fmt.Errorf("Deployment failed")
+		}
+		// the caller should loop on the reader
+		return nil
+	}
+	// next, look for an output
+	if po.Output != nil {
+		c.Console().Printf("-------------------------------------------------------------------------------\n")
+		m := po.Output
+		for _, o := range m {
+			c.Console().Printf("%-42s | %s\n", o.Description, o.OutputValue)
+		}
+		return nil
+	}
+	// last, look for an error
+	if po.Error != "" {
+		c.Console().Printf("Error: %s\n", po.Error)
+		if strings.Contains(po.Error, "Throttling: Rate exceeded") == true {
+			// we shouldn't stop
+			return nil
+		}
+		return fmt.Errorf("Deployment failed, see error details above")
+	}
+	return nil
+}
+
 func (p *awsPlugin) Run(c cli.Interface, args []string, env map[string]string) error {
 	home, err := homedir.Dir()
 	if err != nil {
@@ -249,28 +291,25 @@ func (p *awsPlugin) Run(c cli.Interface, args []string, env map[string]string) e
 	f := func(r io.Reader, done chan bool) {
 		d := json.NewDecoder(r)
 		for {
-			var m aws.StackOutputList
-			if err := d.Decode(&m); err == io.EOF {
+			err = decodeAwsPluginOutput(c, d)
+			if err == io.EOF {
 				done <- true
 				break
 			} else if err != nil {
-				// If there is an error here, it is because the plugin itself is not returning
-				// json for plugin errors (yet) ... so print the buffer for now
+				done <- true
+				fmt.Println(err)
+				// If there is an error here, it is because the plugin itself
+				// failed to return json for plugin errors
+				// so print the buffer for now
 				outscanner := bufio.NewScanner(d.Buffered())
 				for outscanner.Scan() {
 					c.Console().Println(outscanner.Text())
 				}
-
-				done <- true
-				// Still indicate that this was an error because non-JSON responses need to be fixed
-				c.Console().Error(err)
+				c.Console().Error(err) // these errors need to be fixed
 				return
 			}
-			// print the decoded output
-			for _, o := range m.Output {
-				c.Console().Printf("%s: %s\n", o.Description, o.OutputValue)
-			}
 		}
+		return
 	}
 
 	img := fmt.Sprintf("appcelerator/amp-aws:%s", c.Version())

--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/appcelerator/amp/cluster/plugin/aws/plugin"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/spf13/cobra"
@@ -26,6 +29,12 @@ var (
 	svc  *cf.CloudFormation
 )
 
+const (
+	STACK_MODE_CREATE = "create"
+	STACK_MODE_DELETE = "delete"
+	STACK_MODE_UPDATE = "update"
+)
+
 func version(cmd *cobra.Command, args []string) {
 	fmt.Printf("Version: %s - Build: %s\n", Version, Build)
 }
@@ -37,27 +46,109 @@ func initClient(cmd *cobra.Command, args []string) {
 	svc = cf.New(sess, aws.NewConfig().WithRegion(opts.Region).WithLogLevel(aws.LogOff))
 }
 
+// used by the create function to parse the events and send meaningful information to the CLI
+func scanEvents(mode string) error {
+	var emptyReason string
+	significantEventTypes := map[string]bool{"AWS::CloudFormation::Stack": true, "AWS::EC2::VPC": true, "AWS::CloudFormation::WaitCondition": true, "AWS::AutoScaling::AutoScalingGroup": true}
+	significantEventStatuses := map[string]bool{"CREATE_IN_PROGRESS": false, "CREATE_COMPLETE": true, "CREATE_FAILED": true, "ROLLBACK_IN_PROGRESS": true, "ROLLBACK_COMPLETE": true, "DELETE_IN_PROGRESS": true}
+	eventInput := &cf.DescribeStackEventsInput{
+		StackName: aws.String(opts.StackName),
+		NextToken: nil,
+	}
+	eventIds := map[string]bool{}
+	for {
+		//resp, err := svc.DescribeStackEventsWithContext(ctx, eventInput, nil)
+		resp, err := svc.DescribeStackEvents(eventInput)
+		if err != nil {
+			if strings.Contains(err.Error(), "Throttling: Rate exceeded") == true {
+				// ignore it, and continue processing the events
+				time.Sleep(time.Second)
+				continue
+			}
+			return err
+		}
+		events := resp.StackEvents
+		sort.Slice(events, func(i, j int) bool { return events[i].Timestamp.Unix() < events[j].Timestamp.Unix() })
+		for _, se := range events {
+			if eventIds[*se.EventId] == true {
+				// already processed, ignore it
+				continue
+			}
+			eventIds[*se.EventId] = true
+
+			// filtering: stack events and creation / deletion of a few types
+			if *se.ResourceType == "AWS::CloudFormation::Stack" ||
+				(significantEventTypes[*se.ResourceType] == true && significantEventStatuses[*se.ResourceStatus] == true) {
+				if se.ResourceStatusReason == nil {
+					// we'll have an indirection, so better secure it
+					se.ResourceStatusReason = &emptyReason
+				}
+				eventOutput := plugin.StackEvent{EventId: *se.EventId, LogicalResourceId: *se.LogicalResourceId, ResourceStatus: *se.ResourceStatus, ResourceStatusReason: *se.ResourceStatusReason, ResourceType: *se.ResourceType, Timestamp: se.Timestamp.Format(time.UnixDate)}
+				j, err := plugin.PluginOutputToJSON(&eventOutput, nil, nil)
+				if err != nil {
+					return err
+				}
+				fmt.Println(j)
+			}
+			// check end condition, based on the action
+			switch mode {
+			case STACK_MODE_CREATE:
+				if *se.ResourceType == "AWS::CloudFormation::Stack" &&
+					(*se.ResourceStatus == "CREATE_COMPLETE" || *se.ResourceStatus == "DELETE_COMPLETE" || *se.ResourceStatus == "ROLLBACK_COMPLETE") {
+					return nil
+				}
+			case STACK_MODE_DELETE:
+				if *se.ResourceType == "AWS::CloudFormation::Stack" &&
+					(*se.ResourceStatus == "DELETE_FAILED" || *se.ResourceStatus == "DELETE_COMPLETE") {
+					return nil
+				}
+			case STACK_MODE_UPDATE:
+				if *se.ResourceType == "AWS::CloudFormation::Stack" &&
+					(*se.ResourceStatus == "UPDATE_FAILED" || *se.ResourceStatus == "UPDATE_COMPLETE" || *se.ResourceStatus == "ROLLBACK_COMPLETE") {
+					// this is the end
+					return nil
+				}
+			default:
+				return fmt.Errorf("unknown mode: %s", mode)
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return nil
+}
+
 func create(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-
 	resp, err := plugin.CreateStack(ctx, svc, opts, 20)
 	if err != nil {
-		log.Fatal(err)
+		j, jerr := plugin.PluginOutputToJSON(nil, nil, err)
+		if jerr != nil {
+			log.Println(jerr.Error())
+			log.Fatal(err)
+		}
+		fmt.Println(j)
+		os.Exit(1)
 	}
 
 	if opts.Sync {
-		input := &cf.DescribeStacksInput{
-			StackName: aws.String(opts.StackName),
+		err := scanEvents(STACK_MODE_CREATE)
+		if err != nil {
+			j, jerr := plugin.PluginOutputToJSON(nil, nil, err)
+			if jerr != nil {
+				log.Println(jerr.Error())
+				log.Fatal(err)
+			}
+			fmt.Println(j)
+			os.Exit(1)
 		}
-		if err := svc.WaitUntilStackCreateCompleteWithContext(ctx, input); err != nil {
-			log.Fatal(err)
-		}
-		// use the info command to print json cluster info to stdout
 		info(cmd, args)
 	} else {
-		// only print to stdout if not sync; otherwise stdout is used to display json stack output information now
-		log.Printf("stack created: %s\n", opts.StackName)
-		log.Println(awsutil.StringValue(resp.StackId))
+		event := plugin.StackEvent{EventId: "NoSync-000", LogicalResourceId: opts.StackName, ResourceType: "AWS::CloudFormation:Stack", ResourceStatus: "CREATE_IN_PROGRESS", ResourceStatusReason: "The sync flag was not used, please check the status of the stack on the AWS console and read the output", Timestamp: time.Now().Format(time.UnixDate), StackId: *resp.StackId}
+		j, err := plugin.PluginOutputToJSON(&event, nil, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(j)
 	}
 }
 
@@ -68,16 +159,25 @@ func update(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	log.Println(awsutil.StringValue(resp))
-
-	input := &cf.DescribeStacksInput{
-		StackName: aws.String(opts.StackName),
-	}
 	if opts.Sync {
-		if err := svc.WaitUntilStackUpdateCompleteWithContext(ctx, input); err != nil {
+		err := scanEvents(STACK_MODE_UPDATE)
+		if err != nil {
+			j, jerr := plugin.PluginOutputToJSON(nil, nil, err)
+			if jerr != nil {
+				log.Println(jerr.Error())
+				log.Fatal(err)
+			}
+			fmt.Println(j)
+			os.Exit(1)
+		}
+		info(cmd, args)
+	} else {
+		event := plugin.StackEvent{EventId: "NoSync-000", LogicalResourceId: opts.StackName, ResourceType: "AWS::CloudFormation:Stack", ResourceStatus: "UPDATE_IN_PROGRESS", ResourceStatusReason: "The sync flag was not used, please check the status of the stack on the AWS console and read the output", Timestamp: time.Now().Format(time.UnixDate), StackId: *resp.StackId}
+		j, err := plugin.PluginOutputToJSON(&event, nil, nil)
+		if err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("stack updated: %s\n", opts.StackName)
+		fmt.Println(j)
 	}
 }
 
@@ -100,15 +200,18 @@ func delete(cmd *cobra.Command, args []string) {
 					log.Fatal(err)
 				}
 
-				input := &cf.DescribeStacksInput{
-					StackName: aws.String(opts.StackName),
-				}
 				if opts.Sync {
-					if err := svc.WaitUntilStackDeleteCompleteWithContext(ctx, input); err != nil {
-						log.Fatal(err)
+					err := scanEvents(STACK_MODE_DELETE)
+					if err != nil {
+						j, jerr := plugin.PluginOutputToJSON(nil, nil, err)
+						if jerr != nil {
+							log.Println(jerr.Error())
+							log.Fatal(err)
+						}
+						fmt.Println(j)
+						os.Exit(1)
 					}
 				}
-				log.Printf("stack deleted: %s\n", opts.StackName)
 				return
 			case cf.StackStatusDeleteInProgress:
 				log.Fatal("stack deletion already in progress")
@@ -118,7 +221,7 @@ func delete(cmd *cobra.Command, args []string) {
 		}
 	}
 	if flag {
-		log.Fatal(opts.StackName, " stack does not exist")
+		log.Fatal(opts.StackName, " stack doesn't seem to exist")
 	}
 }
 
@@ -126,16 +229,22 @@ func info(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 	resp, err := plugin.InfoStack(ctx, svc, opts)
 	if err != nil {
-		log.Fatal(err)
+		if j, jerr := plugin.PluginOutputToJSON(nil, nil, err); jerr != nil {
+			// print json error to stdout
+			fmt.Println(j)
+			os.Exit(1)
+		} else {
+			log.Fatal(err)
+		}
 	}
 
-	j, err := plugin.StackOutputToJSON(resp)
+	j, err := plugin.PluginOutputToJSON(nil, resp, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// print json result to stdout
-	fmt.Print(j)
+	fmt.Println(j)
 }
 
 func main() {

--- a/cluster/plugin/aws/plugin/plugin.go
+++ b/cluster/plugin/aws/plugin/plugin.go
@@ -188,9 +188,6 @@ func PluginOutputToJSON(ev *StackEvent, so []StackOutput, e error) (string, erro
 		Output: so,
 		Event:  ev,
 	}
-	//if ev != nil && ev.LogicalResourceId != "" {
-	//po.Event = *ev
-	//}
 	if e != nil {
 		po.Error = reg.ReplaceAllString(e.Error(), "")
 	}


### PR DESCRIPTION
- Fix #1662 
- stream stack events

The CLI and the aws plugin are now better integrated with a JSON output containing stack events, stack outputs and errors.
This is fully implemented in the `cluster create` command, but would need more ironing in the `cluster delete` command, which can be done in another PR.
The `cluster update` command is not working right now, so it's not possible to test it.
```
~/Development/src/github.com/appcelerator/amp(cli-logs ✗) amp cluster create --provider aws --aws-region us-west-2 --aws-stackname nde-test --aws-parameter KeyName=xxx --aws-parameter UserWorkerSize=1 --aws-sync
[user nicolas @ localhost:50101]
Tue Oct 24 21:54:40 UTC 2017    nde-test                     CREATE_IN_PROGRESS (User Initiated)
Tue Oct 24 21:55:04 UTC 2017    Vpc                          CREATE_COMPLETE
Tue Oct 24 21:57:20 UTC 2017    ManagerAutoScalingGroup      CREATE_COMPLETE
Tue Oct 24 21:58:41 UTC 2017    ManagerWaitCondition         CREATE_COMPLETE
Tue Oct 24 21:58:47 UTC 2017    UserWorkerAutoScalingGroup   CREATE_COMPLETE
Tue Oct 24 21:58:58 UTC 2017    CoreWorkerAutoScalingGroup   CREATE_COMPLETE
Tue Oct 24 21:59:29 UTC 2017    UserWaitCondition            CREATE_COMPLETE
Tue Oct 24 22:00:20 UTC 2017    CoreWaitCondition            CREATE_COMPLETE
Tue Oct 24 22:01:42 UTC 2017    ApplicationWaitCondition     CREATE_COMPLETE
Tue Oct 24 22:01:47 UTC 2017    nde-test                     CREATE_COMPLETE
-------------------------------------------------------------------------------
VPC ID                                     | vpc-41510a27
URL for cluster health dashboard           | nde-test-ManagerEx-1M0JMQ7O8K4B4-1367928177.us-west-2.elb.amazonaws.com:8080
internal endpoint for the registry service |
public facing endpoint for the cluster     | nde-test-ManagerEx-1M0JMQ7O8K4B4-1367928177.us-west-2.elb.amazonaws.com
~/Development/src/github.com/appcelerator/amp(cli-logs ✗) amp cluster destroy --provider aws --aws-region us-west-2 --aws-stackname nde-test --aws-sync
[user nicolas @ localhost:50101]
Tue Oct 24 21:55:04 UTC 2017    Vpc                          CREATE_COMPLETE
Tue Oct 24 21:57:20 UTC 2017    ManagerAutoScalingGroup      CREATE_COMPLETE
Tue Oct 24 21:58:41 UTC 2017    ManagerWaitCondition         CREATE_COMPLETE
Tue Oct 24 21:58:47 UTC 2017    UserWorkerAutoScalingGroup   CREATE_COMPLETE
Tue Oct 24 21:58:58 UTC 2017    CoreWorkerAutoScalingGroup   CREATE_COMPLETE
Tue Oct 24 21:59:29 UTC 2017    UserWaitCondition            CREATE_COMPLETE
Tue Oct 24 22:00:20 UTC 2017    CoreWaitCondition            CREATE_COMPLETE
Tue Oct 24 22:01:42 UTC 2017    ApplicationWaitCondition     CREATE_COMPLETE
Tue Oct 24 22:01:47 UTC 2017    nde-test                     CREATE_COMPLETE
Tue Oct 24 22:02:31 UTC 2017    nde-test                     DELETE_IN_PROGRESS (User Initiated)
Tue Oct 24 22:02:34 UTC 2017    ApplicationWaitCondition     DELETE_IN_PROGRESS
Tue Oct 24 22:02:36 UTC 2017    CoreWaitCondition            DELETE_IN_PROGRESS
Tue Oct 24 22:02:36 UTC 2017    UserWaitCondition            DELETE_IN_PROGRESS
Tue Oct 24 22:02:37 UTC 2017    CoreWorkerAutoScalingGroup   DELETE_IN_PROGRESS
Tue Oct 24 22:02:38 UTC 2017    UserWorkerAutoScalingGroup   DELETE_IN_PROGRESS
Tue Oct 24 22:04:28 UTC 2017    ManagerWaitCondition         DELETE_IN_PROGRESS
Tue Oct 24 22:04:29 UTC 2017    ManagerAutoScalingGroup      DELETE_IN_PROGRESS
Tue Oct 24 22:10:53 UTC 2017    Vpc                          DELETE_IN_PROGRESS
Error: ValidationError: Stack ndetest does not existstatus code: 400, request id: 3dcbc254b90811e783bf2703644f0874
Deployment failed, see error details above

Error: Deployment failed, see error details aboveError: exit status 1
```