### PR TITLE
amp cluster rm doesn't error on successful removal

### DIFF
--- a/cluster/plugin/aws/plugin/plugin.go
+++ b/cluster/plugin/aws/plugin/plugin.go
@@ -179,7 +179,7 @@ func DeleteStack(ctx context.Context, svc *cf.CloudFormation, opts *RequestOptio
 // PluginOutputToJSON is a helper function that wrap an event, an error or a slice of StackOutput
 // to a JSON string representation of PluginOutput
 func PluginOutputToJSON(ev *StackEvent, so []StackOutput, e error) (string, error) {
-	reg, err := regexp.Compile("[^a-zA-Z0-9:;,. ]+")
+	reg, err := regexp.Compile("[^a-zA-Z0-9:;,.\\-()\\[\\]'\" ]+")
 	if err != nil {
 		return "", err
 	}
@@ -189,7 +189,7 @@ func PluginOutputToJSON(ev *StackEvent, so []StackOutput, e error) (string, erro
 		Event:  ev,
 	}
 	if e != nil {
-		po.Error = reg.ReplaceAllString(e.Error(), "")
+		po.Error = reg.ReplaceAllString(e.Error(), "%")
 	}
 	j, err := json.Marshal(po)
 	if err != nil {


### PR DESCRIPTION
Fix #1740 

## Verification
```
$ amp cluster create --provider aws --aws-region us-west-2 --aws-stackname STACK_NAME --aws-parameter KeyName=KEY_NAME --aws-parameter UserWorkerSize=1 --aws-parameter CoreWorkerSize=1 --aws-parameter ManagerSize=1  --aws-sync
[...]
$ amp cluster destroy --provider aws --aws-region us-west-2 --aws-stackname STACK_NAME --aws-sync
[user xxx @ localhost:50101]
Mon Oct 30 22:45:49 UTC 2017    STACK_NAME           CREATE_IN_PROGRESS (User Initiated)
Mon Oct 30 22:45:55 UTC 2017    STACK_NAME           DELETE_IN_PROGRESS (User Initiated)
Mon Oct 30 22:45:56 UTC 2017    Vpc                  CREATE_FAILED (Resource creation cancelled)
Mon Oct 30 22:46:15 UTC 2017    Vpc                  DELETE_IN_PROGRESS
Mon Oct 30 22:46:52 UTC 2017    STACK_NAME           DELETE_COMPLETE
$ echo $?
0
```