### PR TITLE
AWS deployment improvements

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -38,6 +38,8 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.String("aws-stackname", "", "The name of the AWS stack that will be created")
 	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
 	flags.String("aws-template", "", "UNSUPPORTED: cloud formation template url")
+	flags.String("aws-access-key-id", "", "aws credential: access key id")
+	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
 
 	return cmd
 }

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -40,6 +40,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.String("aws-template", "", "UNSUPPORTED: cloud formation template url")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
+	flags.String("aws-profile", "default", "aws credential: profile")
 
 	return cmd
 }

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -36,7 +36,7 @@ func NewCreateCommand(c cli.Interface) *cobra.Command {
 	flags.StringSlice("aws-parameter", []string{}, "Key-value pairs to pass through to the AWS CloudFormation template")
 	flags.String("aws-region", "", "The region to use when launching the instance")
 	flags.String("aws-stackname", "", "The name of the AWS stack that will be created")
-	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+	flags.Bool("aws-sync", true, "If true, block until the command finishes")
 	flags.String("aws-template", "", "UNSUPPORTED: cloud formation template url")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")

--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -279,9 +279,20 @@ func (p *awsPlugin) Run(c cli.Interface, args []string, env map[string]string) e
 		p.config.DockerOpts.Volumes = []string{}
 	}
 
-	// automatically attempt to mount aws credentials if present
-	awshome := path.Join(home, ".aws")
-	if _, err := os.Stat(awshome); err == nil {
+	mountAwsConfigFolder := true
+	for _, a := range args {
+		if a == "--access-key-id" {
+			mountAwsConfigFolder = false
+			break
+		}
+	}
+	if mountAwsConfigFolder {
+		// automatically attempt to mount aws credentials if present
+		awshome := path.Join(home, ".aws")
+		awscreds := path.Join(awshome, "credentials")
+		if _, err := os.Stat(awscreds); err != nil {
+			return fmt.Errorf("no $HOME/.aws/credentials found, please refer to http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html to configure it")
+		}
 		dockerOpts.Volumes = append(dockerOpts.Volumes, fmt.Sprintf("%s:/root/.aws", awshome))
 	}
 

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -28,7 +28,7 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 	// aws options
 	flags.String("aws-region", "", "Region to use to delete the instance")
 	flags.String("aws-stackname", "", "Name of the AWS stack to be deleted")
-	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+	flags.Bool("aws-sync", true, "If true, block until the command finishes")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
 	flags.String("aws-profile", "default", "aws credential: profile")

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -29,6 +29,8 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 	flags.String("aws-region", "", "Region to use to delete the instance")
 	flags.String("aws-stackname", "", "Name of the AWS stack to be deleted")
 	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
+	flags.String("aws-access-key-id", "", "aws credential: access key id")
+	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
 
 	return cmd
 }

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -31,6 +31,7 @@ func NewRemoveCommand(c cli.Interface) *cobra.Command {
 	flags.Bool("aws-sync", false, "If true, block until the command finishes (default: false)")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
+	flags.String("aws-profile", "default", "aws credential: profile")
 
 	return cmd
 }

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -19,6 +19,8 @@ func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster plugin image")
+	flags.String("aws-access-key-id", "", "aws credential: access key id")
+	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
 	return cmd
 }
 

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -21,6 +21,7 @@ func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster plugin image")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
+	flags.String("aws-profile", "default", "aws credential: profile")
 	return cmd
 }
 

--- a/cli/command/cluster/update.go
+++ b/cli/command/cluster/update.go
@@ -19,6 +19,7 @@ func NewUpdateCommand(c cli.Interface) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&opts.provider, "provider", "local", "Cluster provider")
 	flags.StringVarP(&opts.tag, "tag", "t", c.Version(), "Specify tag for cluster plugin image")
+	flags.Bool("aws-sync", true, "If true, block until the command finishes")
 	flags.String("aws-access-key-id", "", "aws credential: access key id")
 	flags.String("aws-secret-access-key", "", "aws credential: secret access key")
 	flags.String("aws-profile", "default", "aws credential: profile")

--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -25,6 +25,7 @@ var (
 		TemplateURL:     plugin.DefaultTemplateURL,
 		AccessKeyId:     "",
 		SecretAccessKey: "",
+		Profile:         "default",
 	}
 
 	sess *session.Session
@@ -48,6 +49,7 @@ func initClient(cmd *cobra.Command, args []string) {
 		os.Setenv("AWS_SECRET_ACCESS_KEY", opts.SecretAccessKey)
 	} else {
 		os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+		os.Setenv("AWS_PROFILE", opts.Profile)
 	}
 	config := aws.NewConfig().WithLogLevel(aws.LogOff)
 	// region can be set with a CLI option, but if not set it can be set by the config file
