### PR TITLE
Prometheus alerting rules updates

### DIFF
--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -1,18 +1,32 @@
 package service
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"strings"
 
+	"docker.io/go-docker/api/types/swarm"
 	"github.com/appcelerator/amp/api/rpc/service"
 	"github.com/appcelerator/amp/cli"
+	"github.com/appcelerator/amp/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/status"
 )
 
+// inspectOptions as defined in https://github.com/docker/cli/blob/master/cli/command/service/inspect.go
+type inspectOptions struct {
+	refs   []string
+	format string
+	pretty bool
+}
+
+var opts inspectOptions
+
 // NewServiceInspectCommand returns a new instance of the service inspect command.
 func NewServiceInspectCommand(c cli.Interface) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "inspect SERVICE",
 		Short:   "Display detailed information of a service",
 		PreRunE: cli.ExactArgs(1),
@@ -20,6 +34,9 @@ func NewServiceInspectCommand(c cli.Interface) *cobra.Command {
 			return inspectService(c, args)
 		},
 	}
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.format, "format", "f", "", "Format the output using the given Go template")
+	return cmd
 }
 
 func inspectService(c cli.Interface, args []string) error {
@@ -34,6 +51,31 @@ func inspectService(c cli.Interface, args []string) error {
 			return errors.New(s.Message())
 		}
 	}
-	c.Console().Println(reply.Json)
+	if len(opts.format) == 0 {
+		c.Console().Println(reply.Json)
+		return nil
+	}
+	opts.refs = args
+	// check if the user is trying to apply a template to the pretty format, which
+	// is not supported
+	if strings.HasPrefix(opts.format, "pretty") && opts.format != "pretty" {
+		return errors.New("cannot supply extra formatting options to the pretty template")
+	}
+	serviceCtx := formatter.Context{
+		Output: c.Console().OutStream(),
+		Format: formatter.NewServiceFormat(opts.format),
+	}
+	getRef := func(ref string) (interface{}, []byte, error) {
+		var s swarm.Service
+		r := bytes.NewReader([]byte(reply.Json))
+		err := json.NewDecoder(r).Decode(&s)
+		if err != nil {
+			return nil, nil, err
+		}
+		return s, nil, nil
+	}
+	if err := formatter.ServiceInspectWrite(serviceCtx, opts.refs, getRef, nil); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cluster/ampagent/stacks/cluster/03-metrics.yml
+++ b/cluster/ampagent/stacks/cluster/03-metrics.yml
@@ -167,7 +167,7 @@ services:
         io.amp.metrics.port: "9100"
 
   alertmanager:
-    image: prom/alertmanager:v0.10.0
+    image: prom/alertmanager:v0.11.0
     networks:
       - core
     volumes:

--- a/cluster/ampagent/stacks/cluster/03-metrics.yml
+++ b/cluster/ampagent/stacks/cluster/03-metrics.yml
@@ -35,6 +35,7 @@ services:
     environment:
       SERVICE_PORTS: 9090
       VIRTUAL_HOST: "http://alerts.*,https://alerts.*"
+      PROMETHEUS_EXTERNAL_URL: "${PROMETHEUS_EXTERNAL_URL:-https://alerts.local.appcelerator.io}"
     ports:
       - "9090:9090"
     labels:
@@ -173,6 +174,9 @@ services:
       - alertmanager-data:/alertmanager
     ports:
       - "9093:9093"
+    environment:
+      VIRTUAL_HOST: "https://alertmanager.*,alertmanager.*"
+      SERVICE_PORTS: "9093"
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"

--- a/cluster/ampagent/stacks/single/03-metrics.yml
+++ b/cluster/ampagent/stacks/single/03-metrics.yml
@@ -167,7 +167,7 @@ services:
         io.amp.metrics.port: "9100"
 
   alertmanager:
-    image: prom/alertmanager:v0.10.0
+    image: prom/alertmanager:v0.11.0
     networks:
       - core
     volumes:

