### PR TITLE
[tls.2] Docker socket protected with TLS

### DIFF
--- a/examples/clusters/README.md
+++ b/examples/clusters/README.md
@@ -37,7 +37,10 @@ Once the nodes are up and running, it will run the appcelerator/ampadmin image t
 | DockerChannel | channel for Docker installation | stable | edge |
 | DockerPlugins | space separated list of plugins to install | | rexray/ebs |
 | InstallApplication | install AMP | yes | no |
+| NFSEndpoint | enable a NFSv4 service inside the VPC | no | yes |
 | EnableSystemPrune | Enable Docker system prune | yes | no |
+| MonitoringPort | Public port for the dashboard | 8080 | |
+| EnableTLS | Docker socket secured with TLS | yes | |
 
 ## Output
 
@@ -47,8 +50,12 @@ The output of the stack lists the DNS name of the ELB in front of the manager no
 | --------- | ----------- |
 | VpcId | VPC ID |
 | DNSTarget | public facing endpoint for the cluster, It can be used for ssh access, https access to swarm services and configuration of the remote server in the CLI |
+| InternalDockerHost | Docker host for services requiring access to the secured API |
 | InternalRegistryTarget | internal endpoint for the registry service |
 | MetricsURL | URL for cluster health dashboard |
+| NFSEndpoint | NFSv4 Endpoint |
+| InternalPKITarget | internal endpoint for the PKI service |
+
 
 ## Custom AMI
 
@@ -69,3 +76,77 @@ An option of the template is the inclusion of a Docker registry.
 It includes a S3 bucket as registry backend, and an autoscaling group of registry containers.
 The registry is composed of non swarm nodes and is not part of the swarm.
 The registry is only available from the VPC, all Docker swarm nodes are configured with the internal endpoint of the registry as mirror registry.
+
+## Docker socket protected with TLS
+
+When the EnableTLS option is set to yes, all swarm nodes are started with a certificate to protect the Docker socket. It is then available on port 2376 (instead of 2375 when not secured).
+An autoscaling group with a single instance runs a cfssl docker container that is providing a CA, and serves an API for certificate generation. It is used by all the nodes to get the server certificate (for the Docker daemon) and a client certificate (for the Docker CLI).
+The Manager external ELB has a listener on port 2376 that allows external access to the Docker engine API on the manager nodes (round robin). This is by default blocked by the security group, but can be open for a range of IP if a direct access is needed.
+To be able to authenticate, you need the CA certificate, a key and a certificate. This is served by the cfssl container, but is not available from outside of the VPC (for security reason). This can be implemented as an AMP API, that would offer the interfaces with the PKS, generating and providing these 3 pem files to a client, with the added value of authorization. The API is not yet implemented.
+
+#### Using the client certificate on a node of the swarm
+
+Services can use the certificate available on the swarm. For instance, core services requiring access to the API on manager node can be scheduled on non manager nodes, and use the client certificate to connect to the API on the manager node. For that, the service has to mount the certificate from the host.
+
+The certificate is available as well as its private key in /etc/docker: client.cert and client.key.
+
+#### How to get the pem files for a Docker client
+
+Identify the CA URL, it's the DNS name of the CA ELB. You can get it from the AWS console or from the status of the cluster (amp -s CLUSTER_URL cluster status). The URL should include the scheme.
+
+The procedure below can be done only if you open the PKS service outside of the VPC, this is done by adding a rule to the PKS security group (look for CASecurityGroup).
+
+From you client (usually a server from outside the swarm), do:
+```
+docker run --rm cfssl/cfssl:latest info -remote=CA_URL | jq -r .certificate
+```
+
+Paste the result on your machine in `~/.docker/ca.pem`.
+
+Then, prepare a JSON file with the CSR.
+
+```
+{
+    "CN": "USERNAME",
+    "hosts": [
+        "$(hostname)"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "Santa Clara",
+            "O": "Axway",
+            "OU": "AMP",
+            "ST": "California"
+        }
+    ]
+}
+```
+
+
+Submit the CSR and save the response:
+
+```
+docker run --rm -v $PWD/csr.json:/csr.json cfssl/cfssl:latest gencert -remote=CA_URL -profile client /csr.json > response.json
+```
+
+Extract the key on your machine:
+```
+jq -r .key < response.json > ~/.docker/client.cert
+```
+
+Extract the certificate on your machine:
+```
+jq -r .cert < response.json > ~/.docker/client.cert
+```
+
+You can now use the Docker CLI by setting these variables:
+```
+export DOCKER_TLS_VERIFY=1
+export DOCKER_HOST=MANAGER_EXTERNAL_ELB_DNS_NAME:2376
+docker info
+```

--- a/examples/clusters/aws-swarm-asg.yml
+++ b/examples/clusters/aws-swarm-asg.yml
@@ -8,27 +8,27 @@ Mappings:
     # N Virginia
     us-east-1:
       Ubuntu: ami-e4139df2
-      Default: ami-3f20a845
+      Default: ami-2a5f2a50
       Debian: ami-cb4b94dd
     # Ohio
     us-east-2:
       Ubuntu: ami-33ab8f56
-      Default: ami-dff6d8ba
+      Default: ami-db4c64be
       Debian: ami-c5ba9fa0
     # Oregon
     us-west-2:
       Ubuntu: ami-17ba2a77
-      Default: ami-bcf02dc4
+      Default: ami-f9cd6c81
       Debian: ami-fde96b9d
     # Ireland
     eu-west-1:
       Ubuntu: ami-b5a893d3
-      Default: ami-8fd463f6
+      Default: ami-2d7afe54
       Debian: ami-3291be54
     # Sydney
     ap-southeast-2:
       Ubuntu: ami-92e8e6f1
-      Default: ami-38b2585a
+      Default: ami-2afb0d48
       Debian: ami-0dcac96e
   VpcCidrs:
     subnet1:
@@ -96,6 +96,29 @@ Parameters:
     - r4.4xlarge
     ConstraintDescription: Must be a valid EC2 HVM instance type.
     Default: t2.small
+    Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
+  CAInstanceType:
+    Type: String
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - m3.medium
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    ConstraintDescription: Must be a valid EC2 HVM instance type.
+    Default: t2.nano
     Description: EC2 HVM instance type (t2.micro, m3.medium, etc)
   ManagerInstanceType:
     Type: String
@@ -202,6 +225,10 @@ Parameters:
     Type: String
     Description: Use the latest release version for the best result (a tag, e.g. 0.17.0)
     Default: latest
+  ApplicationOptions:
+    Type: String
+    Description: Extra parameters passed to the ampagent for core services deployment
+    Default: ""
   MirrorRegistry:
     Type: String
     Description: If yes, a mirror registry will be installed
