### PR TITLE
Node management - run infrakit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ $(AMPAGENTTARGET): $(PROTOTARGETS) $(AMPAGENTSRC) VERSION
 
 build-ampagent: $(AMPAGENTTARGET)
 	@echo "build $(AMPAGENTIMG)"
-	@$(DOCKER_CMD) build -t $(AMPAGENTIMG) $(AMPAGENTDIR) || (rm -f $(AMPAGENTTARGET); exit 1)
+	@$(DOCKER_CMD) build --no-cache -t $(AMPAGENTIMG) $(AMPAGENTDIR) || (rm -f $(AMPAGENTTARGET); exit 1)
 
 rebuild-ampagent: clean-ampagent build-ampagent
 

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -30,6 +30,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.Bool("local-no-logs", false, "Don't deploy logs stack")
 	flags.Bool("local-no-metrics", false, "Don't deploy metrics stack")
 	flags.Bool("local-no-proxy", false, "Don't deploy proxy stack")
+	flags.Bool("local-no-node-management", true, "Don't deploy node management services")
 
 	// aws options
 	flags.String("aws-onfailure", "", "'DO_NOTHING', 'ROLLBACK' (default), or 'DELETE")

--- a/cluster/ampagent/cmd/install.go
+++ b/cluster/ampagent/cmd/install.go
@@ -29,9 +29,10 @@ const (
 )
 
 type InstallOptions struct {
-	NoLogs    bool
-	NoMetrics bool
-	NoProxy   bool
+	NoLogs           bool
+	NoMetrics        bool
+	NoProxy          bool
+	NoNodeManagement bool
 }
 
 var InstallOpts = &InstallOptions{}