--- a/cluster/ampagent/stacks/single/03-metrics.yml
+++ b/cluster/ampagent/stacks/single/03-metrics.yml
@@ -35,6 +35,7 @@ services:
     environment:
       SERVICE_PORTS: 9090
       VIRTUAL_HOST: "http://alerts.*,https://alerts.*"
+      PROMETHEUS_EXTERNAL_URL: "${PROMETHEUS_EXTERNAL_URL:-https://alerts.local.appcelerator.io}"
     ports:
       - "9090:9090"
     labels:
@@ -173,6 +174,9 @@ services:
       - alertmanager-data:/alertmanager
     ports:
       - "9093:9093"
+    environment:
+      VIRTUAL_HOST: "https://alertmanager.*,alertmanager.*"
+      SERVICE_PORTS: "9093"
     labels:
       io.amp.role: "infrastructure"
       amp.service.stabilize.delay: "3s"

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,0 +1,29 @@
+# Monitoring sample files
+
+Extensive reference documentation is available on [prometheus.io].
+
+## Validation of configuration files
+
+### Prometheus alert rules
+
+The configuration file can be tested with the following command:
+
+    docker run --rm -v $PWD/examples/monitoring/prometheus_alerts.rules:/alerts.rules --entrypoint /bin/promtool prom/prometheus check rules /alerts.rules
+
+## Deployment of new configuration
+
+### Prometheus alert rules
+
+To update the configuration, you first have to check the name of the Docker config used by the prometheus service, and list the existing Docker configs to be able to build a new unique name.
+
+    amp -s <REMOTE_URL> service inspect amp_prometheus --format '{{ (index .Spec.TaskTemplate.ContainerSpec.Configs 0 ).ConfigName }}'
+    amp -s <REMOTE_URL> config ls | grep prometheus
+    amp -s <REMOTE_URL> config create prometheus_alerts_rules_CLUSTERNAME examples/monitoring/prometheus_alerts.rules
+    amp -s <REMOTE_URL> service update --config-rm prometheus_alerts_rules --config-add source=prometheus_alerts_rules_CLUSTERNAME,target=/etc/prometheus/alerts.rules
+
+### Alertmanager configuration
+
+    amp -s <REMOTE_URL> secret ls | grep alertmanager
+    amp -s <REMOTE_URL> service inspect amp_alertmanager --format '{{ (index .Spec.TaskTemplate.ContainerSpec.Secrets 0 ).SecretName }}'
+    amp -s <REMOTE_URL> secret create alertmanager_yml_CLUSTERNAME examples/monitoring/prometheus_alerts.rules
+    amp -s <REMOTE_URL> service update --config-rm prometheus_alerts_rules --config-add source=prometheus_alerts_rules_CLUSTERNAME,target=/etc/prometheus/alerts.rules

