### PR TITLE
convenience script to update the default values in the Consul config

### DIFF
--- a/examples/stacks/mbaas/README.md
+++ b/examples/stacks/mbaas/README.md
@@ -58,6 +58,12 @@ The mongodb configuration and the consul configuration have to be created as Doc
 
     curl -k -H Host:acs.mbaas.local.appcelerator.io https://$REMOTE_SERVER/v1/admins/ping.json
 
+PS: the consul template can be updated with the target domain name. For that, execute the following command before creating the docker config:
+
+    DOMAIN=bob.appcelerator.io examples/stacks/mbaas/prepare-consul-docker-config.sh
+
+This will update the `consul.cloud.json` file.
+
 ## Links
 
 * Mongo: https://mongo.mbaas.local.appcelerator.io

--- a/examples/stacks/mbaas/prepare-consul-docker-config.sh
+++ b/examples/stacks/mbaas/prepare-consul-docker-config.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+echo "checking prerequisite: jq"
+which jq >/dev/null || exit 1
+echo "checking prerequisite: base64"
+which base64 >/dev/null || exit 1
+
+CONFIG=$(dirname $0)/consul.cloud.json
+TMPFILE=$(mktemp)
+PROTOCOL=${PROTOCOL:-https}
+DOMAIN=${DOMAIN:-mbaas.aws.appcelerator.io}
+DASHBOARD_URL=${DASHBOARD_URL:-${PROTOCOL}://dashboard.$DOMAIN}
+ENCODED_DOMAIN=$(echo $DOMAIN | base64)
+ENCODED_DASHBOARD_URL=$(echo $DASHBOARD_URL | base64)
+
+echo "$CONFIG will be updated with domain = $DOMAIN and dashboard_url = $DASHBOARD_URL."
+echo " To set the new values, export the env variables DOMAIN and DASHBOARD_URL before running this script."
+echo " To cancel, Ctrl-C, else press Enter."
+read pause
+
+DOMAIN_KEYS=$(jq -r '.[].key' $CONFIG | grep domain)
+DASHBOARD_URL_KEYS=$(jq -r '.[].key' $CONFIG | grep dashboard_url$)
+# TODO: same with the password fields
+
+cp $CONFIG $TMPFILE
+for k in $DOMAIN_KEYS; do
+  org=$(eval jq -r "'.[] | select(.key == \"$k\").value'" $CONFIG | base64 -D)
+  if [[ "x$org" != "x$DOMAIN" ]]; then
+    echo "updating key $k ($org to $DOMAIN)"
+    eval "jq '[.[] | select(.key == \"$k\").value=\"$ENCODED_DOMAIN\"]' $TMPFILE" > ${TMPFILE}.json || exit 1
+    mv ${TMPFILE}.json $TMPFILE
+  else
+    echo "key $k was already set at the requested value"
+  fi
+done
+for k in $DASHBOARD_URL_KEYS; do
+  org=$(eval jq -r "'.[] | select(.key == \"$k\").value'" $CONFIG | base64 -D)
+  if [[ "x$org" != "x$DASHBOARD_URL" ]]; then
+    echo "updating key $k ($org to $DASHBOARD_URL)"
+    eval "jq '[.[] | select(.key == \"$k\").value=\"$ENCODED_DASHBOARD_URL\"]' $TMPFILE" > ${TMPFILE}.json || exit 1
+    mv ${TMPFILE}.json $TMPFILE
+  else
+    echo "key $k was already set at the requested value"
+  fi
+done
+mv $TMPFILE $CONFIG


### PR DESCRIPTION
Useful to prepare a consul.cloud.json with the specific values of a cloud environment.

Example:
```
DOMAIN=bob.appcelerator.io examples/stacks/mbaas/prepare-consul-docker-config.sh
```