### PR TITLE
[tls.1] Fix Docker client pkg for remote connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - sudo modprobe ip_vs ip_vs_rr
   - docker swarm init --advertise-addr 127.0.0.1
   - docker secret create amplifier_yml tests/test.amplifier.yml
-  - amp cluster create --local-no-metrics
+  - amp cluster create
 # Tests: CLI
   - sudo apt-get install pcregrep
   - sudo mkdir -p $HOME/.config/amp

--- a/cluster/ampagent/Dockerfile
+++ b/cluster/ampagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM appcelerator/alpine:3.7.0
 
 COPY defaults /defaults
 COPY stacks /stacks

--- a/cluster/ampagent/cmd/checks.go
+++ b/cluster/ampagent/cmd/checks.go
@@ -39,10 +39,6 @@ func Checks(cmd *cobra.Command, args []string) error {
 	if !checksOpts.version && !checksOpts.labels && !checksOpts.scheduling {
 		checksOpts.all = true
 	}
-	Docker = ampdocker.NewEnvClient()
-	if err := Docker.Connect(); err != nil {
-		return err
-	}
 	if checksOpts.version || checksOpts.all {
 		if err := VerifyDockerVersion(); err != nil {
 			log.Println("Version test: FAIL")

--- a/cluster/ampagent/cmd/install.go
+++ b/cluster/ampagent/cmd/install.go
@@ -36,7 +36,7 @@ type InstallOptions struct {
 }
 
 var InstallOpts = &InstallOptions{}
-var Docker = ampdocker.NewClient(ampdocker.DefaultURL, ampdocker.DefaultVersion)
+var Docker *ampdocker.Docker
 
 func NewInstallCommand() *cobra.Command {
 	installCmd := &cobra.Command{
@@ -49,6 +49,7 @@ func NewInstallCommand() *cobra.Command {
 }
 
 func Install(cmd *cobra.Command, args []string) error {
+	Docker = ampdocker.NewEnvClient()
 	stdin, stdout, stderr := term.StdStreams()
 	dockerCli := ampdocker.NewDockerCli(stdin, stdout, stderr)
 	if err := Docker.Connect(); err != nil {
@@ -84,6 +85,7 @@ func Install(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	log.Printf("Deploying in %s mode\n", deploymentMode)
 
 	stackFiles, err := getStackFiles("./stacks", deploymentMode)
 	if err != nil {

--- a/cluster/ampagent/cmd/install.go
+++ b/cluster/ampagent/cmd/install.go
@@ -11,14 +11,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"docker.io/go-docker"
 	"docker.io/go-docker/api/types"
-	"docker.io/go-docker/api/types/filters"
 	"github.com/appcelerator/amp/docker/cli/cli/command"
 	"github.com/appcelerator/amp/docker/cli/cli/command/stack"
-	"github.com/appcelerator/amp/docker/cli/opts"
 	"github.com/appcelerator/amp/docker/docker/pkg/term"
 	ampdocker "github.com/appcelerator/amp/pkg/docker"
 	"github.com/spf13/cobra"
@@ -36,7 +33,6 @@ type InstallOptions struct {
 }
 
 var InstallOpts = &InstallOptions{}
-var Docker *ampdocker.Docker
 
 func NewInstallCommand() *cobra.Command {
 	installCmd := &cobra.Command{
@@ -49,12 +45,8 @@ func NewInstallCommand() *cobra.Command {
 }
 
 func Install(cmd *cobra.Command, args []string) error {
-	Docker = ampdocker.NewEnvClient()
 	stdin, stdout, stderr := term.StdStreams()
 	dockerCli := ampdocker.NewDockerCli(stdin, stdout, stderr)
-	if err := Docker.Connect(); err != nil {
-		return err
-	}
 
 	// Create initial secrets
 	createInitialSecrets()
@@ -322,119 +314,6 @@ func createInitialNetworks() error {
 			return err
 		}
 		log.Println("Successfully created network:", network)
-	}
-	return nil
-}
-
-func removeInitialNetworks() error {
-	for _, network := range ampnetworks {
-		// Check if network already exists
-		id, err := Docker.NetworkID(network)
-		if err != nil {
-			return err
-		}
-		if id == "" {
-			continue // Skipping non existent network
-		}
-
-		// Remove network
-		if err := Docker.RemoveNetwork(id); err != nil {
-			return err
-		}
-		log.Printf("Successfully removed network %s [%s]", network, id)
-	}
-	return nil
-}
-
-func removeExitedContainers(timeout int) error {
-	i := 0
-	dontKill := []string{"amp-agent", "amp-local"}
-	var containers []types.Container
-	if timeout == 0 {
-		timeout = 30 // default value
-	}
-	log.Println("waiting for all services to clear up...")
-	filter := filters.NewArgs()
-	filter.Add("is-task", "true")
-	filter.Add("label", "io.amp.role=infrastructure")
-	for i < timeout {
-		containers, err := Docker.GetClient().ContainerList(context.Background(), types.ContainerListOptions{All: true, Filters: filter})
-		if err != nil {
-			return err
-		}
-		if len(containers) == 0 {
-			log.Println("cleared up")
-			break
-		}
-		for _, c := range containers {
-			switch c.State {
-			case "exited":
-				log.Printf("Removing container %s [%s]\n", c.Names[0], c.Status)
-				err := Docker.GetClient().ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{})
-				if err != nil {
-					if strings.Contains(err.Error(), "already in progress") {
-						continue // leave it to Docker
-					}
-					return err
-				}
-			case "removing", "running":
-				// ignore it, _running_ containers will be killed after the loop
-				// _removing_ containers are in progress of deletion
-			default:
-				// this is not expected
-				log.Printf("Container %s found in status %s, %s\n", c.Names[0], c.Status, c.State)
-			}
-		}
-		i++
-		time.Sleep(1 * time.Second)
-	}
-	containers, err := Docker.GetClient().ContainerList(context.Background(), types.ContainerListOptions{All: true, Filters: filter})
-	if err != nil {
-		return err
-	}
-	if i == timeout {
-		log.Println("timing out")
-		log.Printf("%d containers left\n", len(containers))
-	}
-	//
-	for _, c := range containers {
-		for _, e := range dontKill {
-			if strings.Contains(c.Names[0], e) {
-				continue
-			}
-		}
-		log.Printf("Force removing container %s [%s]", c.Names[0], c.State)
-		if err := Docker.GetClient().ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
-			if strings.Contains(err.Error(), "already in progress") {
-				continue // leave it to Docker
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-const ampVolumesPrefix = "amp_"
-
-func removeVolumes(timeout int) error {
-	// volume remove timeout (sec)
-	if timeout == 0 {
-		timeout = 5 // default value
-	}
-	// List amp volumes
-	filter := opts.NewFilterOpt()
-	filter.Set("name=" + ampVolumesPrefix)
-	volumes, err := Docker.ListVolumes(filter)
-	if err != nil {
-		return nil
-	}
-	// Remove volumes
-	for _, volume := range volumes {
-		log.Printf("Removing volume [%s]... ", volume.Name)
-		if err := Docker.RemoveVolume(volume.Name, false, timeout); err != nil {
-			log.Println("Failed")
-			return err
-		}
 	}
 	return nil
 }

--- a/cluster/ampagent/cmd/root.go
+++ b/cluster/ampagent/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	ampdocker "github.com/appcelerator/amp/pkg/docker"
+	"github.com/spf13/cobra"
+)
+
+var Docker *ampdocker.Docker
+
+func NewRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:               "ampctl",
+		PersistentPreRunE: Init,
+		RunE:              Root,
+		Short:             "Run commands in target amp cluster",
+	}
+
+	return rootCmd
+}
+func Init(cmd *cobra.Command, args []string) error {
+	Docker = ampdocker.NewEnvClient()
+	return Docker.Connect()
+}
+
+func Root(cmd *cobra.Command, args []string) error {
+	// perform checks and install by default when no sub-command is specified
+	if err := Checks(cmd, []string{}); err != nil {
+		return err
+	}
+	return Install(cmd, args)
+}

--- a/cluster/ampagent/cmd/uninstall.go
+++ b/cluster/ampagent/cmd/uninstall.go
@@ -17,6 +17,7 @@ func NewUninstallCommand() *cobra.Command {
 }
 
 func Uninstall(cmd *cobra.Command, args []string) error {
+	Docker = docker.NewEnvClient()
 	stdin, stdout, stderr := term.StdStreams()
 	dockerCli := docker.NewDockerCli(stdin, stdout, stderr)
 	if err := Docker.Connect(); err != nil {

--- a/cluster/ampagent/cmd/uninstall.go
+++ b/cluster/ampagent/cmd/uninstall.go
@@ -1,11 +1,21 @@
 package cmd
 
 import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"docker.io/go-docker/api/types"
+	"docker.io/go-docker/api/types/filters"
 	"github.com/appcelerator/amp/docker/cli/cli/command/stack"
+	"github.com/appcelerator/amp/docker/cli/opts"
 	"github.com/appcelerator/amp/docker/docker/pkg/term"
 	"github.com/appcelerator/amp/pkg/docker"
 	"github.com/spf13/cobra"
 )
+
+const ampVolumesPrefix = "amp_"
 
 func NewUninstallCommand() *cobra.Command {
 	uninstallCmd := &cobra.Command{
@@ -17,12 +27,8 @@ func NewUninstallCommand() *cobra.Command {
 }
 
 func Uninstall(cmd *cobra.Command, args []string) error {
-	Docker = docker.NewEnvClient()
 	stdin, stdout, stderr := term.StdStreams()
 	dockerCli := docker.NewDockerCli(stdin, stdout, stderr)
-	if err := Docker.Connect(); err != nil {
-		return err
-	}
 
 	namespace := "amp"
 	if len(args) > 0 {
@@ -47,4 +53,115 @@ func Uninstall(cmd *cobra.Command, args []string) error {
 	}
 
 	return removeInitialNetworks()
+}
+
+func removeExitedContainers(timeout int) error {
+	i := 0
+	dontKill := []string{"amp-agent", "amp-local"}
+	var containers []types.Container
+	if timeout == 0 {
+		timeout = 30 // default value
+	}
+	log.Println("waiting for all services to clear up...")
+	filter := filters.NewArgs()
+	filter.Add("is-task", "true")
+	filter.Add("label", "io.amp.role=infrastructure")
+	for i < timeout {
+		containers, err := Docker.GetClient().ContainerList(context.Background(), types.ContainerListOptions{All: true, Filters: filter})
+		if err != nil {
+			return err
+		}
+		if len(containers) == 0 {
+			log.Println("cleared up")
+			break
+		}
+		for _, c := range containers {
+			switch c.State {
+			case "exited":
+				log.Printf("Removing container %s [%s]\n", c.Names[0], c.Status)
+				err := Docker.GetClient().ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{})
+				if err != nil {
+					if strings.Contains(err.Error(), "already in progress") {
+						continue // leave it to Docker
+					}
+					return err
+				}
+			case "removing", "running":
+				// ignore it, _running_ containers will be killed after the loop
+				// _removing_ containers are in progress of deletion
+			default:
+				// this is not expected
+				log.Printf("Container %s found in status %s, %s\n", c.Names[0], c.Status, c.State)
+			}
+		}
+		i++
+		time.Sleep(1 * time.Second)
+	}
+	containers, err := Docker.GetClient().ContainerList(context.Background(), types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return err
+	}
+	if i == timeout {
+		log.Println("timing out")
+		log.Printf("%d containers left\n", len(containers))
+	}
+	//
+	for _, c := range containers {
+		for _, e := range dontKill {
+			if strings.Contains(c.Names[0], e) {
+				continue
+			}
+		}
+		log.Printf("Force removing container %s [%s]", c.Names[0], c.State)
+		if err := Docker.GetClient().ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
+			if strings.Contains(err.Error(), "already in progress") {
+				continue // leave it to Docker
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func removeInitialNetworks() error {
+	for _, network := range ampnetworks {
+		// Check if network already exists
+		id, err := Docker.NetworkID(network)
+		if err != nil {
+			return err
+		}
+		if id == "" {
+			continue // Skipping non existent network
+		}
+
+		// Remove network
+		if err := Docker.RemoveNetwork(id); err != nil {
+			return err
+		}
+		log.Printf("Successfully removed network %s [%s]", network, id)
+	}
+	return nil
+}
+
+func removeVolumes(timeout int) error {
+	// volume remove timeout (sec)
+	if timeout == 0 {
+		timeout = 5 // default value
+	}
+	// List amp volumes
+	filter := opts.NewFilterOpt()
+	filter.Set("name=" + ampVolumesPrefix)
+	volumes, err := Docker.ListVolumes(filter)
+	if err != nil {
+		return nil
+	}
+	// Remove volumes
+	for _, volume := range volumes {
+		log.Printf("Removing volume [%s]... ", volume.Name)
+		if err := Docker.RemoveVolume(volume.Name, false, timeout); err != nil {
+			log.Println("Failed")
+			return err
+		}
+	}
+	return nil
 }

--- a/cluster/ampagent/main.go
+++ b/cluster/ampagent/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/appcelerator/amp/cluster/ampagent/cmd"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -18,18 +17,7 @@ var (
 
 func main() {
 	log.Printf("ampctl (version: %s, build: %s)\n", Version, Build)
-	rootCmd := &cobra.Command{
-		Use:   "ampctl",
-		Short: "Run commands in target amp cluster",
-		RunE: func(command *cobra.Command, args []string) error {
-			// perform checks and install by default when no sub-command is specified
-			if err := cmd.Checks(command, []string{}); err != nil {
-				return err
-			}
-			return cmd.Install(command, args)
-		},
-	}
-
+	rootCmd := cmd.NewRootCommand()
 	rootCmd.AddCommand(cmd.NewChecksCommand())
 	rootCmd.AddCommand(cmd.NewInstallCommand())
 	rootCmd.AddCommand(cmd.NewUninstallCommand())

--- a/cmd/amplifier/main.go
+++ b/cmd/amplifier/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/appcelerator/amp/cmd/amplifier/server"
 	"github.com/appcelerator/amp/cmd/amplifier/server/configuration"
 	"github.com/appcelerator/amp/data/storage/etcd"
-	"github.com/appcelerator/amp/pkg/docker"
 	"github.com/appcelerator/amp/pkg/elasticsearch"
 	"github.com/appcelerator/amp/pkg/mail"
 	"github.com/appcelerator/amp/pkg/nats-streaming"
@@ -52,8 +51,6 @@ func main() {
 		EtcdEndpoints:    []string{etcd.DefaultEndpoint},
 		ElasticsearchURL: elasticsearch.DefaultURL,
 		NatsURL:          ns.DefaultURL,
-		DockerURL:        docker.DefaultURL,
-		DockerVersion:    docker.DefaultVersion,
 		Registration:     configuration.RegistrationDefault,
 		Notifications:    configuration.NotificationsDefault,
 	}

--- a/cmd/amplifier/server/configuration/configuration.go
+++ b/cmd/amplifier/server/configuration/configuration.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -32,8 +33,6 @@ type Configuration struct {
 	EtcdEndpoints    []string
 	ElasticsearchURL string
 	NatsURL          string
-	DockerURL        string
-	DockerVersion    string
 	JWTSecretKey     string `yaml:"JWTSecretKey"`
 	SUPassword       string `yaml:"SUPassword"`
 	EmailKey         string `yaml:"EmailKey"`
@@ -46,7 +45,7 @@ type Configuration struct {
 }
 
 func (c *Configuration) String() string {
-	return fmt.Sprintf("Version: %s\nBuild: %s\nPort: %s\nH1Port: %s\nEtcdEndpoints: %v\nElasticsearchURL: %s\nNatsURL: %s\nDockerURL: %s\nDockerVersion: %s\nRegistration: %s\nNotifications: %v\n", c.Version, c.Build, c.Port, c.H1Port, c.EtcdEndpoints, c.ElasticsearchURL, c.NatsURL, c.DockerURL, c.DockerVersion, c.Registration, c.Notifications)
+	return fmt.Sprintf("Version: %s\nBuild: %s\nPort: %s\nH1Port: %s\nEtcdEndpoints: %v\nElasticsearchURL: %s\nNatsURL: %s\nDockerURL: %s\nDockerTLSVerify: %s\nRegistration: %s\nNotifications: %v\n", c.Version, c.Build, c.Port, c.H1Port, c.EtcdEndpoints, c.ElasticsearchURL, c.NatsURL, os.Getenv("DOCKER_HOST"), os.Getenv("DOCKER_TLS_VERIFY"), c.Registration, c.Notifications)
 }
 
 // ReadConfig reads the configuration file

--- a/cmd/amplifier/server/server.go
+++ b/cmd/amplifier/server/server.go
@@ -90,7 +90,7 @@ func New(config *configuration.Configuration) (*Amplifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	docker := docker.NewClient(config.DockerURL, config.DockerVersion)
+	docker := docker.NewEnvClient()
 	if err := docker.Connect(); err != nil {
 		return nil, err
 	}

--- a/pkg/docker/cli.go
+++ b/pkg/docker/cli.go
@@ -4,16 +4,27 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/appcelerator/amp/docker/cli/cli/command"
 	"github.com/appcelerator/amp/docker/cli/cli/flags"
+
+	"github.com/docker/go-connections/tlsconfig"
 )
 
 func NewDockerCli(stdin io.ReadCloser, stdout, stderr io.Writer) *command.DockerCli {
 	d := command.NewDockerCli(stdin, stdout, stderr)
 	opts := flags.NewClientOptions()
 	opts.Common = flags.NewCommonOptions()
+	if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); dockerCertPath != "" {
+		opts.Common.TLSOptions = &tlsconfig.Options{
+			CAFile:   filepath.Join(dockerCertPath, flags.DefaultCaFile),
+			CertFile: filepath.Join(dockerCertPath, flags.DefaultCertFile),
+			KeyFile:  filepath.Join(dockerCertPath, flags.DefaultKeyFile),
+		}
+	}
+	opts.Common.TLSVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
 	d.Initialize(opts)
 	return d
 }


### PR DESCRIPTION
This PR is required for _Protected socket on manager nodes_

- fixes in pkg/docker package to allow connection with TLS options. This will be used in a subsequent PR by amplifier and prometheus.

## Verification

automated build