### PR TITLE
NFS dir init and NFS mount for acs

### DIFF
--- a/examples/stacks/apirs/apirs.stage2.yml
+++ b/examples/stacks/apirs/apirs.stage2.yml
@@ -56,3 +56,28 @@ services:
       - source: consul_kv
         target: /values.json
         mode: 0554
+
+  nfs-init:
+    image: alpine:3.6
+    networks:
+      - db
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: none
+      placement:
+        constraints:
+          - node.labels.amp.type.user == true
+    volumes:
+      - type: volume
+        source: nfs_init
+        target: /nfs
+    command: [ "mkdir", "-p", "/nfs/appc/arrowdb/photos", "/nfs/appc/arrowdb/files", "/nfs/appc/arrowdb/exports" ]
+
+volumes:
+  nfs_init:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/
+      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2

--- a/examples/stacks/apirs/apirs.stage3.yml
+++ b/examples/stacks/apirs/apirs.stage3.yml
@@ -18,6 +18,16 @@ services:
       placement:
         constraints:
           - node.labels.amp.type.user == true
+    volumes:
+      - type: volume
+        source: arrowdb_photos
+        target: /opt/appcelerator/acs-api/public/photos
+      - type: volume
+        source: arrowdb_files
+        target: /opt/appcelerator/acs-api/public/file
+      - type: volume
+        source: arrowdb_exports
+        target: /opt/appcelerator/acs-api/public/exports
     environment:
       CONSUL: consul
       SERVICE_PORTS: 8082
@@ -151,3 +161,23 @@ services:
       - bash
       - start-with-consul.sh
       - /harbor/harbor_ui
+
+volumes:
+  arrowdb_photos:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/arrowdb/photos
+      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
+  arrowdb_files:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/arrowdb/files
+      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
+  arrowdb_exports:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/arrowdb/exports
+      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2


### PR DESCRIPTION
Fix amp-82

Example on how to use the cluster NFS server with APIRS services.
Implemented with the acs service.
A new nfs-init service in stage2 creates the folders on the NFS server, so that it can be mounted by acs in stage3.

## How to run it

```
amp -k -s arrow.appcelerator.io cluster status
# get the NFS endpoint
export NFS_SERVER=xxx
amp -k -s arrow.appcelerator.io stack deploy  --with-registry-auth -c apirs.stage2.yml
amp -k -s arrow.appcelerator.io service ps apirs_nfs-init
[user ndegory @ arrow.appcelerator.io:50101]
ID                          NAME               IMAGE        DESIRED STATE   CURRENT STATE   NODE ID                     ERROR
k9of3wd5datct8ts8yj31z9x3   apirs_nfs-init.1   alpine:3.6   SHUTDOWN        COMPLETE        z4zndb6yav310zpdx4gqnbxca
# complete / shutdown means that the task is successfully done
amp -k -s arrow.appcelerator.io stack deploy  --with-registry-auth -c apirs.stage3.yml
amp -k -s arrow.appcelerator.io service ps apirs_acs
[user ndegory @ arrow.appcelerator.io:50101]
ID                          NAME              IMAGE                                                                                          DESIRED STATE   CURRENT STATE   NODE ID                     ERROR
o48l7sk43z1bv0jou1pu1m1uy   apirs_acs.1       services-registry.cloudapp-enterprise-preprod.appctest.com:5000/arrowcloud/arrowdb:1.6.0-sp2   RUNNING         RUNNING         yur74waq6qsxxipc2h5md46jz
```