### PR TITLE
Check local cluster creation prerequisites on Linux

### DIFF
--- a/cluster/plugin/local/main.go
+++ b/cluster/plugin/local/main.go
@@ -40,9 +40,11 @@ func initClient(cmd *cobra.Command, args []string) (err error) {
 }
 
 func create(cmd *cobra.Command, args []string) {
-	// docker swarn init --advertise-addr $interface
 	ctx := context.Background()
 
+	if err := plugin.CheckPrerequisites(opts); err != nil {
+		log.Fatal(err)
+	}
 	if err := plugin.EnsureSwarmExists(ctx, dockerClient, opts); err != nil {
 		log.Fatal(err)
 	}
@@ -52,6 +54,7 @@ func create(cmd *cobra.Command, args []string) {
 	if err := plugin.RunAgent(ctx, dockerClient, "install", opts); err != nil {
 		log.Fatal(err)
 	}
+
 	// use the info command to print json cluster info to stdout
 	info(cmd, args)
 }


### PR DESCRIPTION
This PR enables checking local cluster prerequisites on Linux.

## How to test
```
$ ampmake clean build
$ sudo sysctl -w vm.max_map_count=26214
vm.max_map_count = 26214
$ amp cluster create
[user owner @ localhost:50101]
2017/12/05 19:23:58 vm.max_map_count value is too low. Got: 26214, expected: >= 262144. Please check the documentation on local cluster deployment prerequisites
Error: exit status 1
```
