### PR TITLE
allow aws credentials merged in .aws/config

### DIFF
--- a/cli/command/cluster/plugin.go
+++ b/cli/command/cluster/plugin.go
@@ -290,8 +290,11 @@ func (p *awsPlugin) Run(c cli.Interface, args []string, env map[string]string) e
 		// automatically attempt to mount aws credentials if present
 		awshome := path.Join(home, ".aws")
 		awscreds := path.Join(awshome, "credentials")
-		if _, err := os.Stat(awscreds); err != nil {
-			return fmt.Errorf("no $HOME/.aws/credentials found, please refer to http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html to configure it")
+		awsconfig := path.Join(awshome, "config")
+		_, errcreds := os.Stat(awscreds)
+		_, errconfig := os.Stat(awsconfig)
+		if errcreds != nil && errconfig != nil {
+			return fmt.Errorf("no credentials or config file found in $HOME/.aws/, please refer to http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html to configure your aws credentials, or check the help message on how to use credentials as arguments to the CLI")
 		}
 		dockerOpts.Volumes = append(dockerOpts.Volumes, fmt.Sprintf("%s:/root/.aws", awshome))
 	}


### PR DESCRIPTION
AMP-101

## Verification

1. non regression test
With a "normal" .aws config (aws_access_key_id and aws_secret_access_key in credentials, region in config), run:
```
make build-cli build-plugins
amp cluster create --provider aws --aws-stackname STACK_NAME --aws-parameter KeyName=KEY_PAIR
# It should start the deployment, Ctrl-C after a few seconds
amp cluster rm --provider aws --aws-stackname STACK_NAME
```

2. fix "config only" credentials config
backup your ~/.aws folder
modify it to merge all information from the credentials file into the config file.
Run the commands above once more.
```
make build-cli build-plugins
amp cluster create --provider aws --aws-stackname STACK_NAME --aws-parameter KeyName=KEY_PAIR
```
You can now restore your ~/.aws folder if needed