### PR TITLE
AMI rebuild, fix race condition on networks with system prune

### DIFF
--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-2167c25b
+      Default: ami-3f20a845
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-7db59918
+      Default: ami-dff6d8ba
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-dbac63a3
+      Default: ami-bcf02dc4
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-1be63c62
+      Default: ami-8fd463f6
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-a242aec0
+      Default: ami-38b2585a
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
@@ -186,7 +186,7 @@ Parameters:
   OverlayNetworks:
     Type: String
     Description: Docker overlay networks to create on the swarm, separated by space
-    Default: "public core monit"
+    Default: ""
   DockerPlugins:
     Type: String
     Description: "space separated list of plugins to install. Options can be passed separated with pound sign. Example: rexray/ebs#REXRAY_PREEMPT=true"

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -22,8 +22,8 @@ ec2_instance_type: "t2.small"
 iam_instance_profile: "amp-image-builder-role"
 
 ## Source AMI
-# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171011 in oregon
-ec2_ami: "ami-19e92861"
+# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171116 in oregon
+ec2_ami: "ami-5dca1925"
 
 ## Security Group
 # should open port 80 (and optionally port 22 for debugging)

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -13,7 +13,7 @@ VPC_ID=${VPC_ID:-unset}
 MANAGER_SIZE=${MANAGER_SIZE:-3}
 #CLUSTER_SIZE=
 DRAIN_MANAGER=${DRAIN_MANAGER:-false}
-OVERLAY_NETWORKS=${OVERLAY_NETWORKS:-ampnet}
+#OVERLAY_NETWORKS=${OVERLAY_NETWORKS:-core public monit}
 #MIRROR_REGISTRIES=
 #DOCKER_DEVICE=/dev/sdl
 AMPAGENT_VERSION=${APP_VERSION:-latest}
@@ -496,7 +496,6 @@ else
 fi
 _label_node || exit 1
 _drain_node || exit 1
-_configure_system_prune || exit 1
 _smoke_test || exit 1
 _signal_aws "${SIGNAL_URL}" || exit 1
 if [[ "x$nodeip" = "x$leader" && -n "$APP_SIGNAL_URL" ]]; then
@@ -504,3 +503,4 @@ if [[ "x$nodeip" = "x$leader" && -n "$APP_SIGNAL_URL" ]]; then
   _setup || exit 1
   _signal_aws "${APP_SIGNAL_URL}"
 fi
+_configure_system_prune || exit 1


### PR DESCRIPTION
- Fix amp-78 (amp cluster deploy failure because of missing overlay network)
- Updated AMI