--- a/examples/monitoring/prometheus_alerts.rules
+++ b/examples/monitoring/prometheus_alerts.rules
@@ -1,297 +1,227 @@
-# Global alert (nats, etcd, haproxy, docker engine, system)
-ALERT FileDescriptors
-  IF 100 * (process_max_fds - process_open_fds)/ process_max_fds < 10
-  FOR 30s
-  ANNOTATIONS {
-   summary = "file descriptors exhaustion",
-   description = "file descriptor usage on {{ $labels.job }} / {{ $labels.instance }} is more than 90%"
-  }
-
-# Global alert (nats, etcd, haproxy, docker engine, system)
-ALERT Availability
-  IF up < 1
-  FOR 5m
-  ANNOTATIONS {
-   summary = "resource unavailability",
-   description = "{{ $labels.job }} / {{ $labels.instance }} is not up"
-  }
-
-# elasticsearch
-ALERT ElasticsearchClusterStatus
-  IF es_cluster_status > 1
-  FOR 1m
-  ANNOTATIONS {
-   summary = "elasticsearch cluster status",
-   description = "elasticsearch cluster status is {{ $value }}"
-  }
-ALERT ElasticsearchHeapPercent
-  IF es_jvm_mem_heap_used_percent > 95
-  FOR 1m
-  ANNOTATIONS {
-   summary = "elasticsearch java heap size high usage",
-   description = "elasticsearch instance on {{ $labels.instance }} uses {{ $value }} of its java heap size"
-  }
-ALERT ElasticsearchPendingTasks
-  IF es_cluster_pending_tasks_number > 1000
-  FOR 1m
-  ANNOTATIONS {
-   summary = "elasticsearch high number of pending tasks",
-   description = "elasticsearch instance on {{ $labels.instance }} has {{ $value }} pending tasks"
-  }
-
-# ETCD
-# from https://github.com/coreos/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules
-# general cluster availability
-
-# alert if another failed member will result in an unavailable cluster
-ALERT InsufficientMembers
-IF count(up{job="etcd"}) > 1 and count(up{job="etcd"} == 0) > (count(up{job="etcd"}) / 2 - 1)
-FOR 3m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "etcd cluster insufficient members",
-  description = "If one more etcd member goes down the cluster will be unavailable",
-}
-
-# etcd leader alerts
-# ==================
-
-# alert if any etcd instance has no leader
-ALERT NoLeader
-IF etcd_server_has_leader{job="etcd"} == 0
-FOR 1m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "etcd member has no leader",
-  description = "etcd member {{ $labels.instance }} has no leader",
-}
-
-# alert if there are lots of leader changes
-ALERT HighNumberOfLeaderChanges
-IF increase(etcd_server_leader_changes_seen_total{job="etcd"}[1h]) > 3
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "a high number of leader changes within the etcd cluster are happening",
-  description = "etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour",
-}
-
-# gRPC request alerts
-# ===================
-
-# alert if more than 1% of gRPC method calls have failed within the last 5 minutes
-ALERT HighNumberOfFailedGRPCRequests
-IF sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.01
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "a high number of gRPC requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
-}
-
-# alert if more than 5% of gRPC method calls have failed within the last 5 minutes
-ALERT HighNumberOfFailedGRPCRequests
-IF sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.05
-FOR 5m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "a high number of gRPC requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
-}
-
-# alert if the 99th percentile of gRPC method calls take more than 150ms
-ALERT GRPCRequestsSlow
-IF histogram_quantile(0.99, rate(etcd_grpc_unary_requests_duration_seconds_bucket[5m])) > 0.15
-FOR 10m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "slow gRPC requests",
-  description = "on etcd instance {{ $labels.instance }} gRPC requests to {{ $label.grpc_method }} are slow",
-}
-
-# HTTP requests alerts
-# ====================
-
-# alert if more than 1% of requests to an HTTP endpoint have failed within the last 5 minutes
-ALERT HighNumberOfFailedHTTPRequests
-IF sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m]))
-  / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.01
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "a high number of HTTP requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
-}
-
-# alert if more than 5% of requests to an HTTP endpoint have failed within the last 5 minutes
-ALERT HighNumberOfFailedHTTPRequests
-IF sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m])) 
-  / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.05
-FOR 5m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "a high number of HTTP requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
-}
-
-# alert if the 99th percentile of HTTP requests take more than 150ms
-ALERT HTTPRequestsSlow
-IF histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "slow HTTP requests",
-  description = "on etcd instance {{ $labels.instance }} HTTP requests to {{ $label.method }} are slow",
-}
-
-# file descriptor alerts
-# ======================
-
-instance:fd_utilization = process_open_fds / process_max_fds
-
-# alert if file descriptors are likely to exhaust within the next 4 hours
-ALERT FdExhaustionClose
-IF predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "file descriptors soon exhausted",
-  description = "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon",
-}
-
-# alert if file descriptors are likely to exhaust within the next hour
-ALERT FdExhaustionClose
-IF predict_linear(instance:fd_utilization[10m], 3600) > 1
-FOR 10m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "file descriptors soon exhausted",
-  description = "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon",
-}
-
-# etcd member communication alerts
-# ================================
-
-# alert if 99th percentile of round trips take 150ms
-ALERT EtcdMemberCommunicationSlow
-IF histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m])) > 0.15
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "etcd member communication is slow",
-  description = "etcd instance {{ $labels.instance }} member communication with {{ $label.To }} is slow",
-}
-
-# etcd proposal alerts
-# ====================
-
-# alert if there are several failed proposals within an hour
-ALERT HighNumberOfFailedProposals
-IF increase(etcd_server_proposals_failed_total{job="etcd"}[1h]) > 5
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "a high number of proposals within the etcd cluster are failing",
-  description = "etcd instance {{ $labels.instance }} has seen {{ $value }} proposal failures within the last hour",
-}
-
-# etcd disk io latency alerts
-# ===========================
-
-# alert if 99th percentile of fsync durations is higher than 500ms
-ALERT HighFsyncDurations
-IF histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "high fsync durations",
-  description = "etcd instance {{ $labels.instance }} fync durations are high",
-}
-
-# alert if 99th percentile of commit durations is higher than 250ms
-ALERT HighCommitDurations
-IF histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "high commit durations",
-  description = "etcd instance {{ $labels.instance }} commit durations are high",
-}
-
-
-# NATS
-ALERT NatsHttpRequestDuration
-  IF http_request_duration_microseconds{job="nats", quantile="0.9"} > 5000
-  ANNOTATIONS {
-   summary = "slow nats http requests",
-   description = "a nats instance on {{ $labels.instance }} experiences slow http requests ({{ $value }} sec)"
-  }
-
-# HAPROXY
-ALERT HaproxyServerCurrentQueue
-  IF haproxy_server_current_queue{job="haproxy"} > 10
-  FOR 2m
-  ANNOTATIONS {
-   summary = "Queue is filling up",
-   description = "haproxy backend {{ $labels.backend }} has ({{ $value }} requests in queue"
-  }
-
-# NODES
-ALERT SystemLoad15
-  IF node_load15{job="nodes"} > 2
-  FOR 1m
-  ANNOTATIONS {
-   summary = "high system load",
-   description = "the average system load on 15 min on {{ $labels.instance }} has reached {{ $value }}"
-  }
-ALERT SystemLoad5
-  IF node_load5{job="nodes"} > 4
-  FOR 1m
-  ANNOTATIONS {
-   summary = "high system load",
-   description = "the average system load on 5 min on {{ $labels.instance }} has reached {{ $value }}"
-  }
-ALERT FSUsage
-  IF 100 * node_filesystem_free / node_filesystem_size{fstype=~"xfs|ext4",mountpoint=~"/rootfs|/rootfs/var/lib/docker"} <  20
-  FOR 1m
-  ANNOTATIONS {
-   summary = "FS soon running out of space",
-   description = "the {{ $labels.mountpoint }} on {{ $labels.instance }} has only {{ $value }}% space available"
-  }
-ALERT MemoryUsage
-  IF 100 * node_memory_MemFree / node_memory_MemTotal < 10
-  FOR 5m 
-  ANNOTATIONS {
-   summary = "high memory usage",
-   description = "instance {{ $labels.instance }} has only {{ $value }}% memory available"
-  }
+groups:
+  - name: amp
+    rules:
+    # Global alert (nats, etcd, haproxy, docker engine, system)
+    - alert: FileDescriptors
+      expr: 100 * (process_max_fds - process_open_fds)/ process_max_fds < 10
+      for: 30s
+      labels:
+      annotations:
+        summary: file descriptors exhaustion
+        description: "file descriptor usage on {{ $labels.job }} / {{ $labels.instance }} is more than 90%"
+    # Global alert (nats, etcd, haproxy, docker engine, system)
+    - alert: Availability
+      expr: up < 1
+      for: 5m
+      annotations:
+        summary: "resource unavailability"
+        description: "{{ $labels.job }} / {{ $labels.instance }} is not up"
+    # elasticsearch
+    - alert: ElasticsearchClusterStatus
+      expr: es_cluster_status > 1
+      for: 1m
+      annotations:
+        summary: "elasticsearch cluster status"
+        description: "elasticsearch cluster status is {{ $value }}"
+    - alert: ElasticsearchHeapPercent
+      expr: es_jvm_mem_heap_used_percent > 95
+      for: 1m
+      annotations:
+        summary: "elasticsearch java heap size high usage"
+        description: "elasticsearch instance on {{ $labels.instance }} uses {{ $value }} of its java heap size"
+    - alert: ElasticsearchPendingTasks
+      expr: es_cluster_pending_tasks_number > 1000
+      for: 1m
+      annotations:
+        summary: "elasticsearch high number of pending tasks"
+        description: "elasticsearch instance on {{ $labels.instance }} has {{ $value }} pending tasks"
+    # ETCD
+    # from https://github.com/coreos/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules
+    # general cluster availability
+    # alert if another failed member will result in an unavailable cluster
+    - alert: InsufficientMembers
+      expr: count(up{job="etcd"}) > 1 and count(up{job="etcd"} == 0) > (count(up{job="etcd"}) / 2 - 1)
+      for: 3m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "etcd cluster insufficient members"
+        description: "If one more etcd member goes down the cluster will be unavailable"
+    # etcd leader alerts
+    # ==================
+    # alert if any etcd instance has no leader
+    - alert: NoLeader
+      expr: etcd_server_has_leader{job="etcd"} == 0
+      for: 1m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "etcd member has no leader"
+        description: "etcd member {{ $labels.instance }} has no leader"
+    # alert if there are lots of leader changes
+    - alert: HighNumberOfLeaderChanges
+      expr: increase(etcd_server_leader_changes_seen_total{job="etcd"}[1h]) > 3
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "a high number of leader changes within the etcd cluster are happening"
+        description: "etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour"
+    # gRPC request alerts
+    # ===================
+    # alert if more than 1% of gRPC method calls have failed within the last 5 minutes
+    - alert: HighNumberOfFailedGRPCRequests
+      expr: sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.01
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "a high number of gRPC requests are failing"
+        description: "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}"
+    # alert if more than 5% of gRPC method calls have failed within the last 5 minutes
+    - alert: HighNumberOfFailedGRPCRequests
+      expr: sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m])) > 0.05
+      for: 5m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "a high number of gRPC requests are failing"
+        description: "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}"
+    # alert if the 99th percentile of gRPC method calls take more than 150ms
+    - alert: GRPCRequestsSlow
+      expr: histogram_quantile(0.99, rate(etcd_grpc_unary_requests_duration_seconds_bucket[5m])) > 0.15
+      for: 10m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "slow gRPC requests"
+        description: "on etcd instance {{ $labels.instance }} gRPC requests to {{ $label.grpc_method }} are slow"
+    # HTTP requests alerts
+    # ====================
+    # alert if more than 1% of requests to an HTTP endpoint have failed within the last 5 minutes
+    - alert: HighNumberOfFailedHTTPRequests
+      expr: sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m])) / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.01
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "a high number of HTTP requests are failing"
+        description: "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}"
+    # alert if more than 5% of requests to an HTTP endpoint have failed within the last 5 minutes
+    - alert: HighNumberOfFailedHTTPRequests
+      expr: sum by(method) (rate(etcd_http_failed_total{job="etcd"}[5m])) / sum by(method) (rate(etcd_http_received_total{job="etcd"}[5m])) > 0.05
+      for: 5m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "a high number of HTTP requests are failing"
+        description: "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}"
+    # alert if the 99th percentile of HTTP requests take more than 150ms
+    - alert: HTTPRequestsSlow
+      expr: histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "slow HTTP requests"
+        description: "on etcd instance {{ $labels.instance }} HTTP requests to {{ $label.method }} are slow"
+    # file descriptor alerts
+    # ======================
+    - record: instance:fd_utilization
+      expr: process_open_fds / process_max_fds
+    # alert if file descriptors are likely to exhaust within the next 4 hours
+    - alert: FdExhaustionClose
+      expr: predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "file descriptors soon exhausted"
+        description: "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon"
+    # alert if file descriptors are likely to exhaust within the next hour
+    - alert: FdExhaustionClose
+      expr: predict_linear(instance:fd_utilization[10m], 3600) > 1
+      for: 10m
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "file descriptors soon exhausted"
+        description: "{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon"
+    # etcd member communication alerts
+    # ================================
+    # alert if 99th percentile of round trips take 150ms
+    - alert: EtcdMemberCommunicationSlow
+      expr: histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m])) > 0.15
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "etcd member communication is slow"
+        description: "etcd instance {{ $labels.instance }} member communication with {{ $label.To }} is slow"
+    # etcd proposal alerts
+    # ====================
+    # alert if there are several failed proposals within an hour
+    - alert: HighNumberOfFailedProposals
+      expr: increase(etcd_server_proposals_failed_total{job="etcd"}[1h]) > 5
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "a high number of proposals within the etcd cluster are failing"
+        description: "etcd instance {{ $labels.instance }} has seen {{ $value }} proposal failures within the last hour"
+    # etcd disk io latency alerts
+    # ===========================
+    # alert if 99th percentile of fsync durations is higher than 500ms
+    - alert: HighFsyncDurations
+      expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "high fsync durations"
+        description: "etcd instance {{ $labels.instance }} fync durations are high"
+    # alert if 99th percentile of commit durations is higher than 250ms
+    - alert: HighCommitDurations
+      expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
+      for: 10m
+      labels:
+        severity: "warning"
+      annotations:
+        summary: "high commit durations"
+        description: "etcd instance {{ $labels.instance }} commit durations are high"
+    # NATS
+    - alert: NatsHttpRequestDuration
+      expr: http_request_duration_microseconds{job="nats", quantile="0.9"} > 5000
+      annotations:
+        summary: "slow nats http requests"
+        description: "a nats instance on {{ $labels.instance }} experiences slow http requests ({{ $value }} sec)"
+    # HAPROXY
+    - alert: HaproxyServerCurrentQueue
+      expr: haproxy_server_current_queue{job="haproxy"} > 10
+      for: 2m
+      annotations:
+        summary: "Queue is filling up"
+        description: "haproxy backend {{ $labels.backend }} has ({{ $value }} requests in queue"
+    # NODES
+    - alert: SystemLoad15
+      expr: node_load15{job="nodes"} > 2
+      for: 1m
+      annotations:
+        summary: "high system load"
+        description: "the average system load on 15 min on {{ $labels.instance }} has reached {{ $value }}"
+    - alert: SystemLoad5
+      expr: node_load5{job="nodes"} > 4
+      for: 1m
+      annotations:
+        summary: "high system load"
+        description: "the average system load on 5 min on {{ $labels.instance }} has reached {{ $value }}"
+    - alert: FSUsage
+      expr: 100 * node_filesystem_free / node_filesystem_size{fstype=~"xfs|ext4",mountpoint=~"/rootfs|/rootfs/var/lib/docker"} <  20
+      for: 1m
+      annotations:
+        summary: "FS soon running out of space"
+        description: "the {{ $labels.mountpoint }} on {{ $labels.instance }} has only {{ $value }}% space available"
+    - alert: MemoryUsage
+      expr: 100 * node_memory_MemFree / node_memory_MemTotal < 10
+      for: 5m 
+      annotations:
+        summary: "high memory usage"
+        description: "instance {{ $labels.instance }} has only {{ $value }}% memory available"

