### PR TITLE
nats v0.6.0

### DIFF
--- a/cluster/ampagent/stacks/cluster/02-logs.yml
+++ b/cluster/ampagent/stacks/cluster/02-logs.yml
@@ -46,7 +46,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.5.0
+    image: appcelerator/amp-nats-streaming:v0.6.0
     networks:
       default:
         aliases:

--- a/cluster/ampagent/stacks/single/02-logs.yml
+++ b/cluster/ampagent/stacks/single/02-logs.yml
@@ -37,7 +37,7 @@ services:
         - node.labels.amp.type.search == true
 
   nats:
-    image: appcelerator/amp-nats-streaming:v0.5.0
+    image: appcelerator/amp-nats-streaming:v0.6.0
     networks:
       default:
         aliases:

--- a/images/nats/Dockerfile
+++ b/images/nats/Dockerfile
@@ -1,10 +1,15 @@
+FROM golang:1.9.2 AS builder
+ENV VERSION v0.6.0
+RUN go get -d github.com/nats-io/nats-streaming-server
+WORKDIR /go/src/github.com/nats-io/nats-streaming-server
+RUN git checkout ${VERSION}
+RUN CGO_ENABLED=0 GOOS=linux   GOARCH=amd64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/nats-streaming-server/version.GITCOMMIT=`git rev-parse --short HEAD`" -o /nats-streaming-server
+
 FROM scratch
-
-COPY nats-streaming-server /nats-streaming-server
-
+COPY --from=builder /nats-streaming-server /nats-streaming-server
 # Expose client and management ports
 EXPOSE 4222 6222 8222
-
-# Run with default memory based store 
+# Run with default memory based store
 ENTRYPOINT ["/nats-streaming-server", "-m", "8222"]
 CMD []
+

--- a/images/nats/sut/Dockerfile
+++ b/images/nats/sut/Dockerfile
@@ -1,11 +1,12 @@
-From appcelerator/alpine:3.5.2
+From appcelerator/alpine:3.6.0
 ENV GOPATH          /go
 ENV GOBIN           /go/bin
 RUN apk update && apk upgrade && \
-    apk add go git musl-dev && \
+    apk add go git musl musl-dev && \
     go get -v github.com/nats-io/nats && \
     cd $GOPATH/src/github.com/nats-io/nats && \
-    cp examples/*.go /bin/
+    cp examples/*.go /bin/ && \
+    rm -rf /var/cache/apk/*
 RUN cd $GOPATH/src/github.com/nats-io/nats/examples && \
     mkdir $GOBIN && \
     go install nats-pub.go


### PR DESCRIPTION
update NATS to [v0.6.0](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.6.0), many fixes.