### PR TITLE
Default overlay networks allow more than 255 containers

### DIFF
--- a/cluster/ampagent/cmd/install.go
+++ b/cluster/ampagent/cmd/install.go
@@ -30,9 +30,10 @@ const (
 )
 
 type InstallOptions struct {
-	NoLogs    bool
-	NoMetrics bool
-	NoProxy   bool
+	NoLogs        bool
+	NoMetrics     bool
+	NoProxy       bool
+	SubnetPattern string
 }
 
 var InstallOpts = &InstallOptions{}
@@ -306,7 +307,7 @@ func createInitialSecrets() error {
 var ampnetworks = []string{"public", "monit", "core"}
 
 func createInitialNetworks() error {
-	for _, network := range ampnetworks {
+	for i, network := range ampnetworks {
 		// Check if network already exists
 		exists, err := Docker.NetworkExists(network)
 		if err != nil {
@@ -316,7 +317,8 @@ func createInitialNetworks() error {
 			log.Println("Skipping already existing network:", network)
 			continue
 		}
-		if _, err := Docker.CreateNetwork(network, true, true); err != nil {
+		subnets := []string{fmt.Sprintf(InstallOpts.SubnetPattern, i+1)}
+		if _, err := Docker.CreateNetwork(network, true, true, subnets); err != nil {
 			return err
 		}
 		log.Println("Successfully created network:", network)

--- a/cluster/ampagent/main.go
+++ b/cluster/ampagent/main.go
@@ -14,6 +14,9 @@ var (
 
 	// Build is set with a linker flag (see Makefile)
 	Build string
+
+	// Default pattern for the overlay network creation
+	DefaultSubnetPattern = "10.%d.0.0/16"
 )
 
 func main() {
@@ -38,6 +41,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoLogs, "no-logs", false, "Don't deploy logs stack")
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoMetrics, "no-metrics", false, "Don't deploy metrics stack")
 	rootCmd.PersistentFlags().BoolVar(&cmd.InstallOpts.NoProxy, "no-proxy", false, "Don't deploy proxy stack")
+	rootCmd.PersistentFlags().StringVar(&cmd.InstallOpts.SubnetPattern, "subnet-pattern", DefaultSubnetPattern, "Subnet pattern for overlay networks, should contain a single %d")
 
 	// Environment variables
 	if os.Getenv("TAG") == "" { // If TAG is undefined, use the current project version

--- a/pkg/docker/network.go
+++ b/pkg/docker/network.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"docker.io/go-docker/api/types"
+	"docker.io/go-docker/api/types/network"
 	"golang.org/x/net/context"
 )
 
@@ -35,10 +36,20 @@ func (d *Docker) NetworkID(name string) (string, error) {
 	return "", nil
 }
 
-func (d *Docker) CreateNetwork(name string, overlay bool, attachable bool) (string, error) {
+func (d *Docker) CreateNetwork(name string, overlay bool, attachable bool, subnets []string) (string, error) {
+	ipamCfg := []network.IPAMConfig{}
+	for _, s := range subnets {
+		ipamCfg = append(ipamCfg, network.IPAMConfig{Subnet: s, AuxAddress: map[string]string{}})
+	}
 	spec := types.NetworkCreate{
 		CheckDuplicate: true,
 		Attachable:     attachable,
+	}
+	if ipamCfg != nil {
+		spec.IPAM = &network.IPAM{
+			Driver: "default",
+			Config: ipamCfg,
+		}
 	}
 	if overlay {
 		spec.Driver = "overlay"


### PR DESCRIPTION
Fix AMP-141 (amp overlay network can't default to /24)

## Verification

```
$ docker network rm core monit public
$ make build-ampagent build-cli
$ amp cluster create
$ docker network inspect core --format '{{(index .IPAM.Config 0).Subnet}}'
# should be a /16
```