@@ -229,12 +256,23 @@ Parameters:
     Default: 8080
     MinValue: 1025
     MaxValue: 32768
+  EnableTLS:
+    Type: String
+    Description: "Secure the Docker engine API for mutual auth"
+    AllowedValues:
+    - yes
+    Default: yes
+  TLSRotation:
+    Type: String
+    Description: "Expiration of Docker API certificates issued by the PKI"
+    Default: "168h"
 
 Conditions:
   InstallApplicationCond: !Or [ !Equals [ !Ref InstallApplication, "yes" ], !Equals [ !Ref InstallApplication, "true" ] ]
   EnableSystemPruneCond:  !Or [ !Equals [ !Ref EnableSystemPrune, "yes" ], !Equals [ !Ref EnableSystemPrune, "true" ] ]
   MirrorRegistryCond:     !Or [ !Equals [ !Ref MirrorRegistry, "yes" ], !Equals [ !Ref MirrorRegistry, "true" ] ]
   NFSEndpointCond:     !Or [ !Equals [ !Ref NFSEndpoint, "yes" ], !Equals [ !Ref NFSEndpoint, "true" ] ]
+  EnableTLSCond:          !Or [ !Equals [ !Ref EnableTLS,          "yes" ], !Equals [ !Ref EnableTLS,          "true" ] ]
 
 Resources:
   Vpc:
@@ -448,7 +486,7 @@ Resources:
     Properties:
       GroupDescription: Manager nodes security group
       SecurityGroupIngress:
-      # engine API open from all VPC
+      # http engine API open from all VPC
       - SourceSecurityGroupId:
           !Ref CoreSecurityGroup
         IpProtocol: tcp
@@ -518,6 +556,10 @@ Resources:
         IpProtocol: tcp
         FromPort: '443'
         ToPort: '443'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '2376'
+        ToPort: '2376'
       - CidrIp: 0.0.0.0/0
         IpProtocol: tcp
         FromPort: '50101'
@@ -699,6 +741,58 @@ Resources:
       IpProtocol: -1
       SourceSecurityGroupId:
         Ref: MetricsSecurityGroup
+
+  CAExtSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: Certificate Authority ELB security group
+      SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      VpcId:
+        Ref: Vpc
+
+  CASecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: InternetGateway
+    Properties:
+      GroupDescription: Certificate Authority security group
+      SecurityGroupIngress:
+      # all nodes to internal ELB
+      - CidrIp:
+          Fn::FindInMap:
+          - VpcCidrs
+          - vpc
+          - cidr
+        IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+      # internet facing ELB to CA intances
+      - SourceSecurityGroupId:
+          !Ref CAExtSecurityGroup
+        IpProtocol: tcp
+        FromPort: '8888'
+        ToPort: '8888'
+      VpcId:
+        Ref: Vpc
+  # internal ELB to CA instances
+  CASelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId:
+        Ref: CASecurityGroup
+      IpProtocol: tcp
+      FromPort: '8888'
+      ToPort: '8888'
+      SourceSecurityGroupId:
+        Ref: CASecurityGroup
 
   ClusterRole:
     Type: AWS::IAM::Role
@@ -920,6 +1014,130 @@ Resources:
         Enabled: 'true'
         Timeout: '60'
 
+  CAWaitHandle:
+    Type: "AWS::CloudFormation::WaitConditionHandle"
+    Condition: EnableTLSCond
+
+  CAWaitCondition:
+    Type: "AWS::CloudFormation::WaitCondition"
+    Condition: EnableTLSCond
+    DependsOn: CAAutoScalingGroup
+    Properties:
+      Handle: !Ref CAWaitHandle
+      Timeout: 420
+      Count: 1
+
+  CAAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Condition: EnableTLSCond
+    DependsOn:
+      - PublicSubnet1
+      - PublicSubnet2
+      - PublicSubnet3
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
+        PauseTime: PT30S
+        WaitOnResourceSignals: false
+    Properties:
+      DesiredCapacity: 1
+      HealthCheckGracePeriod: 300
+      HealthCheckType: ELB
+      LoadBalancerNames:
+      - !Ref CAInternalELB
+      - !Ref CAExternalELB
+      LaunchConfigurationName: !Ref CAAsgLaunchConfig
+      MaxSize: 2
+      MinSize: 0
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value:
+          Fn::Join:
+          - '-'
+          - - Ref: AWS::StackName
+            - CA
+      - Key: amp.clusterid
+        PropagateAtLaunch: true
+        Value: !Ref AWS::StackName
+      VPCZoneIdentifier:
+      - !Ref PublicSubnet1
+  CAAsgLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Condition: EnableTLSCond
+    DependsOn:
+      - CAWaitHandle
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref ClusterInstanceProfile
+      ImageId:
+        Fn::FindInMap:
+        - AMI
+        - Ref: AWS::Region
+        - Ref: LinuxDistribution
+      InstanceType: !Ref CAInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+        - Ref: CASecurityGroup
+      UserData:
+        Fn::Base64:
+          !Sub
+            - |
+              #cloud-config
+              repo_update: false
+              repo_upgrade: none
+              runcmd:
+                - curl -sf ${ConfigurationURL}/userdata-aws-ca -o /usr/local/bin/userdata-aws-ca && chmod +x /usr/local/bin/userdata-aws-ca || true
+                - SYSTEM_PRUNE="${EnableSystemPrune}" SYNC=true SIGNAL_URL="${CAWaitHandle}" CHANNEL="stable" PLUGINS="rexray/ebs" REGION=${AWS::Region} STACK_ID="${AWS::StackId}" STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-ca || shutdown -h
+            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
+  CAInternalELB:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Condition: EnableTLSCond
+    Properties:
+      Scheme: internal
+      Subnets:
+        - !Ref PublicSubnet1
+      SecurityGroups:
+        - Ref: CASecurityGroup
+      CrossZone: true
+      Listeners:
+      - LoadBalancerPort: '80'
+        InstancePort: '8888'
+        Protocol: HTTP
+        InstanceProtocol: HTTP
+      HealthCheck:
+        Target: HTTP:8888/
+        HealthyThreshold: 2
+        UnhealthyThreshold: 3
+        Interval: 30
+        Timeout: 5
+      ConnectionDrainingPolicy:
+        Enabled: 'true'
+        Timeout: '60'
+  CAExternalELB:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Condition: EnableTLSCond
+    Properties:
+      Scheme: internet-facing
+      Subnets:
+        - !Ref PublicSubnet1
+      SecurityGroups:
+        - Ref: CAExtSecurityGroup
+      CrossZone: true
+      Listeners:
+      - LoadBalancerPort: '22'
+        InstancePort: '22'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '80'
+        InstancePort: '8888'
+        Protocol: HTTP
+        InstanceProtocol: HTTP
+      ConnectionDrainingPolicy:
+        Enabled: 'true'
+        Timeout: '60'
+
   CoreWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
 
