### PR TITLE
Enhance cloud provider detection

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -26,24 +26,26 @@ func CloudProvider() (Provider, error) {
 	dataLen := 3
 	uuidFile, err := os.Open("/sys/hypervisor/uuid")
 	if err != nil {
+		uuidFile, err = os.Open("/sys/devices/virtual/dmi/id/product_uuid")
+	}
+	if err != nil {
 		// file does not exist, so we'll consider it's not a cloud deployment
 		return ProviderLocal, nil
 	}
 	data := make([]byte, dataLen)
 	count, err := uuidFile.Read(data)
 	if err != nil {
-		log.Infoln("Unable to establish provider from uuid file:", err)
-		return ProviderLocal, nil
+		return ProviderUnknown, fmt.Errorf("Unable to establish provider from uuid file: %s", err)
 	}
 	if count != dataLen {
 		log.Infoln("Unable to establish provider, empty uuid file")
 		return ProviderLocal, nil
 	}
 	switch string(data) {
-	case "ec2":
+	case "ec2", "EC2":
 		return ProviderAWS, nil
 	default:
-		return ProviderUnknown, fmt.Errorf("found unexpected value in uuid file: %s", string(data))
+		return ProviderLocal, nil
 	}
 }
 


### PR DESCRIPTION
Detection of cloud provider based on /sys/hypervision/uuid may fail (it's maybe related to ENA). In this case, falling back to /sys/devices/virtual/dmi/id/product_uuid provides the information.

## Verification

Deploy a cluster on AWS and deploy locally, and run the amp cluster status command to make sure the Provider is correctly identified.