### PR TITLE
NFS endpoint

### DIFF
--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -54,6 +54,7 @@ func scanEvents(mode string) error {
 		"AWS::EC2::VPC":                      true,
 		"AWS::CloudFormation::WaitCondition": true,
 		"AWS::AutoScaling::AutoScalingGroup": true,
+		"AWS::EFS::FileSystem":               true,
 	}
 	significantEventStatuses := map[string]bool{
 		cf.StackStatusCreateInProgress:   false,

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -209,6 +209,13 @@ Parameters:
     - no
     - yes
     Default: no
+  NFSEndpoint:
+    Type: String
+    Description: If yes, a NFSv4 service will be provided
+    AllowedValues:
+    - no
+    - yes
+    Default: no
   EnableSystemPrune:
     Type: String
     Description: "Cleans up unused images, containers, networks and volumes"
@@ -227,6 +234,7 @@ Conditions:
   InstallApplicationCond: !Or [ !Equals [ !Ref InstallApplication, "yes" ], !Equals [ !Ref InstallApplication, "true" ] ]
   EnableSystemPruneCond:  !Or [ !Equals [ !Ref EnableSystemPrune, "yes" ], !Equals [ !Ref EnableSystemPrune, "true" ] ]
   MirrorRegistryCond:     !Or [ !Equals [ !Ref MirrorRegistry, "yes" ], !Equals [ !Ref MirrorRegistry, "true" ] ]
+  NFSEndpointCond:     !Or [ !Equals [ !Ref NFSEndpoint, "yes" ], !Equals [ !Ref NFSEndpoint, "true" ] ]
 
 Resources:
   Vpc:
@@ -1250,6 +1258,59 @@ Resources:
         Enabled: 'true'
         Timeout: '60'
 
+  SharedFileSystem:
+    Type: AWS::EFS::FileSystem
+    Condition: NFSEndpointCond
+    Properties:
+      PerformanceMode: generalPurpose
+      FileSystemTags:
+      - Key: "Name"
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::AccountId
+            - Ref: AWS::StackName
+            - FS
+  FSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: NFSEndpointCond
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: "Security group for EFS mount target"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '2049'
+          ToPort: '2049'
+          CidrIp:
+            Fn::FindInMap:
+            - VpcCidrs
+            - vpc
+            - cidr
+  MountTarget1:
+    Type: AWS::EFS::MountTarget
+    Condition: NFSEndpointCond
+    Properties:
+      FileSystemId: !Ref SharedFileSystem
+      SubnetId: !Ref PublicSubnet1
+      SecurityGroups:
+        - Ref: FSSecurityGroup
+  MountTarget2:
+    Type: AWS::EFS::MountTarget
+    Condition: NFSEndpointCond
+    Properties:
+      FileSystemId: !Ref SharedFileSystem
+      SubnetId: !Ref PublicSubnet2
+      SecurityGroups:
+        - Ref: FSSecurityGroup
+  MountTarget3:
+    Type: AWS::EFS::MountTarget
+    Condition: NFSEndpointCond
+    Properties:
+      FileSystemId: !Ref SharedFileSystem
+      SubnetId: !Ref PublicSubnet3
+      SecurityGroups:
+        - Ref: FSSecurityGroup
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -1260,6 +1321,7 @@ Metadata:
       - LinuxDistribution
       - ConfigurationURL
       - MonitoringPort
+      - NFSEndpoint
     - Label:
         default: Registry Properties
       Parameters:
@@ -1322,6 +1384,8 @@ Metadata:
         default: Enable System Prune
       MirrorRegistry:
         default: Dedicated Registry
+      NFSEndpoint:
+        default: Shared File System
       RegistryInstanceType:
         default: Registry instance type?
       MonitoringPort:
@@ -1333,7 +1397,7 @@ Outputs:
     Value: !GetAtt ManagerExternalELB.DNSName
   InternalRegistryTarget:
     Description: internal endpoint for the registry service
-    Value: !If [ MirrorRegistryCond, !GetAtt RegistryInternalELB.DNSName, "" ]
+    Value: !If [ MirrorRegistryCond, !GetAtt RegistryInternalELB.DNSName, "disabled" ]
   MetricsURL:
     Description: URL for cluster health dashboard
     Value:
@@ -1344,3 +1408,10 @@ Outputs:
   VpcId:
     Description: VPC ID
     Value: !Ref Vpc
+  NFSEndpoint:
+    Description: NFSv4 Endpoint
+    Value:
+      Fn::If:
+      - NFSEndpointCond
+      - !Join [ '.', [ !Ref SharedFileSystem, efs, !Ref 'AWS::Region', 'amazonaws.com' ]]
+      - 'disabled'

--- a/examples/stacks/nfs/README.md
+++ b/examples/stacks/nfs/README.md
@@ -1,0 +1,28 @@
+NFS client
+==========
+
+http server mounting a NFS share, and serving the same files across the replicas.
+
+Get the URL of your NFS server. If it's the one deployed with the AMP cluster, you have it in the outputs of the stack.
+
+    $ export NFS_SERVER=fs-12345678.efs.us-west-2.amazonaws.com
+    $ amp stack deploy -c ./nfs.yml
+
+Optionally you can verify that the NFS endpoint has been correctly set on the service
+
+    $ amp service inspect nfs_client | jq '.Spec.TaskTemplate.ContainerSpec.Mounts[0].VolumeOptions.DriverConfig.Options.o'
+
+You can log in one of the containers, add a file in /html/:
+
+    $ echo "nfs works!" > /html/nfs.html
+
+The app will be available at [http://nfs.examples.local.appcelerator.io/nfs.html](http://nfs.examples.local.appcelerator.io/nfs.html)
+
+Test with
+
+    $ curl -i http://nfs.examples.local.appcelerator.io/nfs.html
+
+or open it in a browser.
+Repeating it will distribute the request on the replicas (the Server header is the container ID). The body should be the same, since the file is shared on the NFS server.
+
+You can replace the Docker image in the stack file by the official `nginx` image, however you'll have to modify the docroot from `/html` to `/usr/share/nginx/html`, and you'll lose the Server header reflecting the container hostname.

--- a/examples/stacks/nfs/nfs.yml
+++ b/examples/stacks/nfs/nfs.yml
@@ -1,0 +1,35 @@
+version: "3.2"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+services:
+  client:
+    #image: nginx
+    image: ndegory/nginx-prometheus:latest
+    networks:
+      - default
+    environment:
+      SERVICE_PORTS: "80"
+      VIRTUAL_HOST: "nfs.examples.*,https://nfs.examples.*"
+    volumes:
+      - type: volume
+        source: nfs_export
+        #target: /usr/share/nginx/html
+        target: /html
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints: [node.labels.amp.type.user == true]
+
+volumes:
+  nfs_export:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/
+      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2


### PR DESCRIPTION
- new option in the cloudformation template for an EFS filesystem. It's then available to the full VPC and can be mounted directly by a container
- sample stack with a nginx container mounting the EFS FS and sharing the files on the replicas

## How to test
```
$ amp cluster create --provider aws --aws-region us-west-2 --aws-stackname nde-efs --aws-parameter KeyName=xxx --aws-parameter UserWorkerSize=2 --aws-parameter CoreWorkerSize=1 --aws-parameter ManagerSize=1 --aws-parameter NFSEndpoint=true --aws-sync
# take note of the output of the stack, in particular the DNSTarget and the NFSEndpoint
# update your /etc/hosts or update your dns so that you have an alias to DNSTarget (you should have something like youralias.yourdomain and youralias.nfs.examples.youralias.yourdomain resolving to DNSTarget)
# cat examples/stacks/nfs/README.md
# follow the instructions in the readme to try the sample
```