@@ -1003,8 +1221,8 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
-            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
+                - SYNC=true CA_URL="${CADnsName}" SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${CoreWaitHandle}" LABELS="amp.type.metrics=true amp.type.api=true amp.type.core=true amp.type.mq=true amp.type.kv=true amp.type.search=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
+            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], CADnsName: !If [ EnableTLSCond, !Join ["", ["http://", !GetAtt CAInternalELB.DNSName]], "" ] }
 
   UserWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -1089,8 +1307,8 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-worker -o /usr/local/bin/userdata-aws-worker && chmod +x /usr/local/bin/userdata-aws-worker || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
-            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ] }
+                - SYNC=true CA_URL="${CADnsName}" SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${UserWaitHandle}" LABELS="amp.type.user=true" CHANNEL="stable" PLUGINS="${DockerPlugins}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} DOCKER_DEVICE=/dev/sdl LEADER=${ManagerInternalELB.DNSName} MIRROR_REGISTRIES="${RegistryDnsName}" /usr/local/bin/userdata-aws-worker || shutdown -h
+            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], CADnsName: !If [ EnableTLSCond, !Join ["", ["http://", !GetAtt CAInternalELB.DNSName]], "" ] }
 
   ApplicationWaitHandle:
     Type: "AWS::CloudFormation::WaitConditionHandle"
@@ -1124,6 +1342,7 @@ Resources:
       - PublicSubnet1
       - PublicSubnet2
       - PublicSubnet3
+      - CAWaitCondition
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1
@@ -1192,8 +1411,8 @@ Resources:
               repo_upgrade: none
               runcmd:
                 - curl -sf ${ConfigurationURL}/userdata-aws-manager -o /usr/local/bin/userdata-aws-manager && chmod +x /usr/local/bin/userdata-aws-manager || true
-                - SYNC=true SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" CHANNEL="stable" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" LABELS="amp.type.api=true amp.type.route=true amp.type.metrics=true" /usr/local/bin/userdata-aws-manager || shutdown -h
-            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], ApplicationSignalURL: !If [ InstallApplicationCond, !Ref ApplicationWaitHandle, "" ] }
+                - SYNC=true CA_URL="${CADnsName}" INTERNAL_LB="${ManagerInternalELB.DNSName}" EXTERNAL_LB="${ManagerExternalELB.DNSName}" SYSTEM_PRUNE="${EnableSystemPrune}" SIGNAL_URL="${ManagerWaitHandle}" APP_SIGNAL_URL="${ApplicationSignalURL}" APP_VERSION="${ApplicationVersion}" APP_OPTIONS="${ApplicationOptions}" CHANNEL="stable" PLUGINS="${DockerPlugins}" OVERLAY_NETWORKS="${OverlayNetworks}" REGION=${AWS::Region} STACK_NAME=${AWS::StackName} VPC_ID=${Vpc} CLUSTER_SIZE="${ManagerSize}+${CoreWorkerSize}+${UserWorkerSize}" MANAGER_SIZE=${ManagerSize} DRAIN_MANAGER=${DrainManager} DOCKER_DEVICE=/dev/sdl MIRROR_REGISTRIES="${RegistryDnsName}" LABELS="amp.type.route=true" /usr/local/bin/userdata-aws-manager || shutdown -h
+            - { RegistryDnsName: !If [ MirrorRegistryCond, !Join ["", ["http://", !GetAtt RegistryInternalELB.DNSName]], "" ], ApplicationSignalURL: !If [ InstallApplicationCond, !Ref ApplicationWaitHandle, "" ], CADnsName: !If [ EnableTLSCond, !Join ["", ["http://", !GetAtt CAInternalELB.DNSName]], "" ] }
   ManagerInternalELB:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -1210,12 +1429,16 @@ Resources:
         InstancePort: '2375'
         Protocol: TCP
         InstanceProtocol: TCP
+      - LoadBalancerPort: '2376'
+        InstancePort: '2376'
+        Protocol: TCP
+        InstanceProtocol: TCP
       - LoadBalancerPort: '2377'
         InstancePort: '2377'
         Protocol: TCP
         InstanceProtocol: TCP
       HealthCheck:
-        Target: TCP:2375
+        Target: !Join [ ":", [ "TCP", !If [ EnableTLSCond, "2376", "2375" ] ] ]
         HealthyThreshold: 3
         UnhealthyThreshold: 5
         Interval: 30
@@ -1246,6 +1469,10 @@ Resources:
         InstanceProtocol: TCP
       - LoadBalancerPort: '443'
         InstancePort: '443'
+        Protocol: TCP
+        InstanceProtocol: TCP
+      - LoadBalancerPort: '2376'
+        InstancePort: '2376'
         Protocol: TCP
         InstanceProtocol: TCP
       - LoadBalancerPort: !Ref MonitoringPort
@@ -1356,11 +1583,15 @@ Metadata:
       - AufsVolumeSize
       - OverlayNetworks
       - EnableSystemPrune
+      - EnableTLS
+      - TLSRotation
+      - CAInstanceType
     - Label:
         default: AMP deployment
       Parameters:
       - InstallApplication
       - ApplicationVersion
+      - ApplicationOptions
     ParameterLabels:
       KeyName:
         default: Which SSH key to use?
@@ -1391,7 +1622,9 @@ Metadata:
       InstallApplication:
         default: Install Application
       ApplicationVersion:
-        default: Application Version
+        default: AMP Version
+      ApplicationOptions:
+        default: AMP Deployment Options
       EnableSystemPrune:
         default: Enable System Prune
       MirrorRegistry:
@@ -1400,13 +1633,33 @@ Metadata:
         default: Shared File System
       RegistryInstanceType:
         default: Registry instance type?
+      RegistryInstanceType:
+        default: PKI instance type?
       MonitoringPort:
         default: Monitoring Port
+      EnableTLS:
+        default: Enable TLS
+      TLSRotation:
+        default: TLS Rotation
 
 Outputs:
   DNSTarget:
     Description: public facing endpoint for the cluster
     Value: !GetAtt ManagerExternalELB.DNSName
