### PR TITLE
CLI defaults to 127.0.0.1

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ type cli struct {
 
 const (
 	// DefaultAddress for amp connection
-	DefaultAddress = "localhost"
+	DefaultAddress = "127.0.0.1"
 
 	// DefaultPort for amp connection
 	DefaultPort = configuration.DefaultPort

--- a/tests/cli/gateway/auth_test.sh
+++ b/tests/cli/gateway/auth_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 amp -k login --name owner --password password
-TOKEN=$(cat ~/.config/amp/localhost.credentials)
+TOKEN=$(cat ~/.config/amp/127.0.0.1.credentials)
 curl -k --header "Authorization: amp $TOKEN" https://gw.local.appcelerator.io/v1/stacks | grep "{\"entries\":\[\]}"

--- a/tests/cli/settings/settings-cmd/settings_cmd_test.sh
+++ b/tests/cli/settings/settings-cmd/settings_cmd_test.sh
@@ -2,7 +2,7 @@
 
 # server address passed as command-line argument
 test_cli_config() {
-  echo $(amp -k settings) | grep -Eq "Settings file: none\s+[[:alpha:][:space:]]+: Server:\s+localhost"
+  echo $(amp -k settings) | grep -Eq "Settings file: none\s+[[:alpha:][:space:]]+: Server:\s+127.0.0.1"
 }
 
 # server address passed in local config

--- a/tests/cli/settings/token/token_test.sh
+++ b/tests/cli/settings/token/token_test.sh
@@ -5,7 +5,7 @@ test_setup() {
 }
 
 test_name() {
-  find $HOME/.config/amp -name 'localhost*'
+  find $HOME/.config/amp -name '127.0.0.1.credentials'
 }
 
 test_teardown() {


### PR DESCRIPTION
Fix AMP-116

On recent redhat systems, the CLI is unable to reach amplifier with localhost:50101.
Switching the default to 127.0.0.1 works.