### PR TITLE
Remove build public key from AMI

### DIFF
--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-7ea06904
+      Default: ami-2167c25b
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-5d785438
+      Default: ami-7db59918
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-e2d6109a
+      Default: ami-dbac63a3
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-2a68bb53
+      Default: ami-1be63c62
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-1438da76
+      Default: ami-a242aec0
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -187,12 +187,6 @@ Parameters:
     Type: String
     Description: Docker overlay networks to create on the swarm, separated by space
     Default: ampnet
-  DockerChannel:
-    Type: String
-    Default: stable
-    AllowedValues:
-    - stable
-    - edge
   DockerPlugins:
     Type: String
     Description: "space separated list of plugins to install. Options can be passed separated with pound sign. Example: rexray/ebs#REXRAY_PREEMPT=true"
@@ -989,7 +983,7 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
+                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
             - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
 
   UserWaitHandle:
@@ -1075,7 +1069,7 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL=${DockerChannel} PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
+                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
             - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
 
   ApplicationWaitHandle:
@@ -1178,7 +1172,7 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/userdata-aws-manager && chmod +x /usr/local/bin/userdata-aws-manager || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="${DockerChannel}" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" LABELS="amp.type.api=true amp.type.route=true amp.type.metrics=true" /usr/local/bin/userdata-aws-manager || shutdown -h
+                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="stable" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" LABELS="amp.type.api=true amp.type.route=true amp.type.metrics=true" /usr/local/bin/userdata-aws-manager || shutdown -h
             - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], ApplicationSignalURL: !If [ InstallApplicationCond, !Ref ApplicationWaitHandle, "" ] }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
@@ -1284,7 +1278,6 @@ Metadata:
     - Label:
         default: Docker Configuration
       Parameters:
-      - DockerChannel
       - DockerPlugins
       - AufsVolumeSize
       - OverlayNetworks
@@ -1313,8 +1306,6 @@ Metadata:
         default: Drain manager nodes?
       OverlayNetworks:
         default: Docker overlay networks
-      DockerChannel:
-        default: Docker channel
       DockerPlugins:
         default: Docker plugins
       ConfigurationURL:

--- a/examples/clusters/build-ami.sh
+++ b/examples/clusters/build-ami.sh
@@ -2,7 +2,7 @@
 DIR="$(dirname $0)"
 cd "$DIR"
 DIR="$(pwd -P)"
-image="appcelerator/ansible:2.3"
+image="appcelerator/ansible:2.4"
 REGIONS="us-east-1 us-east-2 us-west-2 eu-west-1 ap-southeast-2"
 OWNER=654814900965
 IMAGE_NAME=ubuntu-xenial-docker

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
-## Docker Channel
-# stable: use "https://get.docker.com"
-# edge: use "https://test.docker.com"
+## Docker Channel: stable, edge, test, experimental
+docker_channel: "stable"
 docker_url: "https://get.docker.com"
 
 ## AWS Region where the build should be done
@@ -23,8 +22,8 @@ ec2_instance_type: "t2.small"
 iam_instance_profile: "amp-image-builder-role"
 
 ## Source AMI
-# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170919 in oregon
-ec2_ami: "ami-ecc63a94"
+# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171011 in oregon
+ec2_ami: "ami-19e92861"
 
 ## Security Group
 # should open port 80 (and optionally port 22 for debugging)

--- a/examples/clusters/roles/ami/tasks/main.yml
+++ b/examples/clusters/roles/ami/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- include: set-constants.yml
-- include: upload-userdata.yml
-- include: run-instance.yml
-- include: wait-for-instance.yml
-- include: snapshot-volume.yml
-#- include: set-volumes.yml
-- include: register-ami.yml
-- include: copy-ami.yml
-- include: terminate-instance.yml
+- import_tasks: set-constants.yml
+- import_tasks: upload-userdata.yml
+- import_tasks: run-instance.yml
+- import_tasks: wait-for-instance.yml
+- import_tasks: snapshot-volume.yml
+#- import_tasks: set-volumes.yml
+- import_tasks: register-ami.yml
+- import_tasks: copy-ami.yml
+- import_tasks: terminate-instance.yml

--- a/examples/clusters/roles/ami/tasks/terminate-instance.yml
+++ b/examples/clusters/roles/ami/tasks/terminate-instance.yml
@@ -6,12 +6,12 @@
     instance_ids: "{{ ec2_instance.instance_ids }}"
 
 - name: Cleanup managers userdata
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "scripts/userdata-aws-manager"
     mode: delobj
 - name: Cleanup workers userdata
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "scripts/userdata-aws-worker"
     mode: delobj

--- a/examples/clusters/roles/ami/tasks/upload-userdata.yml
+++ b/examples/clusters/roles/ami/tasks/upload-userdata.yml
@@ -1,18 +1,18 @@
 ---
 - name: Upload managers userdata
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "scripts/userdata-aws-manager"
     src: userdata-aws-manager
     mode: put
 - name: Upload workers userdata
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "scripts/userdata-aws-worker"
     src: userdata-aws-worker
     mode: put
 - name: Upload registry userdata
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "scripts/userdata-aws-registry"
     src: userdata-aws-registry

--- a/examples/clusters/roles/ami/templates/userdata.j2
+++ b/examples/clusters/roles/ami/templates/userdata.j2
@@ -31,7 +31,7 @@ runcmd:
   - curl -sSf 'https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz' | tar xzf -
   - (cd aws-cfn-bootstrap-* && python setup.py install) || _ko 
   - rm -rf aws-cfn-bootstrap-*
-  - wget -qO- "{{docker_url}}" | sh || _ko
+  - export CHANNEL="{{docker_channel}}" ; wget -qO- "{{docker_url}}" | sh || _ko
   - if [ "x$_release" = "xUbuntu" ]; then usermod -G docker ubuntu 2>/dev/null ; fi
   - if [ "x$_release" = "xDebian" ]; then usermod -G docker admin  2>/dev/null ; fi
   - echo "vm.max_map_count = 262144" > "/etc/sysctl.d/99-amp.conf" # prerequisite for elasticsearch
@@ -39,4 +39,6 @@ runcmd:
   - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-worker" /usr/local/bin/userdata-aws-worker || _ko
   - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-registry" /usr/local/bin/userdata-aws-registry || _ko
   - chmod u+x /usr/local/bin/userdata-aws-worker /usr/local/bin/userdata-aws-manager /usr/local/bin/userdata-aws-registry
+  - echo "" > ~ubuntu/.ssh/authorized_keys
+  - shred -u ~/.*history
   - _ok

--- a/images/ansible/Dockerfile
+++ b/images/ansible/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@edgetesting http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
-RUN apk --update add ca-certificates sudo ansible@edge py-boto@edge py-boto3@edgetesting && \
+RUN apk --update add ca-certificates sudo ansible@edge py2-ansible-lint@edgetesting py-boto@edge py2-boto3@edgetesting py2-futures@edgetesting py2-s3transfer@edgetesting py2-botocore@edgetesting && \
     rm -rf /var/cache/apk/*
 
 CMD [ "ansible-playbook", "--version" ]


### PR DESCRIPTION
- Fix #1663 (clean up authorized_keys)
- Remove obsolete parameter (DockerChannel)
- AMI build is now forcing the stable channel for docker installation

CloudFormation template is already pushed on s3.

## How to test

Deploy the cloudformation template from the AWS console, by uploading the local template.
Once the cluster is deployed, check the dashboards (URL in the stack output) to verify that you have the expected number of node, all running on Docker 17.09. SSH to one instance and check that the authorized keys of the ubuntu user only contains your public key.