+  InternalDockerHost:
+    Description: Docker host for services requiring access to the secured API
+    Value:
+      Fn::Join:
+        - ""
+        - - "tcp://"
+          - !GetAtt ManagerInternalELB.DNSName
+          - ":2376"
+  #PKITarget:
+    #Description: public facing endpoint for the PKI service
+    #Value: !If [ EnableTLSCond, !GetAtt CAExternalELB.DNSName, "disabled" ]
+  InternalPKITarget:
+    Description: internal endpoint for the PKI service
+    Value: !If [ EnableTLSCond, !GetAtt CAInternalELB.DNSName, "disabled" ]
   InternalRegistryTarget:
     Description: internal endpoint for the registry service
     Value: !If [ MirrorRegistryCond, !GetAtt RegistryInternalELB.DNSName, "disabled" ]

--- a/examples/clusters/build-ami.sh
+++ b/examples/clusters/build-ami.sh
@@ -7,7 +7,7 @@ REGIONS="us-east-1 us-east-2 us-west-2 eu-west-1 ap-southeast-2"
 OWNER=654814900965
 IMAGE_NAME=ubuntu-xenial-docker
 
-if [[ ! -f $HOME/.aws/credentials ]]; then
+if [[ ! -f $HOME/.aws/credentials && ! -f $HOME/.aws/config ]]; then
   echo "Please configure your aws credentials first"
   exit 1
 fi

--- a/examples/clusters/roles/ami/defaults/main.yml
+++ b/examples/clusters/roles/ami/defaults/main.yml
@@ -22,8 +22,8 @@ ec2_instance_type: "t2.small"
 iam_instance_profile: "amp-image-builder-role"
 
 ## Source AMI
-# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171116 in oregon
-ec2_ami: "ami-5dca1925"
+# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171121.1 in oregon
+ec2_ami: "ami-0def3275"
 
 ## Security Group
 # should open port 80 (and optionally port 22 for debugging)

--- a/examples/clusters/roles/ami/tasks/upload-userdata.yml
+++ b/examples/clusters/roles/ami/tasks/upload-userdata.yml
@@ -11,6 +11,12 @@
     object: "scripts/userdata-aws-worker"
     src: userdata-aws-worker
     mode: put
+- name: Upload PKS userdata
+  aws_s3:
+    bucket: "{{ s3_bucket }}"
+    object: "scripts/userdata-aws-ca"
+    src: userdata-aws-ca
+    mode: put
 - name: Upload registry userdata
   aws_s3:
     bucket: "{{ s3_bucket }}"

--- a/examples/clusters/roles/ami/templates/userdata.j2
+++ b/examples/clusters/roles/ami/templates/userdata.j2
@@ -34,11 +34,13 @@ runcmd:
   - export CHANNEL="{{docker_channel}}" ; wget -qO- "{{docker_url}}" | sh || _ko
   - if [ "x$_release" = "xUbuntu" ]; then usermod -G docker ubuntu 2>/dev/null ; fi
   - if [ "x$_release" = "xDebian" ]; then usermod -G docker admin  2>/dev/null ; fi
+  - docker pull appcelerator/cfssl:latest
   - echo "vm.max_map_count = 262144" > "/etc/sysctl.d/99-amp.conf" # prerequisite for elasticsearch
   - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-manager" /usr/local/bin/userdata-aws-manager || _ko
   - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-worker" /usr/local/bin/userdata-aws-worker || _ko
+  - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-ca" /usr/local/bin/userdata-aws-ca || _ko
   - aws s3 --region="{{ ec2_region }}" cp "s3://{{ s3_bucket }}/scripts/userdata-aws-registry" /usr/local/bin/userdata-aws-registry || _ko
-  - chmod u+x /usr/local/bin/userdata-aws-worker /usr/local/bin/userdata-aws-manager /usr/local/bin/userdata-aws-registry
+  - chmod u+x /usr/local/bin/userdata-aws-worker /usr/local/bin/userdata-aws-manager /usr/local/bin/userdata-aws-registry /usr/local/bin/userdata-aws-ca
   - echo "" > ~ubuntu/.ssh/authorized_keys
   - shred -u ~/.*history
   - _ok