@@ -92,7 +93,8 @@ func Install(cmd *cobra.Command, args []string) error {
 	for _, stackFile := range stackFiles {
 		if strings.Contains(stackFile, "logs") && InstallOpts.NoLogs ||
 			strings.Contains(stackFile, "metrics") && InstallOpts.NoMetrics ||
-			strings.Contains(stackFile, "proxy") && InstallOpts.NoProxy {
+			strings.Contains(stackFile, "proxy") && InstallOpts.NoProxy ||
+			strings.Contains(stackFile, "nodemngt") && InstallOpts.NoNodeManagement {
 			continue
 		}
 		log.Println("Deploying stack", stackFile)

--- a/cluster/ampagent/main.go
+++ b/cluster/ampagent/main.go
@@ -38,6 +38,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoLogs, "no-logs", false, "Don't deploy logs stack")
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoMetrics, "no-metrics", false, "Don't deploy metrics stack")
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoProxy, "no-proxy", false, "Don't deploy proxy stack")
+	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoNodeManagement, "no-node-management", false, "Don't deploy node management stack")
 
 	// Environment variables
 	if os.Getenv("TAG") == "" { // If TAG is undefined, use the current project version

--- a/cluster/ampagent/stacks/cluster/05-nodemngt.yml
+++ b/cluster/ampagent/stacks/cluster/05-nodemngt.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  infrakit-config:
+
+services:
+
+  infrakit:
+    image: appcelerator/infrakit:latest
+    networks:
+      - default
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.role == manager
+    environment:
+      INFRAKIT_LOG_LEVEL: 4
+      INFRAKIT_AWS_NAMESPACE_TAGS: "infrakit.scope=${STACK_NAME:-undefined}"
+      INFRAKIT_AWS_STACKNAME: "${STACK_NAME:-undefined}"
+      INFRAKIT_MANAGER_BACKEND: "swarm"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - infrakit-config:/infrakit
+    labels:
+      io.amp.role: "infrastructure"
+    ports:
+      - "24864:24864"

--- a/cluster/ampagent/stacks/single/05-nodemngt.yml
+++ b/cluster/ampagent/stacks/single/05-nodemngt.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+networks:
+  default:
+    external:
+      name: ampnet
+
+volumes:
+  infrakit-config:
+
+services:
+
+  infrakit:
+    image: appcelerator/infrakit:latest
+    networks:
+      - default
+    deploy:
+      mode: global
+      labels:
+        io.amp.role: "infrastructure"
+      placement:
+        constraints:
+        - node.role == manager
+    environment:
+      INFRAKIT_LOG_LEVEL: 4
+      INFRAKIT_AWS_NAMESPACE_TAGS: "infrakit.scope=${STACK_NAME:-undefined}"
+      INFRAKIT_AWS_STACKNAME: "${STACK_NAME:-undefined}"
+      INFRAKIT_MANAGER_BACKEND: "swarm"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - infrakit-config:/infrakit
+    labels:
+      io.amp.role: "infrastructure"
+    ports:
+      - "24864:24864"

--- a/cluster/plugin/local/main.go
+++ b/cluster/plugin/local/main.go
@@ -124,6 +124,7 @@ func main() {
 	initCmd.PersistentFlags().BoolVar(&opts.NoLogs, "no-logs", false, "Don't deploy logs stack")
 	initCmd.PersistentFlags().BoolVar(&opts.NoMetrics, "no-metrics", false, "Don't deploy metrics stack")
 	initCmd.PersistentFlags().BoolVar(&opts.NoProxy, "no-proxy", false, "Don't deploy proxy stack")
+	initCmd.PersistentFlags().BoolVar(&opts.NoNodeManagement, "no-node-management", true, "Don't deploy node management stack")
 
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/cluster/plugin/local/plugin/plugin.go
+++ b/cluster/plugin/local/plugin/plugin.go
@@ -37,13 +37,14 @@ type RequestOptions struct {
 	// Node labels
 	Labels map[string]string
 	// Tag of the ampagent image
-	Tag           string
-	Registration  string
-	Notifications bool
-	ForceLeave    bool
-	NoLogs        bool
-	NoMetrics     bool
-	NoProxy       bool
+	Tag              string
+	Registration     string
+	Notifications    bool
+	ForceLeave       bool
+	NoLogs           bool
+	NoMetrics        bool
+	NoProxy          bool
+	NoNodeManagement bool
 }
 
 type FullSwarmInfo struct {
@@ -139,6 +140,9 @@ func RunAgent(ctx context.Context, c *docker.Client, action string, opts *Reques
 	}
 	if opts.NoProxy {
 		actionArgs = append(actionArgs, "--no-proxy")
+	}
+	if opts.NoNodeManagement {
+		actionArgs = append(actionArgs, "--no-node-management")
 	}
 	switch action {
 	case "install":

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -751,6 +751,9 @@ Resources:
           - 'ec2:DeleteNetworkInterface'
           - 'elasticfilesystem:DescribeFileSystems'
           - 'elasticfilesystem:DescribeMountTargets'
+            # next two lines for aws metadata plugin
+          - 'cloudformation:DescribeStacks'
+          - 'cloudformation:DescribeStackResources'
           Resource: '*'
           Effect: Allow
         Version: '2012-10-17'

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -494,6 +494,11 @@ Resources:
         IpProtocol: udp
         FromPort: '4789'
         ToPort: '4789'
+      # infrakit mux server
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '24864'
+        ToPort: '24864'
       # node exporter
       - SourceSecurityGroupId:
           !Ref MetricsSecurityGroup
@@ -1242,6 +1247,10 @@ Resources:
         InstanceProtocol: TCP
       - LoadBalancerPort: '9090'
         InstancePort: '9090'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '24864'
+        InstancePort: '24864'
         Protocol: TCP
         InstanceProtocol: TCP
       - LoadBalancerPort: '50101'

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-2167c25b
+      Default: ami-e5349f9f
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-7db59918
+      Default: ami-750d2210
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-dbac63a3
+      Default: ami-894982f1
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-1be63c62
+      Default: ami-b8d171c1
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-a242aec0
+      Default: ami-f33fd191
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -22,8 +22,8 @@ ec2_instance_type: "t2.small"
 iam_instance_profile: "amp-image-builder-role"
 
 ## Source AMI
-# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171011 in oregon
-ec2_ami: "ami-19e92861"
+# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171026.1 in oregon
+ec2_ami: "ami-0a00ce72"
 
 ## Security Group
 # should open port 80 (and optionally port 22 for debugging)

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -469,7 +469,7 @@ _wait_for_full_swarm() {
 }
 
 _setup() {
-  docker run --rm -v /var/run/docker:/var/run/docker -v /var/run/docker.sock:/var/run/docker.sock appcelerator/ampagent:${AMPAGENT_VERSION}
+  docker run --rm -e VPC_ID="${VPC_ID}" -e STACK_NAME="${STACK_NAME}" -v /var/run/docker:/var/run/docker -v /var/run/docker.sock:/var/run/docker.sock appcelerator/ampagent:${AMPAGENT_VERSION}
 }
 
 _sanity_check || exit 1

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -214,16 +214,24 @@ _get_worker_join_token(){
 _swarm_join(){
   local _manager=$1
   local _token
-  _token=$(_get_worker_join_token "$_manager") || return 1
+  if [[ -n "$_manager" ]]; then
+    _token=$(_get_worker_join_token "$_manager") || return 1
+  else
+    # infrakit mode
+    _manager="{{ SPEC.SwarmJoinIP }}"
+    _token="{{ SWARM_JOIN_TOKENS.Worker }}"
+  fi
   echo "joining the Swarm" >&2
-  docker swarm join --token "$_token" "$_manager:2377"
+  docker swarm join --token "$_token" "${_manager}:2377"
 }
 
 # add labels on the Swarm node
+# TODO: should be done by InfraKit, not by the node itself
 _label_node(){
   local _manager=$1
   local _self
   local _publicip
+  [[ -z "$_manager" ]] && return 0
   _self=$(docker info -f '{{.Swarm.NodeID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
   echo "applying label PublicIP=$_publicip" >&2

--- a/images/infrakit/Dockerfile
+++ b/images/infrakit/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.9-alpine AS build
+RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev libvirt-lxc libvirt-qemu git openssh
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+ARG INFRAKIT_VERSION
+COPY build-infrakit /usr/local/bin/
+RUN go get -u -v github.com/docker/infrakit/cmd/infrakit
+RUN if [ -n "${INFRAKIT_VERSION}" ]; then cd /go/src/github.com/docker/infrakit/ && git checkout ${INFRAKIT_VERSION}; fi
+RUN build-infrakit linux
+RUN ls -l /build/infrakit
+
+FROM appcelerator/alpine:3.6.0
+RUN apk add --update ca-certificates openssl openssh
+RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs /infrakit/cli /infrakit/instance/terraform
+VOLUME /infrakit
+WORKDIR /infrakit
+ENV INFRAKIT_HOME /infrakit
+# Defined in pkg/discovery
+ENV INFRAKIT_PLUGINS_DIR /infrakit/plugins
+# Defined in pkg/cli
+ENV INFRAKIT_CLI_DIR /infrakit/cli
+# Defined in cmd/infrakit/playbook
+ENV INFRAKIT_PLAYBOOKS_FILE /infrakit/playbooks
+# When using the manager 'os' option
+ENV INFRAKIT_LEADER_FILE /infrakit/leader
+ENV INFRAKIT_STORE_DIR /infrakit/configs
+# Default options for the manager plugin
+ENV INFRAKIT_MANAGER_BACKEND swarm
+ENV INFRAKIT_MANAGER_GROUP group-stateless
+# Default options for the aws metadata plugin
+ENV INFRAKIT_AWS_METADATA_TEMPLATE_URL file:///infrakit/aws-metadata-export.ikt
+ENV INFRAKIT_AWS_METADATA_POLL_INTERVAL 300s
+COPY --from=build /build/infrakit /usr/local/bin/infrakit
+COPY aws-metadata-export.ikt ${INFRAKIT_HOME}/
+CMD ["infrakit", "plugin", "start", "vars", "manager", "group", "swarm", "vanilla", "combo", "aws"]
+#HEALTHCHECK --interval=5s --retries=3 --timeout=2s CMD infrakit var keys >/dev/null 2>&1

--- a/images/infrakit/aws-metadata-export.ikt
+++ b/images/infrakit/aws-metadata-export.ikt
@@ -1,0 +1,31 @@
+{{/*
+
+AWS specific - This is where we introspect the environment and export the values to other templates.
+Copy of https://raw.githubusercontent.com/infrakit/examples/master/latest/metadata/aws/export.ikt
+
+*/}}
+
+{{ $availabilityZone := include "http://169.254.169.254/latest/meta-data/placement/availability-zone" }}
+{{ $amiID := include "http://169.254.169.254/latest/meta-data/ami-id" }}
+{{ $instanceType := include "http://169.254.169.254/latest/meta-data/instance-type" }}
+{{ $keyName := (include "http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key" | split " ")._2 | trim }}
+{{ $mac:= include "http://169.254.169.254/latest/meta-data/network/interfaces/macs"}} {{/* assumes only one */}}
+{{ $netprefix:= cat "http://169.254.169.254/latest/meta-data/network/interfaces/macs/" $mac | nospace }}
+{{ $securityGroups := cat $netprefix "security-groups" | nospace | include }}     {{/* assumes only one */}}
+{{ $securityGroupIDs := cat $netprefix "security-group-ids" | nospace | include }}  {{/* assumes only one */}}
+{{ $subnetID := cat $netprefix "subnet-id" | nospace | include }}
+{{ $vpcID := cat $netprefix "vpc-id" | nospace | include }}
+
+{{ $iam := include "http://169.254.169.254/latest/meta-data/iam/info" | jsonDecode }} {{/* parsed as object */}}
+
+{{/* export them values here as metadata */}}
+{{ export "local/availabilityZone" $availabilityZone }}
+{{ export "local/amiID" $amiID }}
+{{ export "local/instanceType" $instanceType }}
+{{ export "local/keyName" $keyName }}
+{{ export "local/mac" $mac }}
+{{ export "local/securityGroups" $securityGroups }}
+{{ export "local/securityGroupIDs" $securityGroupIDs }}
+{{ export "local/subnetID" $subnetID }}
+{{ export "local/vpcID" $vpcID }}
+{{ export "local/iam" $iam }} {{/* an object */}}

--- a/images/infrakit/build-infrakit
+++ b/images/infrakit/build-infrakit
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+export GOPATH=/go
+export PATH=/go/bin:$PATH
+
+case "$1" in
+    darwin)
+	export GOOS=darwin
+	export GOARCH=amd64
+	echo "Building for mac ${GOOS} / ${GOARCH}"
+	;;
+    linux)
+	export GOOS=linux
+	export GOARCH=amd64
+	export BUILD_FLAGS="-buildmode pie"
+	echo "Building for linux ${GOOS} / ${GOARCH}"
+	;;
+    *)
+	if [[ "${GOOS}" == "" ]]; then
+	    echo "Must set GOOS and GOOARCH environment variables"
+	    exit -1
+	fi
+	echo "Building for linux ${GOOS} / ${GOARCH}"
+	;;
+esac
+
+if [[ "$2" == "update" ]]; then
+    go get -u -v github.com/docker/infrakit/cmd/infrakit
+fi
+
+cd /go/src/github.com/docker/infrakit/cmd/infrakit
+
+# See Makefile
+VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always)
+REVISION=$(git rev-list -1 HEAD)
+DOCKER_CLIENT_VERSION=1.24
+BINARY=infrakit
+PACKAGE=github.com/docker/infrakit/cmd/infrakit
+
+echo "Building for ${BINARY} GOOS=${GOOS} GOARCH=${GOARCH}, version=${VERSION}, revision=${REVISION}"
+
+go build -o /build/${BINARY} ${BUILD_FLAGS} \
+   -ldflags "-s -w -X github.com/docker/infrakit/pkg/cli.Version=${VERSION} -X github.com/docker/infrakit/pkg/cli.Revision=${REVISION} -X github.com/docker/infrakit/pkg/util/docker.ClientVersion=${DOCKER_CLIENT_VERSION} -extldflags \"-static\"" \
+   ${PACKAGE}
+
+echo "Done.  You may want to copy the file to your path, like:  'sudo cp ./infrakit /usr/local/bin/'"

--- a/images/infrakit/plugins.json
+++ b/images/infrakit/plugins.json
@@ -1,0 +1,141 @@
+[
+    {
+      "Key": "vars",
+      "Launch": {
+        "inproc": {
+          "Kind": "vars",
+          "Options": {
+            "InitialTemplate": ""
+          }
+        }
+      }
+    },
+    {
+      "Key": "manager-file",
+      "Launch": {
+        "inproc": {
+          "Kind": "manager",
+          "Options": {
+            "Name": "",
+            "Group": "group-stateless",
+            "Metadata": "vars"
+          },
+          "Backend": "file"
+        }
+      }
+    },
+    {
+      "Key": "manager-swarm",
+      "Launch": {
+        "inproc": {
+          "Kind": "manager",
+          "Options": {
+            "Name": "",
+            "Group": "group-stateless",
+            "Metadata": "vars"
+          },
+          "Backend": "swarm",
+          "Settings": {
+            "PollInterval": "5s",
+            "Docker": {
+              "Host": "unix:///var/run/docker.sock",
+              "TLS": {
+                "CAFile": "",
+                "CertFile": "",
+                "KeyFile": "",
+                "InsecureSkipVerify": false,
+                "ClientAuth": 0
+              }
+            }
+          },
+          "Mux": {
+            "Listen": ":24864",
+            "Advertise": "localhost:24864"
+          }
+        }
+      }
+    },
+    {
+      "Key": "group-stateless",
+      "Launch": {
+        "inproc": {
+          "Kind": "group",
+          "Options": {
+            "PollInterval": "10s",
+            "MaxParallelNum": 0,
+            "PollIntervalGroupSpec": "10s",
+            "PollIntervalGroupDetail": "10s"
+          }
+        }
+      }
+    },
+    {
+      "Key": "instance-aws",
+      "Launch": {
+        "inproc": {
+          "Kind": "aws",
+          "Options": {
+            "Namespace": {},
+            "ELBNames": [
+              ""
+            ],
+            "Region": "",
+            "AccessKeyID": "",
+            "SecretAccessKey": "",
+            "SessionToken": "",
+            "Retries": 0,
+            "Debug": false,
+            "Template": "",
+            "TemplateOptions": {
+              "DelimLeft": "",
+              "DelimRight": "",
+              "MultiPass": false,
+              "CacheDir": ""
+            },
+            "StackName": "",
+            "PollInterval": "1m0s"
+          }
+        }
+      }
+    },
+    {
+      "Key": "flavor-combo",
+      "Launch": {
+        "inproc": {
+          "Kind": "combo",
+          "Options": {
+          }
+        }
+      }
+    },
+    {
+      "Key": "flavor-vanilla",
+      "Launch": {
+        "inproc": {
+          "Kind": "vanilla",
+          "Options": {
+            "DelimLeft": "",
+            "DelimRight": "",
+            "MultiPass": true,
+            "CacheDir": ""
+          }
+        }
+      }
+    },
+    {
+      "Key": "flavor-swarm",
+      "Launch": {
+        "inproc": {
+          "Kind": "swarm",
+          "Options": {
+            "DelimLeft": "",
+            "DelimRight": "",
+            "MultiPass": true,
+            "CacheDir": "",
+            "ManagerInitScriptTemplate": "",
+            "WorkerInitScriptTemplate": ""
+          }
+        }
+      }
+    }
+]


### PR DESCRIPTION
https://techweb.axway.com/jira/browse/AMP-6

InfraKit deployed as a core service.
A few concerns (such as security) are ignored here, and will be the object of other PRs.

## Verification
```
make build-cli build-plugins
make VERSION=latest clean-ampagent build-ampagent
docker tag appcelerator/ampagent:latest appcelerator/ampagent:${USER}
docker push appcelerator/ampagent:${USER}
amp cluster create --provider aws --aws-region $REGION --aws-stackname ${USER}-ikt --aws-parameter KeyName=$KEYNAME  --aws-parameter ApplicationVersion=${USER} --aws-template https://s3.amazonaws.com/io-amp-binaries/templates/edge/aws-swarm-asg.yml --aws-sync
# note the DNS target output, that's the URL you should use in the next commands
docker run --rm -v infrakit_client:/infrakit appcelerator/infrakit:latest infrakit remote set ${USER}-ikt ${URL}:24864
docker run --rm -v infrakit_client:/infrakit -e INFRAKIT_HOST=${USER}-ikt appcelerator/infrakit:latest infrakit plugin ls
# should list many plugins
docker run --rm -v infrakit_client:/infrakit -e INFRAKIT_HOST=${USER}-ikt appcelerator/infrakit:latest infrakit aws/ec2-instance describe
# should only show the headers, as no instance has been provided by InfraKit yet
```