--- a/monitoring/promctl/main.go
+++ b/monitoring/promctl/main.go
@@ -36,6 +36,8 @@ const (
 	metricsModeLabel     = "io.amp.metrics.mode"
 	metricsModeTasks     = "tasks"
 	metricsModeExporter  = "exporter"
+	externalURLEnv       = "PROMETHEUS_EXTERNAL_URL"
+	externalURLOption    = "--web.external-url"
 )
 
 var prometheusArgs = []string{
@@ -299,6 +301,10 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&host, "host", defaultHost, "host")
 	RootCmd.PersistentFlags().Int32VarP(&period, "period", "p", defaultPeriod, "reload period in minute")
 
+	// Set Prometheus external URL if provided
+	if url := os.Getenv(externalURLEnv); url != "" {
+		prometheusArgs = append(prometheusArgs, fmt.Sprintf("%s=%s", externalURLOption, url))
+	}
 	// start Prometheus
 	proc := exec.Command(prometheusCmd, prometheusArgs...)
 	stdout, err := proc.StdoutPipe()

--- a/tests/cli/service/inspect/inspect_test.sh
+++ b/tests/cli/service/inspect/inspect_test.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-amp -k service inspect pinger_pinger 2>/dev/null | pcregrep -q "pinger"
+test_inspect() {
+  amp -k service inspect pinger_pinger 2>/dev/null | grep -q "pinger"
+}
+
+test_inspect_format() {
+  secret_name=amplifier_yml
+  secrets=$(amp -k service inspect amp_amplifier --format '{{ range .Spec.TaskTemplate.ContainerSpec.Secrets}} {{ .SecretName }} {{ end }}') || return 1
+ echo $secrets | grep -q $secret_name
+}

