### PR TITLE
`amp service ps` displays all tasks

### DIFF
--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -18,24 +18,18 @@ type taskOptions struct {
 	quiet bool
 }
 
-const (
-	StateRunning = "RUNNING"
-)
-
 // NewServicePsCommand returns a new instance of the service ps command
 func NewServicePsCommand(c cli.Interface) *cobra.Command {
 	opts := taskOptions{}
 	cmd := &cobra.Command{
 		Use:     "ps [OPTIONS] SERVICE",
-		Short:   "List running tasks of a service",
+		Short:   "List tasks of a service",
 		PreRunE: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return tasks(c, args, opts)
 		},
 	}
-	flags := cmd.Flags()
-	flags.BoolVarP(&opts.all, "all", "a", false, "Display all tasks")
-	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display task ids")
+	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Only display task ids")
 	return cmd
 }
 
@@ -55,9 +49,6 @@ func tasks(c cli.Interface, args []string, opts taskOptions) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, cli.Padding, ' ', 0)
 	fmt.Fprintln(w, "ID\tIMAGE\tDESIRED STATE\tCURRENT STATE\tNODE ID\tERROR")
 	for _, task := range reply.Tasks {
-		if !opts.all && task.CurrentState != StateRunning {
-			continue
-		}
 		if opts.quiet {
 			c.Console().Println(task.Id)
 		} else {

--- a/tests/cli/service/ps/ps_test.sh
+++ b/tests/cli/service/ps/ps_test.sh
@@ -2,6 +2,4 @@
 
 amp -k service ps pinger_pinger 2>/dev/null | grep -o -w -E -q '[[:alnum:]]{25}'
 
-amp -k service ps pinger_pinger 2>/dev/null | grep -Evq 'SHUTDOWN'
-
-amp -k service ps pinger_pinger -a 2>/dev/null | grep -E -i 'RUNNING|SHUTDOWN'
+amp -k service ps pinger_pinger 2>/dev/null | grep -E -i 'RUNNING|SHUTDOWN'


### PR DESCRIPTION
https://techweb.axway.com/jira/projects/AMP/issues/AMP-33

`amp service ps` now lists all the tasks irrespective of their current status

### To test
```
$ ampmake build 
$ amp cluster create
$ amp -k signup --name user --email user@amp --password password
$ amp -k stack up -c ~/mbaas.yml
$ amp service ps mbaas_acs
[user user @ localhost:50101]
ID                          IMAGE                                                                                          DESIRED STATE   CURRENT STATE   NODE ID                     ERROR
ell5myuqk1w8vgfw5j4xs0stb   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   SHUTDOWN        REJECTED        fqfmft46djy60moa2qiiybx0z   No such image: services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2
psrm5zwews1vxdykrzcz3zybe   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   READY           ASSIGNED        fqfmft46djy60moa2qiiybx0z
rfgk6fqnaw961jtboqzl9b3th   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   SHUTDOWN        REJECTED        fqfmft46djy60moa2qiiybx0z   No such image: services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2
rjbcthgkg5s6zpemgu5xxv5kj   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   SHUTDOWN        REJECTED        fqfmft46djy60moa2qiiybx0z   No such image: services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2
rz0osd45vw5uertg0p786ysmz   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   SHUTDOWN        REJECTED        fqfmft46djy60moa2qiiybx0z   No such image: services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2
v1fwvjer20wlnvb2hw42d4l26   services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   SHUTDOWN        REJECTED        fqfmft46djy60moa2qiiybx0z   No such image: services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2
```