--- a/examples/clusters/userdata-aws-ca
+++ b/examples/clusters/userdata-aws-ca
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+SYNC=${SYNC:-false}
+if [[ -z "$REGION" ]]; then
+  echo "region is required"
+  exit 1
+fi
+if [[ -z "$STACK_NAME" ]]; then
+  echo "stack name is required"
+  exit 1
+fi
+# Optional values
+PORT="${PORT:-8888}"
+IMAGE_NAME="${IMAGE_NAME:-appcelerator/cfssl}"
+IMAGE_VERSION="${IMAGE_VERSION:-dev-20171208}"
+CONTAINER_NAME="cfssl"
+VOLUME_NAME="${REGION}_${STACK_NAME}_${STACK_ID##*/}_PKS"
+#SIGNAL_URL=
+#PLUGINS=
+EXPIRY_DEFAULT=168h
+EXPIRY_SERVER="${EXPIRY_SERVER:-168h}"
+EXPIRY_CLIENT="${EXPIRY_CLIENT:-8760h}"
+
+_init_system(){
+  systemctl --version >/dev/null 2>&1 && echo systemd && return
+  [[ `/sbin/init --version` =~ upstart ]] && echo upstart && return
+  echo sysv
+} 
+
+_install_docker(){
+  local _release=$(lsb_release -is)
+  local _host
+  # on Debian style systems, this checks that docker-ce is installed
+  grep -A1 docker-ce /var/lib/dpkg/status | grep -q "installed$"
+  if [[ $? -ne 0 ]]; then
+    case $CHANNEL in
+    stable) _host="get.docker.com" ;;
+    edge|beta|test) _host="test.docker.com" ;;
+    experimental) _host="experimental.docker.com" ;;
+    *) return 1 ;;
+    esac
+    echo "installing Docker from $_host" >&2
+    wget -qO- "https://$_host/" | sh || return 1
+  fi
+  [[ "x$_release" = "xUbuntu" ]] && usermod -G docker ubuntu 2>/dev/null
+  [[ "x$_release" = "xDebian" ]] && usermod -G docker admin  2>/dev/null
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl enable docker.service
+    docker version -f {{.Server.Version}} &>/dev/null || systemctl start docker.service
+  else
+    chkconfig docker on
+    docker version -f {{.Server.Version}} &>/dev/null || service docker start
+  fi
+  docker version >&2
+}
+
+# generates a CA. Echoes filepath of CA key and filepath of CA cert
+#TODO: remove the need for openssl and use cfssl for the ca generation
+_gen_ca(){
+  which openssl >/dev/null || return 1
+
+  CAKEY=$(mktemp).pem
+  CACERT=$(mktemp).pem
+  KEYLEN=2048
+  # 10 years validity for the CA
+  EXPIRE=3560
+  CASUBJECT="/C=US/ST=California/L=Santa Clara/O=Axway/OU=AMP/CN=ca-$(hostname)"
+
+  openssl genrsa -out $CAKEY $KEYLEN
+  openssl req -new -x509 -days $EXPIRE -key $CAKEY -sha256 -out $CACERT -subj "$CASUBJECT"
+  echo $CAKEY $CACERT
+}
+
+_install_plugins() {
+  local plugin
+  local alias
+  local options
+  for plugin in $PLUGINS; do
+    options="${plugin#*#}"
+    [[ "x$options" = "x$plugin" ]] && options="" || options="${options//\#/ }"
+    plugin="${plugin%%#*}"
+    alias=${plugin#store/}
+    alias=${alias%:*}
+    docker plugin ls | grep -q "$plugin" && continue
+    docker plugin install "$plugin" $options --alias "$alias" --grant-all-permissions # || return 1
+  done
+  return 0
+}
+
+_set_live_restore(){
+  local _live_restore=${1:-true}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  case $_live_restore in
+    true|false) true;;
+    *) echo "_set_live_restore only accepts true or false"
+       return 1
+       ;;
+  esac
+  _tmp=$(mktemp)
+  echo "setting live restore" >&2
+  cat /etc/docker/daemon.json | jq ".\"live-restore\" = $_live_restore" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_set_log_rotation(){
+  local _max_size=${1:-10m}
+  local _max_file=${2:-3}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  _tmp=$(mktemp)
+  echo "setting log rotation" >&2
+  cat /etc/docker/daemon.json | jq ".\"log-opts\".\"max-size\" = \"$_max_size\" | .\"log-opts\".\"max-file\" = \"$_max_file\"" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_set_metrics_address(){
+  local _host=${1:-127.0.0.1}
+  local _port=${2:-9323}
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  # bridge is most probably 172.17.0.1
+  if [[ "$_host" = "bridge" ]]; then
+    _host=$(ip route show dev docker0 | sed 's/.*src \([0-9\.]*\).*/\1/')
+    [[ -z "$_host" ]] && _host=0.0.0.0
+  fi
+  _tmp=$(mktemp)
+  echo "setting the metrics address ($_host:$_port)" >&2
+  cat /etc/docker/daemon.json | jq ".\"metrics-addr\" = \"${_host}:${_port}\" | .experimental = true" > "$_tmp" || return 1
+  mv "$_tmp" /etc/docker/daemon.json
+}
+
+_restart_docker(){
+  echo "restarting Docker" >&2
+  if [[ $(_init_system) = "systemd" ]]; then
+    systemctl restart docker.service
+  else
+    service docker restart
+  fi
+}
+
+
+# creates a volume if it doesn't already exist
+# add the CA key and cert to the volume at creation
+_create_volume(){
+  local _driver_opts
+  local _key
+  local _cert
+  local _config
+  # check if the volume already exists, in which case we reuse it
+  docker volume ls -q --filter name=^${VOLUME_NAME}$ | grep -q "$VOLUME_NAME"
+  if [[ $? -eq 0 ]]; then
+    echo "volume $VOLUME_NAME already exist, no change applied"
+    echo "volumes seen on this node:"
+    docker volume ls
+    echo "inspect volume $VOLUME_NAME"
+    docker volume inspect "$VOLUME_NAME"
+    return 0
+  fi
+  docker plugin ls | grep -q "rexray/ebs"
+  if [[ $? -eq 0 ]]; then
+    _driver_opts="--driver rexray/ebs"
+  fi
+  echo "creating volume $VOLUME_NAME with ${_driver_opts:-local driver}"
+  docker volume create $_driver_opts "$VOLUME_NAME" || return 1
+  # create the configuration file
+  _config=$(mktemp) || return 1
+  cat > $_config <<EOF
+{
+    "signing": {
+        "default": {
+            "expiry": "$EXPIRY_DEFAULT"
+        },
+        "profiles": {
+            "server": {
+                "expiry": "$EXPIRY_SERVER",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "$EXPIRY_CLIENT",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}
+EOF
+  docker run -d --rm --name copyctr -v "$VOLUME_NAME:/data" alpine sleep 300 || return 1
+  read _key _cert <<< $(_gen_ca)
+  [[ ! -f $_key ]] && exit 1
+  [[ ! -f $_cert ]] && exit 1
+  docker cp $_key copyctr:/data/ca-key.pem || return 1
+  docker cp $_cert copyctr:/data/ca-cert.pem || return 1
+  docker cp $_config copyctr:/data/cfssl.conf || return 1
+  rm $_key $_cert $_config
+}
+
+# run the ssl service
+_serve(){
+  docker run -d --restart=always -p ${PORT}:${PORT} --name "${CONTAINER_NAME}" -v $VOLUME_NAME:/data ${IMAGE_NAME}:${IMAGE_VERSION} serve -config /data/cfssl.conf -address=0.0.0.0 -ca file:/data/ca-cert.pem -ca-key file:/data/ca-key.pem
+}
+
+_smoke_test(){
+  sleep 5
+  docker container ls --filter name=${CONTAINER_NAME} | grep -q Up && return 0
+  echo "smoke test failed, container ${CONTAINER_NAME} is not running"
+  docker ps -a
+  docker logs cfssl
+  return 1
+}
+
+_signal_aws() {
+  [[ "x$SYNC" != "xtrue" ]] && return 0
+  _url=$1
+  [[ -x /usr/local/bin/cfn-signal ]] || return 1
+  if [[ -z "$_url" ]]; then
+    echo "_signal_aws was called without any URL" >&2
+    return 1
+  fi
+  /usr/local/bin/cfn-signal --stack "${STACK_NAME}" --region "${REGION}" --success true "$_url"
+  return 0
+}
+
+_install_docker || exit 1
+_install_plugins || exit 1
+_set_live_restore || exit 1
+_set_log_rotation "10m" "3" || exit 1
+_set_metrics_address "bridge" "9323" || exit 1
+_restart_docker || exit 1
+_create_volume || exit 1
+_serve || exit 1
+_smoke_test || exit 1
+_signal_aws "${SIGNAL_URL}"

--- a/examples/clusters/userdata-aws-manager
+++ b/examples/clusters/userdata-aws-manager
@@ -17,8 +17,21 @@ DRAIN_MANAGER=${DRAIN_MANAGER:-false}
 #MIRROR_REGISTRIES=
 #DOCKER_DEVICE=/dev/sdl
 AMPAGENT_VERSION=${APP_VERSION:-latest}
+AMPAGENT_OPTIONS=${APP_OPTIONS}
+#INTERNAL_LB=
+#EXTERNAL_LB=
+# CA_URL=
+[[ -n "$CA_URL" ]] && FORCE_TLS=true || FORCE_TLS=false
+
 SYSTEMD_DOCKER_OVERRIDE=/etc/systemd/system/docker.service.d/docker.conf
 SYSV_DOCKER_DEFAULT=/etc/default/docker
+ENGINE_API_HTTP_PORT=2375
+ENGINE_API_TLS_PORT=2376
+[[ -n "$CA_URL" ]] && ENGINE_API_PORT=$ENGINE_API_TLS_PORT || ENGINE_API_PORT=$ENGINE_API_HTTP_PORT
+SERVER_CERT_DIR=/etc/docker/tls/server
+DOCKER_CERT_PATH=/etc/docker/tls/client
+CFSSL_IMAGE=appcelerator/cfssl
+CFSSL_VERSION=dev-20171208
 
 _init_system(){
   systemctl --version >/dev/null 2>&1 && echo systemd && return
@@ -62,10 +75,11 @@ _install_plugins(){
   local options
   for plugin in $PLUGINS; do
     options="${plugin#*#}"
-    [[ "x$options" = "x$plugin" ]] && options="" || options="${options//#/ }"
+    [[ "x$options" = "x$plugin" ]] && options="" || options="${options//\#/ }"
     plugin="${plugin%%#*}"
     alias=${plugin#store/}
     alias=${alias%:*}
+    docker plugin ls | grep -q "$plugin" && continue
     docker plugin install "$plugin" $options --alias "$alias" --grant-all-permissions # || return 1
   done
   return 0
@@ -80,8 +94,105 @@ _configure_system_prune(){
   (crontab -l 2>/dev/null; echo "$_cron_spec $_cmd") | crontab -
 }
 
+# get the CA cert and a new certificate for this node
+_gen_cert() {
+  [[ -z "$CA_URL" ]] && return 0
+  local _csr=certs/keyrequest.json
+  mkdir -p certs
+  mkdir -p $SERVER_CERT_DIR
+  if [[ ! -f $SERVER_CERT_DIR/ca.crt ]]; then
+    docker run --rm ${CFSSL_IMAGE}:${CFSSL_VERSION} info -remote=$CA_URL | jq -r .certificate > $SERVER_CERT_DIR/ca.crt
+  fi
+  if [[ ! -f $SERVER_CERT_DIR/server.key ]]; then
+    # prepare a csr for the server certificate
+    cat > $_csr << EOF
+{
+    "CN": "$(hostname)",
+    "hosts": [
+        "${INTERNAL_LB}",
+        "${EXTERNAL_LB}",
+        "$(hostname)",
+        "$(_get_node_ip)",
+        "localhost"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "Santa Clara",
+            "O": "Axway",
+            "OU": "AMP",
+            "ST": "California"
+        }
+    ]
+}
+EOF
+    docker run --rm -v $PWD/certs:/csr ${CFSSL_IMAGE}:${CFSSL_VERSION} gencert -remote=$CA_URL -profile server /csr/keyrequest.json > response.json || return 1
+    jq -r .cert < response.json > $SERVER_CERT_DIR/server.cert
+    jq -r .key < response.json > $SERVER_CERT_DIR/server.key
+    rm $_csr
+  fi
+  mkdir -p $DOCKER_CERT_PATH
+  if [[ ! -f $DOCKER_CERT_PATH/ca.crt ]]; then
+    cp -p $SERVER_CERT_DIR/ca.crt $DOCKER_CERT_PATH/ca.pem
+  fi
+  if [[ ! -f $DOCKER_CERT_PATH/key.pem ]]; then
+    # prepare a csr for the docker client certificate on this node
+    cat > $_csr << EOF
+{
+    "CN": "docker-client-$(hostname)",
+    "hosts": [
+        "$(hostname)"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "Santa Clara",
+            "O": "Axway",
+            "OU": "AMP",
+            "ST": "California"
+        }
+    ]
+}
+EOF
+    docker run --rm -v $PWD/certs:/csr ${CFSSL_IMAGE}:${CFSSL_VERSION} gencert -remote=$CA_URL -profile client /csr/keyrequest.json > response.json || return 1
+    jq -r .cert < response.json > $DOCKER_CERT_PATH/cert.pem
+    jq -r .key < response.json > $DOCKER_CERT_PATH/key.pem
+    rm $_csr
+  fi
+  # one last check on the content of the keys and certs
+  for f in $SERVER_CERT_DIR/ca.crt $SERVER_CERT_DIR/server.cert $SERVER_CERT_DIR/server.key $DOCKER_CERT_PATH/cert.pem $DOCKER_CERT_PATH/key.pem; do
+    echo "Checking integrity of $f"
+    grep -q -- '-----BEGIN' "$f" || return 1
+  done
+}
+
+# prepare the docker client for TLS connections
+_secure_client() {
+  [[ -z "$CA_URL" ]] && return 0
+  export DOCKER_CERT_PATH
+  export DOCKER_TLS_VERIFY=1
+}
+
 # expose the Docker remote api
 _expose_remote_api() {
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    echo "{}" > /etc/docker/daemon.json
+  fi
+  if [[ "x$FORCE_TLS" != x@(false|no) ]]; then
+    _tmp=$(mktemp)
+    echo "enabling TLS" >&2
+    cat /etc/docker/daemon.json | jq ".\"tls\" = true | .\"tlscacert\" = \"$SERVER_CERT_DIR/ca.crt\" | .\"tlscert\" = \"$SERVER_CERT_DIR/server.cert\" | .\"tlskey\" = \"$SERVER_CERT_DIR/server.key\" | .\"tlsverify\" = true" > "$_tmp" || return 1
+    mv "$_tmp" /etc/docker/daemon.json
+  fi
+  # host option can't be set in the daemon.json file, it would conflict with what is set in the service definition
   case $(_init_system) in
   systemd)
     mkdir -p "$(dirname $SYSTEMD_DOCKER_OVERRIDE)"
@@ -90,13 +201,13 @@ _expose_remote_api() {
     cat > "$SYSTEMD_DOCKER_OVERRIDE" <<EOF
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:2375 -H unix:///var/run/docker.sock
+ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:${ENGINE_API_PORT} -H unix://
 EOF
     systemctl daemon-reload
   ;;
   sysv)
     cat >> "$SYSV_DOCKER_DEFAULT" <<EOF
-DOCKER_OPTS='-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock'
+DOCKER_OPTS='-H tcp://0.0.0.0:${ENGINE_API_PORT} -H unix://'
 EOF
   ;;
   *)
@@ -278,7 +389,7 @@ _elect_leader(){
     for _node in $_ips; do
       sleep 1
       [[ "x$_node" = "x$_local_node" ]] && continue
-      _docker_version=$(docker -H "$_node:2375" version 2>/dev/null)
+      _docker_version=$(docker -H "$_node:$ENGINE_API_PORT" version 2>/dev/null)
       _not_ready=$((_not_ready+$?))
       [[ -z "$_docker_version" ]] && ((_not_ready++))
     done
@@ -287,7 +398,7 @@ _elect_leader(){
   echo "all manager nodes have an available Docker engine API ($SECONDS s)" >&2
   # look for an existing leader
   for _node in $_ips; do
-    _swarm_status=$(docker -H "$_node:2375" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
+    _swarm_status=$(docker -H "$_node:$ENGINE_API_PORT" node inspect self --format "{{ .ManagerStatus.Leader }}" 2>/dev/null)
     if [[ "x$_swarm_status" = "xtrue" ]]; then
       # we found a leader
       echo "found an established leader manager: $_node" >&2
@@ -316,7 +427,7 @@ _get_manager_join_token(){
   echo "retrieving the swarm manager token (will timeout after $_timeout s)" >&2
   SECONDS=0
   while [[ $SECONDS -lt $_timeout ]]; do
-    _token=$(docker -H "$_manager:2375" swarm join-token -q manager)
+    _token=$(docker -H "$_manager:$ENGINE_API_PORT" swarm join-token -q manager)
     if [[ $? -eq 0 && -n "$_token" ]]; then
       echo "manager token obtained ($SECONDS s)" >&2
       echo $_token
@@ -419,7 +530,7 @@ _signal_aws() {
 # wait for all nodes to be up and running (and labeled)
 _wait_for_full_swarm() {
   local _timeout=360
-  local _timeout_label=60
+  local _timeout_label=90
   local _label
   local _label_prefix="amp.type."
   local _labels="api route metrics mq kv search core user"
@@ -469,7 +580,13 @@ _wait_for_full_swarm() {
 }
 
 _setup() {
-  docker run --rm -v /var/run/docker:/var/run/docker -v /var/run/docker.sock:/var/run/docker.sock appcelerator/ampagent:${AMPAGENT_VERSION}
+  local _tls_opts
+  # AMP_HOST points to the manager load balancer, and can be used as a DOCKER_HOST env var in the stack files
+  [[ -n "$CA_URL" ]] && _tls_opts="-e AMP_HOST=tcp://${INTERNAL_LB}:${ENGINE_API_PORT} -e AMP_CERT_PATH=$DOCKER_CERT_PATH -e AMP_TLS_VERIFY=1 -v $DOCKER_CERT_PATH:/root/.docker"
+  # extra arguments can be passed to the cloudformation stack parameter ApplicationOptions
+  docker run --rm $_tls_opts \
+    -v /var/run/docker:/var/run/docker -v /var/run/docker.sock:/var/run/docker.sock \
+    appcelerator/ampagent:${AMPAGENT_VERSION} ${AMPAGENT_OPTIONS}
 }
 
 _sanity_check || exit 1
@@ -480,6 +597,8 @@ _system_prerequisites || exit 1
 nodeip=$(_get_node_ip)
 _install_docker || exit 1
 _install_plugins || exit 1
+_gen_cert || exit 1
+_secure_client || exit 1
 _expose_remote_api || exit 1
 _set_mirror_registries "$MIRROR_REGISTRIES" || exit 1
 _set_log_rotation "10m" "3" || exit 1

--- a/examples/clusters/userdata-aws-registry
+++ b/examples/clusters/userdata-aws-registry
@@ -14,6 +14,7 @@ SECRET=${SECRET:-F1Am4d9zE}
 PORT=${PORT:-5000}
 DEBUG_PORT=${DEBUG_PORT:=5001}
 REGISTRY_VERSION=${REGISTRY_VERSION:-2}
+CHANNEL=${CHANNEL:-stable}
 
 # make sure the prerequisites are already installed, install them in the other case
 which dpkg &>/dev/null

--- a/examples/clusters/userdata-aws-worker
+++ b/examples/clusters/userdata-aws-worker
@@ -13,6 +13,13 @@ VPC_ID=${VPC_ID:-unset}
 SYSTEMD_DOCKER_OVERRIDE=/etc/systemd/system/docker.service.d/docker.conf
 SYSV_DOCKER_DEFAULT=/etc/default/docker
 #LEADER=
+# CA_URL=
+ENGINE_API_HTTP_PORT=2375
+ENGINE_API_TLS_PORT=2376
+[[ -n "$CA_URL" ]] && ENGINE_API_PORT=$ENGINE_API_TLS_PORT || ENGINE_API_PORT=$ENGINE_API_HTTP_PORT
+DOCKER_CERT_PATH=/etc/docker/tls/client
+CFSSL_IMAGE=appcelerator/cfssl
+CFSSL_VERSION=dev-20171208
 
 _init_system(){
   systemctl --version >/dev/null 2>&1 && echo systemd && return
@@ -56,10 +63,11 @@ _install_plugins(){
   local options
   for plugin in $PLUGINS; do
     options="${plugin#*#}"
-    [[ "x$options" = "x$plugin" ]] && options="" || options="${options//#/ }"
+    [[ "x$options" = "x$plugin" ]] && options="" || options="${options//\#/ }"
     plugin="${plugin%%#*}"
     alias=${plugin#store/}
     alias=${alias%:*}
+    docker plugin ls | grep -q "$plugin" && continue
     docker plugin install "$plugin" $options --alias "$alias" --grant-all-permissions # || return 1
   done
   return 0
@@ -191,18 +199,75 @@ _set_metrics_address(){
   mv "$_tmp" /etc/docker/daemon.json
 }
 
+# get the CA cert and a new certificate for the client
+_gen_cert() {
+  [[ -z "$CA_URL" ]] && return 0
+  # prepare a csr
+  local _csr=certs/keyrequest.json
+  mkdir -p certs
+  mkdir -p $DOCKER_CERT_PATH
+  if [[ ! -f $DOCKER_CERT_PATH/ca.pem ]]; then
+    docker run --rm ${CFSSL_IMAGE}:${CFSSL_VERSION} info -remote=$CA_URL | jq -r .certificate > $DOCKER_CERT_PATH/ca.pem
+  fi
+  if [[ ! -f $DOCKER_CERT_PATH/key.pem ]]; then
+    cat > $_csr << EOF
+{
+    "CN": "docker-client-$(hostname)",
+    "hosts": [
+        "$(hostname)"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "Santa Clara",
+            "O": "Axway",
+            "OU": "AMP",
+            "ST": "California"
+        }
+    ]
+}
+EOF
+    docker run --rm -v $PWD/certs:/csr ${CFSSL_IMAGE}:${CFSSL_VERSION} gencert -remote=$CA_URL -profile client /csr/keyrequest.json > response.json || return 1
+    jq -r .cert < response.json > $DOCKER_CERT_PATH/cert.pem
+    jq -r .key < response.json > $DOCKER_CERT_PATH/key.pem
+    rm $_csr
+  fi
+  # one last check on the content of the keys and certs
+  for f in ca.pem cert.pem key.pem; do
+    echo "Checking integrity of $f"
+    grep -q -- '-----BEGIN' "$DOCKER_CERT_PATH/$f" || return 1
+  done
+}
+
+# prepare the docker client for TLS connections
+_secure_client() {
+  unset DOCKER_TLS_VERIFY
+  if [[ -z "$CA_URL" ]]; then
+    return 0
+  fi
+  # the docker remote API is not enabled on the worker nodes, so TLS is not set. Only on the remote manager nodes.
+  export DOCKER_CERT_PATH
+  DOCKER_TLS_VERIFY_MANAGER=1
+}
+
 _get_worker_join_token(){
   local _manager=$1
   local _loop=0
   local _timeout=900
   local _token
+  [[ -n "$DOCKER_TLS_VERIFY_MANAGER" ]] && export DOCKER_TLS_VERIFY=1
   echo "retrieving the swarm worker token (will timeout after $_timeout s)" >&2
   SECONDS=0
   while [[ $SECONDS -lt $_timeout ]]; do
-    _token=$(docker -H "$_manager:2375" swarm join-token -q worker)
+    _token=$(docker -H "$_manager:$ENGINE_API_PORT" swarm join-token -q worker)
     if [[ $? -eq 0 && -n "$_token" ]]; then
       echo "worker token obtained ($SECONDS s)" >&2
       echo $_token
+      unset DOCKER_TLS_VERIFY
       return 0
     fi
     sleep 2
@@ -224,14 +289,18 @@ _label_node(){
   local _manager=$1
   local _self
   local _publicip
+  echo "labeling node" >&2
   _self=$(docker info -f '{{.Swarm.NodeID}}') || return 1
   _publicip=$(curl -sf 169.254.169.254/latest/meta-data/public-ipv4) || return 1
+  # in case TLS has been enabled on the manager, we should force it for the client
+  [[ -n "$DOCKER_TLS_VERIFY_MANAGER" ]] && export DOCKER_TLS_VERIFY=1
   echo "applying label PublicIP=$_publicip" >&2
-  docker -H "$_manager" node update --label-add "PublicIP=$_publicip" "$_self" >/dev/null || return 1
+  docker -H "$_manager:$ENGINE_API_PORT" node update --label-add "PublicIP=$_publicip" "$_self" >/dev/null|| return 1
   for _label in $LABELS; do
     echo "applying label $_label" >&2
-    docker -H "$_manager" node update --label-add "${_label}" "$_self" >/dev/null || return 1
+    docker -H "$_manager:$ENGINE_API_PORT" node update --label-add "${_label}" "$_self" >/dev/null || return 1
   done
+  unset DOCKER_TLS_VERIFY
 }
 
 _get_node_ip(){
@@ -243,6 +312,7 @@ _get_node_ip(){
 _smoke_test(){
   local _state
   SECONDS=0
+  unset DOCKER_TLS_VERIFY
   while [[ $SECONDS -lt 10 ]]; do
     _state=$(docker info -f '{{.Swarm.LocalNodeState}}')
     [[ "x$_state" = "xactive" ]] && return 0
@@ -272,6 +342,8 @@ _set_mirror_registries "$MIRROR_REGISTRIES" || exit 1
 _set_log_rotation "10m" "3" || exit 1
 _set_metrics_address "bridge" "9323" || exit 1
 _restart_docker || exit 1
+_gen_cert || exit 1
+_secure_client || exit 1
 _swarm_join "$LEADER" || exit 1
 _label_node "$LEADER" || exit 1
 _configure_system_prune || exit 1

--- a/images/cfssl/Dockerfile
+++ b/images/cfssl/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.9.2-alpine3.6 AS builder
+ENV GOPATH /go
+ENV USER root
+ENV CFSSL_VERSION d2393674072314fda47d2c7c16cb7fd4cdc16821
+RUN set -x && \
+    apk --no-cache add git gcc libc-dev && \
+    mkdir -p /go/src/github.com/cloudflare && cd /go/src/github.com/cloudflare  &&\
+    git clone https://github.com/cloudflare/cfssl && cd cfssl && \
+    git checkout ${CFSSL_VERSION} && \
+    go get github.com/GeertJohan/go.rice/rice && rice embed-go -i=./cli/serve && \
+    mkdir bin && cd bin && \
+    go build ../cmd/cfssl && \
+    go build ../cmd/cfssljson && \
+    go build ../cmd/mkbundle && \
+    go build ../cmd/multirootca && \
+    echo "Build complete."
+
+FROM appcelerator/alpine:3.7.0
+COPY --from=builder /go/src/github.com/cloudflare/cfssl/vendor/github.com/cloudflare/cfssl_trust /etc/cfssl
+COPY --from=builder /go/src/github.com/cloudflare/cfssl/bin/ /usr/bin
+VOLUME [ "/etc/cfssl" ]
+WORKDIR /etc/cfssl
+EXPOSE 8888
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/cfssl"]
+CMD ["--help"]

--- a/images/cfssl/README.md
+++ b/images/cfssl/README.md
@@ -1,0 +1,3 @@
+# appcelerator/cfssl
+
+Based on https://github.com/cloudflare/cfssl/blob/master/Dockerfile.minimal


### PR DESCRIPTION
- Fix AMP-102 (enable TLS on manager nodes), see details in https://techweb.axway.com/confluence/display/AMP/Cluster+with+secured+Docker+API
- Fix AMP-132 (AMI updated to Docker CE 17.09.1)
- Internal PKI for Docker daemon certificates
- all manager nodes expose the engine API with TLS enabled
- all nodes get a unique client certificate give access to the manager nodes API

Not in this PR:

- certificate rotation
- proxy moved to non manager nodes (docker/dockercloud-haproxy#215)

## Verification

- deploy a cluster on AWS (see https://github.com/appcelerator/amp/wiki/Deploy-a-dev-cluster-on-AWS)
- check that the dashboard are able to display data about the cluster
- list the service, amplifier should be on a worker node
- signup to amp
- deploy a stack with a service requiring access to the Docker API on a manager
  - mount the docker certificates: - /etc/docker/tls/client:/root/.docker
  - add an env var with the url to the manager LB: - DOCKER_HOST: ${InternalDockerHost} # this value can be read in amp cluster status)