--- a/tests/cli/service/list/list_test.sh
+++ b/tests/cli/service/list/list_test.sh
@@ -3,15 +3,16 @@
 SECONDS=0
 
 test_stack_deploy() {
-  amp -k stack up -c tests/cli/service/list/global.service.yml global
+  amp -k stack up -c tests/cli/service/list/global.service.yml global || return 1
   amp -k stack up -c tests/cli/service/list/replicated.service.yml replicated
 }
 
 test_service_starting() {
-  amp -k service ls 2>/dev/null | grep -q "\s*global\s*0/1\s*STARTING|RUNNING\s*appcelerator/pinger\s*latest\s*"
-  amp -k service ls 2>/dev/null | grep -q "\s*replicated\s*0/1\s*STARTING\s*appcelerator/pinger\s*latest\s*"
+  amp -k service ls 2>/dev/null | pcregrep -q "global_pinger\s*.*s*(STARTING|RUNNING)\s*appcelerator/pinger" || return 1
+  amp -k service ls 2>/dev/null | pcregrep -q "replicated_pinger\s*.*\s*(STARTING|RUNNING)\s*appcelerator/pinger"
 }
 
+# FIXME: this test is not reliable, test condition and usage of the internal variable SECONDS
 test_service_global_running() {
   while true
   do
@@ -24,6 +25,7 @@ test_service_global_running() {
   done
 }
 
+# FIXME: this test is not reliable, test condition and usage of the internal variable SECONDS
 test_service_replicated_running() {
   while true
   do


### PR DESCRIPTION
- Fix amp-86 (link to prometheus in alertmanager alerts)
- Fix amp-87 (migrated sample alert rules file for Prometheus 2.0)
- Fix amp-90 (--format option for service inspect command)
- Bump alertmanager version to 0.11.0

## Verification

```
make build-cli build-ampagent
docker config rm prometheus_alerts_rules
docker config create prometheus_alerts_rules examples/monitoring/prometheus_alerts.rules
amp cluster create
amp -k user signup
# check amp-87
amp -k service logs -i amp_prometheus
# there should be no error related to the alerting rules
# check amp-90 (there's also a unit test for this one)
amp -k service inspect amp_prometheus --format '{{ (index .Spec.TaskTemplate.ContainerSpec.Configs 0 ).ConfigName }}'
# check amp-86
# go to prometheus: alerts.local.appcelerator.io
# wait for an alert to fire (you will have to trigger it, that's an exercice for the reviewer)
```
![image](https://user-images.githubusercontent.com/11839374/33336389-a108939a-d424-11e7-9047-b9cddc231e56.png)
```
# go to alertmanager: alertmanager.local.appcelerator.io
# the alert should be there, check the link to the Prometheus alert (Source), it should point to Prometheus.
```
![image](https://user-images.githubusercontent.com/11839374/33336416-b30e904e-d424-11e7-96b0-9aafdd27d18c.png)