@@ -342,6 +344,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&opts.Sync, "sync", "s", false, "block until operation is complete")
 	rootCmd.PersistentFlags().StringVar(&opts.AccessKeyId, "access-key-id", "", "access key id (for example, AKIAIOSFODNN7EXAMPLE)")
 	rootCmd.PersistentFlags().StringVar(&opts.SecretAccessKey, "secret-access-key", "", "secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)")
+	rootCmd.PersistentFlags().StringVar(&opts.Profile, "profile", "default", "credential profile")
 
 	initCmd := &cobra.Command{
 		Use:   "init",

--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -280,9 +280,11 @@ func delete(cmd *cobra.Command, args []string) {
 				}
 				return
 			case cf.StackStatusDeleteInProgress:
-				log.Fatal("stack deletion already in progress")
+				log.Fatal("cluster deletion already in progress, check again in a few minutes")
+			case cf.StackStatusRollbackInProgress:
+				log.Fatal("cluster deployment is performing a rollback, the deletion is not possible right now, please try again in in a few minutes")
 			default:
-				log.Fatalf("stack deletion not possible with the current stack status - %s", *stk.StackStatus)
+				log.Fatalf("cluster deletion not possible with the current status [%s], try again in a few minutes", *stk.StackStatus)
 			}
 		}
 	}

--- a/cluster/plugin/aws/main.go
+++ b/cluster/plugin/aws/main.go
@@ -341,7 +341,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&opts.Region, "region", "r", "", "aws region")
 	rootCmd.PersistentFlags().StringVarP(&opts.StackName, "stackname", "n", "", "aws stack name")
 	rootCmd.PersistentFlags().StringSliceVarP(&opts.Params, "parameter", "p", []string{}, "parameter")
-	rootCmd.PersistentFlags().BoolVarP(&opts.Sync, "sync", "s", false, "block until operation is complete")
+	rootCmd.PersistentFlags().BoolVarP(&opts.Sync, "sync", "s", true, "block until operation is complete")
 	rootCmd.PersistentFlags().StringVar(&opts.AccessKeyId, "access-key-id", "", "access key id (for example, AKIAIOSFODNN7EXAMPLE)")
 	rootCmd.PersistentFlags().StringVar(&opts.SecretAccessKey, "secret-access-key", "", "secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)")
 	rootCmd.PersistentFlags().StringVar(&opts.Profile, "profile", "default", "credential profile")

--- a/cluster/plugin/aws/plugin/plugin.go
+++ b/cluster/plugin/aws/plugin/plugin.go
@@ -36,6 +36,10 @@ type RequestOptions struct {
 	Sync bool
 	// TemplateURL is the URL for the AWS CloudFormation to use
 	TemplateURL string
+	// AWS Access Key ID
+	AccessKeyId string
+	// AWS Secret Access Key
+	SecretAccessKey string
 }
 
 // StackOutput contains the converted output from the create stack operation

--- a/cluster/plugin/aws/plugin/plugin.go
+++ b/cluster/plugin/aws/plugin/plugin.go
@@ -40,6 +40,8 @@ type RequestOptions struct {
 	AccessKeyId string
 	// AWS Secret Access Key
 	SecretAccessKey string
+	// AWS Profile
+	Profile string
 }
 
 // StackOutput contains the converted output from the create stack operation

--- a/cluster/plugin/aws/plugin/plugin.go
+++ b/cluster/plugin/aws/plugin/plugin.go
@@ -204,7 +204,7 @@ func PluginOutputToJSON(ev *StackEvent, so []StackOutput, e error) (string, erro
 
 // ListStack lists the stacks based on the filter on stack status
 func ListStack(ctx context.Context, svc *cf.CloudFormation) (*cf.ListStacksOutput, error) {
-	statusFilter := []string{cf.StackStatusCreateFailed, cf.StackStatusCreateInProgress, cf.ChangeSetStatusCreateComplete, cf.StackStatusRollbackInProgress, cf.StackStatusRollbackFailed, cf.StackStatusDeleteInProgress}
+	statusFilter := []string{cf.StackStatusCreateFailed, cf.StackStatusCreateInProgress, cf.StackStatusCreateComplete, cf.StackStatusRollbackInProgress, cf.StackStatusRollbackFailed, cf.StackStatusDeleteInProgress, cf.StackStatusRollbackComplete}
 	input := &cf.ListStacksInput{
 		StackStatusFilter: aws.StringSlice(statusFilter),
 	}


### PR DESCRIPTION
- Fix amp-73 (warning when credentials are not provided)
- Fix amp-76 (allow credentials to be passed as arguments)
- region can be read from the .aws/config file
- option --aws-sync now defaults to true
- new --aws-profile option, for credentials file with multiple profiles
- stacks in ROLLBACK_COMPLETE status were ignored by the rm command

The only way to provide credentials was to create a .aws/credentials file. It's still the recommended way to do it. We now have an alternative way to pass the credentials: with the --aws-access-key-id and --aws-secret-access-key.