### PR TITLE
HA consul example for APIRS

### DIFF
--- a/examples/stacks/apirs/apirs.dashboard.json
+++ b/examples/stacks/apirs/apirs.dashboard.json
@@ -247,7 +247,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "mongodb_mongod_op_counters_total{instance=\"apirs_mongo\"}",
+              "expr": "rate(mongodb_mongod_op_counters_total{instance=\"apirs_mongo\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}",
@@ -258,7 +258,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "MongoDB Operations",
+          "title": "MongoDB Operations (per sec)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -296,7 +296,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Dashboard Row",
+      "title": "Mongo",
       "titleSize": "h6"
     },
     {
@@ -391,91 +391,82 @@
           "valueName": "current"
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": true,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": "${DS_PROMETHEUS}",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+          "fill": 1,
+          "id": 14,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
           },
-          "id": 7,
-          "interval": null,
+          "lines": true,
+          "linewidth": 1,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "expr": "consul_health_node_status",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "",
-              "refId": "A",
-              "step": 20
+              "legendFormat": "{{node}}",
+              "refId": "A"
             }
           ],
-          "thresholds": "0.1,0.9",
-          "title": "Consul Health Status",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Health Node Status",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-              "op": "=",
-              "text": "UNHEALTHY",
-              "value": "0"
-            },
-            {
-              "op": "=",
-              "text": "HEALTHY",
-              "value": "1"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
-          ],
-          "valueName": "current"
+          ]
         },
         {
           "cacheTimeout": null,
@@ -636,7 +627,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Dashboard Row",
+      "title": "Consul",
       "titleSize": "h6"
     },
     {
@@ -975,7 +966,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Dashboard Row",
+      "title": "Redis",
       "titleSize": "h6"
     }
   ],

--- a/examples/stacks/apirs/apirs.stage1.yml
+++ b/examples/stacks/apirs/apirs.stage1.yml
@@ -14,8 +14,31 @@ volumes:
   mongo-primary-db:
   mongo-secondary-db:
   mongo-arbiter-db:
-  consul-data:
+  consul-data-member-a:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/consul/a
+      o: addr=${NFS_SERVER},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
+  consul-data-member-b:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/consul/b
+      o: addr=${NFS_SERVER},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
+  consul-data-member-c:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/appc/consul/c
+      o: addr=${NFS_SERVER},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
   redis-data:
+  nfs_init:
+    driver: local
+    driver_opts:
+      type: nfs
+      device: :/
+      o: addr=${NFS_SERVER},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
 
 services:
   mongo-primary:
@@ -90,22 +113,83 @@ services:
         io.amp.metrics.port: "9104"
         io.amp.metrics.mode: "exporter"
 
-  consul:
-    image: consul:1.0.0
+  consul-member-a:
+    image: consul:1.0.1
     networks:
-      - backend
-      - db
-      - public
+      backend:
+        aliases:
+         - consul
+      db:
+        aliases:
+         - consul
+      public:
+        aliases:
+         - consul
     deploy:
       replicas: 1
       placement:
         constraints:
           - node.labels.amp.type.user == true
     volumes:
-      - consul-data:/consul/data
+      - consul-data-member-a:/consul/data
     environment:
       SERVICE_PORTS: 8500
       VIRTUAL_HOST: "https://consul.apirs.*,consul.apirs.*"
+      CONSUL_BIND_INTERFACE: "eth0"
+      CONSUL_CLIENT_INTERFACE: "eth0"
+    command: ["agent", "-server", "-client=0.0.0.0", "-ui", "-bootstrap-expect=3", "-retry-join=consul-member-b", "-retry-join=consul-member-c"]
+
+  consul-member-b:
+    image: consul:1.0.1
+    networks:
+      backend:
+        aliases:
+         - consul
+      db:
+        aliases:
+         - consul
+      public:
+        aliases:
+         - consul
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.amp.type.user == true
+    volumes:
+      - consul-data-member-b:/consul/data
+    environment:
+      SERVICE_PORTS: 8500
+      VIRTUAL_HOST: "https://consul.apirs.*,consul.apirs.*"
+      CONSUL_BIND_INTERFACE: "eth0"
+      CONSUL_CLIENT_INTERFACE: "eth0"
+    command: ["agent", "-server", "-client=0.0.0.0", "-ui", "-bootstrap-expect=3", "-retry-join=consul-member-b", "-retry-join=consul-member-c"]
+
+  consul-member-c:
+    image: consul:1.0.1
+    networks:
+      backend:
+        aliases:
+         - consul
+      db:
+        aliases:
+         - consul
+      public:
+        aliases:
+         - consul
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.amp.type.user == true
+    volumes:
+      - consul-data-member-c:/consul/data
+    environment:
+      SERVICE_PORTS: 8500
+      VIRTUAL_HOST: "https://consul.apirs.*,consul.apirs.*"
+      CONSUL_BIND_INTERFACE: "eth0"
+      CONSUL_CLIENT_INTERFACE: "eth0"
+    command: ["agent", "-server", "-client=0.0.0.0", "-ui", "-bootstrap-expect=3", "-retry-join=consul-member-b", "-retry-join=consul-member-c"]
 
   consul_exporter:
     image: prom/consul-exporter:v0.3.0
@@ -166,3 +250,21 @@ services:
 #      REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED: "false"
       SERVICE_PORTS: 5000
       VIRTUAL_HOST: "registry.apirs.*,https://registry.apirs.*"
+
+  nfs-init:
+    image: alpine:3.7
+    networks:
+      - db
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: none
+      placement:
+        constraints:
+          - node.labels.amp.type.user == true
+    volumes:
+      - type: volume
+        source: nfs_init
+        target: /nfs
+    command: [ "mkdir", "-p", "/nfs/appc/consul/a", "/nfs/appc/consul/b", "/nfs/appc/consul/c",  "/nfs/appc/arrowdb/photos", "/nfs/appc/arrowdb/files", "/nfs/appc/arrowdb/exports" ]
+

--- a/examples/stacks/apirs/apirs.stage2.yml
+++ b/examples/stacks/apirs/apirs.stage2.yml
@@ -38,7 +38,7 @@ services:
         mode: 0554
 
   consul-init:
-    image: consul:1.0.0
+    image: consul:1.0.1
     networks:
       - db
     deploy:
@@ -56,28 +56,3 @@ services:
       - source: consul_kv
         target: /values.json
         mode: 0554
-
-  nfs-init:
-    image: alpine:3.6
-    networks:
-      - db
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: none
-      placement:
-        constraints:
-          - node.labels.amp.type.user == true
-    volumes:
-      - type: volume
-        source: nfs_init
-        target: /nfs
-    command: [ "mkdir", "-p", "/nfs/appc/arrowdb/photos", "/nfs/appc/arrowdb/files", "/nfs/appc/arrowdb/exports" ]
-
-volumes:
-  nfs_init:
-    driver: local
-    driver_opts:
-      type: nfs
-      device: :/
-      o: addr=${NFS_SERVER:-fs-0a000a00.efs.us-west-2.amazonaws.com},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2


### PR DESCRIPTION
Fix AMP-135

Consul cluster with 3 members, with local data persistency.
Consul by default runs in dev mode without persistency. Changing the command to set it to production mode (allowing persistency in the mounted volume). HA is implemented with 3 services (member-a, member-b and member-c) with a single replica each but sharing the same service alias (consul). Each member has a dedicated volume on the NFS server.

Updated sample dashboards.

![image](https://user-images.githubusercontent.com/11839374/34017772-f1669512-e0db-11e7-962c-2aa9b9a1eba3.png)
